### PR TITLE
Expand keygen tool

### DIFF
--- a/cmd/tools/keygen/build.bat
+++ b/cmd/tools/keygen/build.bat
@@ -4,38 +4,8 @@ setlocal
 
 set CGO_ENABLED=0
 
-echo | set /p=Building Linux 64-bit...
-set GOOS=linux
-set GOARCH=amd64
-go build -ldflags="-s -w" -o ./keygen_linux ./src/keygen.go
-echo  done
-
-echo | set /p=Building FreeBSD 64-bit...
-set GOOS=freebsd
-set GOARCH=amd64
-go build -ldflags="-s -w" -o ./keygen_freebsd ./src/keygen.go
-echo  done
-
-echo | set /p=Building OpenBSD 64-bit...
-set GOOS=openbsd
-set GOARCH=amd64
-go build -ldflags="-s -w" -o ./keygen_openbsd ./src/keygen.go
-echo  done
-
-echo | set /p=Building ARM 64-bit...
-set GOOS=linux
-set GOARCH=arm64
-go build -ldflags="-s -w" -o ./keygen_arm ./src/keygen.go
-echo  done
-
-echo | set /p=Building MacOS 64-bit...
-set GOOS=darwin
-set GOARCH=amd64
-go build -ldflags="-s -w" -o ./keygen_mac ./src/keygen.go
-echo  done
-
 echo | set /p=Building Windows 64-bit...
 set GOOS=windows
 set GOARCH=amd64
-go build -ldflags="-s -w" -o ./keygen.exe ./src/keygen.go
+go build -ldflags="-s -w" -o ./dist/keygen.exe ./keygen.go
 echo  done

--- a/cmd/tools/keygen/build.sh
+++ b/cmd/tools/keygen/build.sh
@@ -1,27 +1,16 @@
-#!/bin/sh
+#!/bin/bash
 
 CGO_ENABLED=0
 
-printf "Building keygen Linux 64-bit... "
-GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ./dist/keygen_linux ./keygen.go
-printf "done\n"
+build() {
+    printf "Building keygen $1... "
+    GOOS=$2 GOARCH=$3 go build -ldflags="-s -w" -o ./dist/keygen_$2 ./keygen.go
+    printf "done\n"
+}
 
-printf "Building keygen FreeBSD 64-bit... "
-GOOS=freebsd GOARCH=amd64 go build -ldflags="-s -w" -o ./dist/keygen_freebsd ./keygen.go
-printf "done\n"
-
-printf "Building keygen OpenBSD 64-bit... "
-GOOS=openbsd GOARCH=amd64 go build -ldflags="-s -w" -o ./dist/keygen_openbsd ./keygen.go
-printf "done\n"
-
-printf "Building keygen ARM 64-bit... "
-GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o ./dist/keygen_arm ./keygen.go
-printf "done\n"
-
-printf "Building keygen MacOS 64-bit... "
-GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o ./dist/keygen_mac ./keygen.go
-printf "done\n"
-
-printf "Building keygen Windows 64-bit... "
-GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o ./dist/keygen.exe ./keygen.go
-printf "done\n"
+case "$OSTYPE" in
+  darwin*)  build "MacOS 64-bit" darwin amd64 ;; 
+  linux*)   build "Linux 64-bit" linux amd64 ;; 
+  msys*)    build "Windows 64-bit" windows amd64 ;;
+  *)        echo "unknown or unsupported OS type: $OSTYPE" ;;
+esac

--- a/cmd/tools/keygen/keygen.go
+++ b/cmd/tools/keygen/keygen.go
@@ -6,17 +6,17 @@
 package main
 
 import (
-	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"log"
 
+	"github.com/networknext/backend/crypto"
 	"golang.org/x/crypto/nacl/box"
 )
 
 func main() {
-	signaturePublicKey, signaturePrivateKey, err := generateCustomerKeyPair()
+	signaturePublicKey, signaturePrivateKey, err := crypto.GenerateCustomerKeyPair()
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -29,37 +29,16 @@ func main() {
 	fmt.Printf("\nWelcome to Network Next!\n\n")
 
 	fmt.Printf("This is your public key for packet signature verification:\n\n")
-	fmt.Printf("    %s\n", base64.StdEncoding.EncodeToString(signaturePublicKey))
+	fmt.Printf("    %s\n\n", base64.StdEncoding.EncodeToString(signaturePublicKey))
 
 	fmt.Printf("This is your private key for packet signature verification:\n\n")
-	fmt.Printf("    %s\n", base64.StdEncoding.EncodeToString(signaturePrivateKey))
+	fmt.Printf("    %s\n\n", base64.StdEncoding.EncodeToString(signaturePrivateKey))
 
-	fmt.Printf("This is your public key for token encryption:\n\n")
-	fmt.Printf("    %s\n", base64.StdEncoding.EncodeToString(encryptionPublicKey[:]))
+	fmt.Printf("This is your public key for route token encryption:\n\n")
+	fmt.Printf("    %s\n\n", base64.StdEncoding.EncodeToString(encryptionPublicKey[:]))
 
-	fmt.Printf("This is your private key for token encryption:\n\n")
-	fmt.Printf("    %s\n", base64.StdEncoding.EncodeToString(encryptionPrivateKey[:]))
+	fmt.Printf("This is your private key for route token encryption:\n\n")
+	fmt.Printf("    %s\n\n", base64.StdEncoding.EncodeToString(encryptionPrivateKey[:]))
 
 	fmt.Printf("IMPORTANT: Save your private keys in a secure place and don't share them with anybody, not even us!\n\n")
-}
-
-// generateRelayKeyPair creates a public and private keypair using crypto/ed25519 and prepends a random 8 byte customer ID
-// This is copied from crypto to avoid libsodium dependency so that keygen can be built for multiple platforms.
-func generateCustomerKeyPair() ([]byte, []byte, error) {
-	customerID := make([]byte, 8)
-	rand.Read(customerID)
-
-	publicKey, privateKey, err := ed25519.GenerateKey(nil)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	customerPublicKey := make([]byte, 0)
-	customerPublicKey = append(customerPublicKey, customerID...)
-	customerPublicKey = append(customerPublicKey, publicKey...)
-	customerPrivateKey := make([]byte, 0)
-	customerPrivateKey = append(customerPrivateKey, customerID...)
-	customerPrivateKey = append(customerPrivateKey, privateKey...)
-
-	return customerPublicKey, customerPrivateKey, nil
 }


### PR DESCRIPTION
Went to expand the keygen tool as per the monday task, but it seems like most of the work with it is done. It already generated a signature key pair, so all I did was made the signature key pair come from the crypto package and added the encryption key pair. Not sure what other additions need to go into this, if any.

I changed up the build script to only build for the platform you're using, since crypto has a C dependency with libsodium and cross compiling with cgo is not trivial.
