### PR TITLE
Fix server backend failing signature verification on second continue route

### DIFF
--- a/transport/packet_server.go
+++ b/transport/packet_server.go
@@ -319,21 +319,18 @@ func (packet *SessionUpdatePacket) GetSignData() []byte {
 	binary.Write(buf, binary.LittleEndian, uint8(packet.ConnectionType))
 
 	var onNetworkNext uint8
-	onNetworkNext = 0
 	if packet.OnNetworkNext {
 		onNetworkNext = 1
 	}
+	binary.Write(buf, binary.LittleEndian, onNetworkNext)
 
 	if packet.Version.AtLeast(SDKVersion{3, 4, 0}) {
 		var committed uint8
-		committed = 0
 		if packet.Committed {
 			committed = 1
 		}
 		binary.Write(buf, binary.LittleEndian, committed)
 	}
-
-	binary.Write(buf, binary.LittleEndian, onNetworkNext)
 
 	binary.Write(buf, binary.LittleEndian, packet.DirectMinRtt)
 	binary.Write(buf, binary.LittleEndian, packet.DirectMaxRtt)


### PR DESCRIPTION
Tricky one, unit tests passed since GetSignData is consistent, but I noticed a subtle difference in GetSignData in next.cpp - `next` was getting written before `committed`, but in backend it was the other way round.

https://github.com/networknext/backend/blob/master/sdk/next.cpp#L8067-L8068

I believe this works on first packet since they are both false, so even though order is flipped the sign data ended up the same.

On second packet one of these bools was true so order does matter, and that caused the failure.