### PR TITLE
Router shader groundwork

### DIFF
--- a/routing/buyer.go
+++ b/routing/buyer.go
@@ -6,5 +6,5 @@ type Buyer struct {
 	Active    bool
 	Live      bool
 	PublicKey []byte
-	Config    BuyerConfig
+	Config    RouterConfig
 }

--- a/routing/router_config.go
+++ b/routing/router_config.go
@@ -1,7 +1,7 @@
 package routing
 
-// Various settings a buyer can tweak to adjust the behaviour of Network Next to their liking
-type BuyerConfig struct {
+// Various settings a buyer can tweak to adjust the behaviour of Network Next route selection to their liking
+type RouterConfig struct {
 	// The maximum upstream bandwidth a customer is willing to pay for per slice
 	EnvelopeKbpsUp int64
 
@@ -65,7 +65,7 @@ type BuyerConfig struct {
 	AbTest bool
 }
 
-const DefaultBuyerConfig = BuyerConfig{
+const DefaultRouterConfig = RouterConfig{
 	MaxCentsPerGB:     25.0,
 	EnvelopeKbpsUp:    256,
 	EnvelopeKbpsDown:  256,


### PR DESCRIPTION
Started to work on storing a "route shader" per buyer, but it's my understanding there has been a fair amount of confusion as to what this actually is, and what the parameters you can set on it drives.

I took the time to port the fields of the old route shader into a new struct that for now I'm calling "RouterConfig", and inspected the old codebase to try and determine what the current actual behavior of each of the parameters is and comment appropriately to share that knowledge (hoping this should make life easier when we go to actually get feature parity with old backend).

@gafferongames if you could take a look at the comments I left in router_config.go and make sure it all makes sense would be good :)


Wondering whether there are any features here that we do not want to port across - and anything that we want to change before I go and set this up in firestore etc?

For example not sure if want to convert bools such as `PacketLossSafety` into float params like `RttVeto`, and do a pass to make naming more consistent etc.