### PR TITLE
func_test Command Line Arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ build-functional-backend:
 .PHONY: run-test-func
 run-test-func:
 	@printf "\nRunning functional tests...\n\n" ; \
-	$(GO) run ./cmd/tools/functional/tests/func_tests.go ; \
+	$(GO) run ./cmd/tools/functional/tests/func_tests.go $(tests) ; \
 	printf "\ndone\n\n"
 
 .PHONY: test-func

--- a/cmd/tools/functional/tests/func_tests.go
+++ b/cmd/tools/functional/tests/func_tests.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -1523,7 +1525,7 @@ func test_packet_loss_direct() {
 type test_function func()
 
 func main() {
-	tests := []test_function{
+	allTests := []test_function{
 		test_direct_default,
 		test_direct_upgrade,
 		test_direct_no_upgrade,
@@ -1547,6 +1549,23 @@ func main() {
 		test_uncommitted_to_committed,
 		test_user_flags,
 		test_packet_loss_direct,
+	}
+
+	// If there are command line arguments, use reflection to see what tests to run
+	var tests []test_function
+	prefix := "main."
+	if len(os.Args) > 1 {
+		for _, funcName := range os.Args[1:] {
+			for _, test := range allTests {
+				name := runtime.FuncForPC(reflect.ValueOf(test).Pointer()).Name()
+				name = name[len(prefix):]
+				if funcName == name {
+					tests = append(tests, test)
+				}
+			}
+		}
+	} else {
+		tests = allTests // No command line args, run all tests
 	}
 
 	for i := range tests {


### PR DESCRIPTION
func_tests.go can now take command line arguments to specify which tests to run. If none are specified, then it runs them all sequentially as before.

To specify which tests to run, use `make test-func tests="test_direct_default test_direct_upgrade test_direct_no_upgrade"` etc. The name of the test should match the func name in the list of all tests in `main()`.

If you want specify tests for func_tests.go to run without make for some reason, just list the tests without quotes and without the `tests=` prefix.