### PR TITLE
fixed a off by one error with writing tests

### DIFF
--- a/cmd/relay/src/testing/encoding/read.test.cpp
+++ b/cmd/relay/src/testing/encoding/read.test.cpp
@@ -24,7 +24,6 @@ namespace testing
         size_t index = 0;
         encoding::ReadAddress(bin, index, addr);
         check(index == RELAY_ADDRESS_BYTES);
-        std::cout << addr.toString() << std::endl;
     }
 
     void Test_ReadAddress_ipv6()

--- a/cmd/relay/src/testing/encoding/write.test.cpp
+++ b/cmd/relay/src/testing/encoding/write.test.cpp
@@ -57,7 +57,6 @@ namespace testing
         check(bin[16] == 0xFF);
         check(bin[17] == 0x5A);
         check(bin[18] == 0xC7);
-        check(bin[19] == 0x00);
     }
 
     void Test_WriteAddress_none()


### PR DESCRIPTION
What the title implies, was checking one index in an array higher than what I should so uninitialized memory was causing inconsistent test pass/fails