### PR TITLE
use a duration gauge to report point in time in ms

### DIFF
--- a/cmd/server_backend/server_backend.go
+++ b/cmd/server_backend/server_backend.go
@@ -207,28 +207,28 @@ func main() {
 		}()
 	}
 
-	updateDuration, err := metricsHandler.NewHistogram(ctx, &metrics.Descriptor{
+	updateDuration, err := metricsHandler.NewGauge(ctx, &metrics.Descriptor{
 		DisplayName: "Server update duration",
 		ServiceName: "server_backend",
-		ID:          "server.update.duration",
+		ID:          "server.duration",
 		Unit:        "milliseconds",
 		Description: "How long it takes to process a server update request.",
-	}, 50)
+	})
 	if err != nil {
-		level.Error(logger).Log("msg", "Failed to create metric histogram", "metric", "server.update.duration", "err", err)
-		updateDuration = &metrics.EmptyHistogram{}
+		level.Error(logger).Log("msg", "Failed to create metric histogram", "metric", "server.duration", "err", err)
+		updateDuration = &metrics.EmptyGauge{}
 	}
 
-	sessionDuration, err := metricsHandler.NewHistogram(ctx, &metrics.Descriptor{
+	sessionDuration, err := metricsHandler.NewGauge(ctx, &metrics.Descriptor{
 		DisplayName: "Session update duration",
 		ServiceName: "server_backend",
 		ID:          "session.duration",
 		Unit:        "milliseconds",
 		Description: "How long it takes to process a session update request",
-	}, 50)
+	})
 	if err != nil {
 		level.Error(logger).Log("msg", "Failed to create metric histogram", "metric", "session.duration", "err", err)
-		sessionDuration = &metrics.EmptyHistogram{}
+		sessionDuration = &metrics.EmptyGauge{}
 	}
 
 	updateCount, err := metricsHandler.NewCounter(ctx, &metrics.Descriptor{

--- a/metrics/stackdriver.go
+++ b/metrics/stackdriver.go
@@ -121,14 +121,13 @@ func (handler *StackDriverHandler) WriteLoop(ctx context.Context, logger log.Log
 							},
 							Value: &monitoringpb.TypedValue{
 								Value: &monitoringpb.TypedValue_Int64Value{
-									Int64Value: int64(math.Round(mapData.counter.Value())),
+									Int64Value: int64(math.Round(mapData.counter.ValueReset())),
 								},
 							},
 						},
 					},
 				}
 
-				mapData.counter.ValueReset()
 				index++
 			}
 

--- a/transport/udp.go
+++ b/transport/udp.go
@@ -11,8 +11,6 @@ import (
 	"runtime"
 	"time"
 
-	gkmetrics "github.com/go-kit/kit/metrics"
-
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	jsoniter "github.com/json-iterator/go"
@@ -99,14 +97,14 @@ func (e ServerCacheEntry) MarshalBinary() ([]byte, error) {
 }
 
 // ServerUpdateHandlerFunc ...
-func ServerUpdateHandlerFunc(logger log.Logger, redisClient redis.Cmdable, storer storage.Storer, duration metrics.Histogram, counter metrics.Counter) UDPHandlerFunc {
+func ServerUpdateHandlerFunc(logger log.Logger, redisClient redis.Cmdable, storer storage.Storer, duration metrics.Gauge, counter metrics.Counter) UDPHandlerFunc {
 	logger = log.With(logger, "handler", "server")
 
 	return func(w io.Writer, incoming *UDPPacket) {
-		timer := gkmetrics.NewTimer(duration.With("method", "ServerUpdateHandlerFunc"))
-		timer.Unit(time.Millisecond)
+		durationStart := time.Now()
 		defer func() {
-			timer.ObserveDuration()
+			durationSince := time.Since(durationStart)
+			duration.Set(float64(durationSince.Milliseconds()))
 			counter.Add(1)
 		}()
 
@@ -210,14 +208,14 @@ type RouteProvider interface {
 }
 
 // SessionUpdateHandlerFunc ...
-func SessionUpdateHandlerFunc(logger log.Logger, redisClient redis.Cmdable, storer storage.Storer, rp RouteProvider, iploc routing.IPLocator, geoClient *routing.GeoClient, duration metrics.Histogram, counter metrics.Counter, biller billing.Biller, serverPrivateKey []byte, routerPrivateKey []byte) UDPHandlerFunc {
+func SessionUpdateHandlerFunc(logger log.Logger, redisClient redis.Cmdable, storer storage.Storer, rp RouteProvider, iploc routing.IPLocator, geoClient *routing.GeoClient, duration metrics.Gauge, counter metrics.Counter, biller billing.Biller, serverPrivateKey []byte, routerPrivateKey []byte) UDPHandlerFunc {
 	logger = log.With(logger, "handler", "session")
 
 	return func(w io.Writer, incoming *UDPPacket) {
-		timer := gkmetrics.NewTimer(duration.With("method", "SessionUpdateHandlerFunc"))
-		timer.Unit(time.Millisecond)
+		durationStart := time.Now()
 		defer func() {
-			timer.ObserveDuration()
+			durationSince := time.Since(durationStart)
+			duration.Set(float64(durationSince.Milliseconds()))
 			counter.Add(1)
 		}()
 

--- a/transport/udp_server_update_handler_test.go
+++ b/transport/udp_server_update_handler_test.go
@@ -24,7 +24,7 @@ func TestFailToUnmarshalServerUpdate(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:13")
 	assert.NoError(t, err)
 
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
 	handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: []byte("this is not a proper packet")})
 
 	_, err = redisServer.Get("SERVER-0.0.0.0:13")
@@ -54,7 +54,7 @@ func TestSDKVersionTooOld(t *testing.T) {
 	data, err := packet.MarshalBinary()
 	assert.NoError(t, err)
 
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
 	handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	_, err = redisServer.Get("SERVER-0.0.0.0:13")
@@ -86,7 +86,7 @@ func TestBuyerNotFound(t *testing.T) {
 	data, err := packet.MarshalBinary()
 	assert.NoError(t, err)
 
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
 	handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	_, err = redisServer.Get("SERVER-0.0.0.0:13")
@@ -122,7 +122,7 @@ func TestWrongBuyerPublicKey(t *testing.T) {
 	data, err := packet.MarshalBinary()
 	assert.NoError(t, err)
 
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
 	handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	_, err = redisServer.Get("SERVER-0.0.0.0:13")
@@ -169,7 +169,7 @@ func TestServerPacketSequenceTooOld(t *testing.T) {
 	err = redisServer.Set("SERVER-0.0.0.0:13", string(se))
 	assert.NoError(t, err)
 
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
 	handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	ds, err := redisServer.Get("SERVER-0.0.0.0:13")
@@ -225,7 +225,7 @@ func TestSuccessfulUpdate(t *testing.T) {
 	}
 
 	// Initialize the UDP handler with the required redis client
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
 
 	// Invoke the handler with the data packet and address it is coming from
 	handler(&buf, &incoming)

--- a/transport/udp_session_update_handler_test.go
+++ b/transport/udp_session_update_handler_test.go
@@ -42,7 +42,7 @@ func TestFailToUnmarshalSessionUpdate(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, nil, nil, nil, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, nil, nil, nil)
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, nil, nil, nil, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, nil, nil, nil)
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: []byte("this is not a proper packet")})
 
 	assert.Equal(t, 0, resbuf.Len())
@@ -83,7 +83,7 @@ func TestNoBuyerFound(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, nil, nil, nil, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, nil, TestServerBackendPrivateKey, nil)
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, nil, nil, nil, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, nil, TestServerBackendPrivateKey, nil)
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	ValidateDirectResponsePacket(resbuf, t)
@@ -127,7 +127,7 @@ func TestVerificationFailed(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, nil, nil, nil, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, nil, TestServerBackendPrivateKey, nil)
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, nil, nil, nil, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, nil, TestServerBackendPrivateKey, nil)
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	ValidateDirectResponsePacket(resbuf, t)
@@ -185,7 +185,7 @@ func TestSessionPacketSequenceTooOld(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, nil, nil, nil, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, nil, TestServerBackendPrivateKey, nil)
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, nil, nil, nil, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, nil, TestServerBackendPrivateKey, nil)
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	ValidateDirectResponsePacket(resbuf, t)
@@ -250,7 +250,7 @@ func TestClientIPLookupFail(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, nil, &iploc, nil, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, nil, TestServerBackendPrivateKey, nil)
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, nil, &iploc, nil, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, nil, TestServerBackendPrivateKey, nil)
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	ValidateDirectResponsePacket(resbuf, t)
@@ -326,7 +326,7 @@ func TestNoRelaysNearClient(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey, nil)
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey, nil)
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	ValidateDirectResponsePacket(resbuf, t)
@@ -409,7 +409,7 @@ func TestNoRoutesFound(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey, nil)
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey, nil)
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	ValidateDirectResponsePacket(resbuf, t)
@@ -513,7 +513,7 @@ func TestNextRouteResponse(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	assert.Greater(t, resbuf.Len(), 0)
@@ -631,7 +631,7 @@ func TestContinueRouteResponse(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	var actual transport.SessionResponsePacket
@@ -756,7 +756,7 @@ func TestCachedRouteResponse(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	assert.Greater(t, resbuf.Len(), 0)
@@ -865,7 +865,7 @@ func TestTokenEncryptionFailure(t *testing.T) {
 
 	var resbuf bytes.Buffer
 
-	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyHistogram{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &rp, &iploc, &geoClient, &metrics.EmptyGauge{}, &metrics.EmptyCounter{}, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	assert.Greater(t, resbuf.Len(), 0)


### PR DESCRIPTION
The Stackdriver histogram stuff is not very intuitive to wire up so I switched this over to a gauge value for now until it is figured out. So the duration is reported in milliseconds to see the last reported duration of the handler instead of a calculated distribution over time.

@roman-networknext This might merge conflict with you, but provides a baseline to have the duration working.