### PR TITLE
Remove miniredis

### DIFF
--- a/cmd/relay_backend/relay_backend.go
+++ b/cmd/relay_backend/relay_backend.go
@@ -48,8 +48,8 @@ func main() {
 	}
 
 	// Attempt to connect to REDIS_HOST, falling back to local instance if not explicitly specified
-	redisHost := os.Getenv("REDIS_HOST")
-	if len(redisHost) == 0 {
+	redisHost, ok := os.LookupEnv("REDIS_HOST")
+	if !ok {
 		redisHost = "localhost:6379"
 		log.Printf("env var 'REDIS_HOST' is not set, falling back to default value of '%s'\n", redisHost)
 	}

--- a/cmd/server_backend/server_backend.go
+++ b/cmd/server_backend/server_backend.go
@@ -58,8 +58,8 @@ func main() {
 	}
 
 	// Attempt to connect to REDIS_HOST, falling back to local instance if not explicitly specified
-	redisHost := os.Getenv("REDIS_HOST")
-	if len(redisHost) == 0 {
+	redisHost, ok := os.LookupEnv("REDIS_HOST")
+	if !ok {
 		redisHost = "localhost:6379"
 		log.Printf("env var 'REDIS_HOST' is not set, falling back to default value of '%s'\n", redisHost)
 	}


### PR DESCRIPTION
Fallback to local redis instance to be run by the developer rather than to miniredis in relay and server backend. Still using miniredis for unit tests, and didn't update docs since still 'optional' for local dev, and @blainsmith touching docs in another PR