### PR TITLE
DecisionNoChange fix

### DIFF
--- a/routing/route.go
+++ b/routing/route.go
@@ -10,10 +10,10 @@ type Route struct {
 	Stats  Stats
 }
 
-func (r *Route) Decide(prevDecision Decision, nnStats Stats, directStats Stats, routeDecisions ...DecisionFunc) Decision {
+func (r *Route) Decide(prevDecision Decision, nnStats Stats, directStats Stats, metrics *DecisionMetrics, routeDecisions ...DecisionFunc) Decision {
 	nextDecision := prevDecision
 	for _, routeDecision := range routeDecisions {
-		decision := routeDecision(nextDecision, r.Stats, nnStats, directStats)
+		decision := routeDecision(nextDecision, r.Stats, nnStats, directStats, metrics)
 
 		nextDecision.OnNetworkNext = decision.OnNetworkNext
 		if decision.Reason != DecisionNoChange { // DecisionNoChange signals that the decision function chose not to update the deicision reason

--- a/routing/route_decision.go
+++ b/routing/route_decision.go
@@ -1,10 +1,22 @@
 package routing
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/networknext/backend/metrics"
+)
 
 type Decision struct {
 	OnNetworkNext bool
 	Reason        DecisionReason
+}
+
+type DecisionMetrics struct {
+	VetoedSessions metrics.Counter
+}
+
+var EmptyDecisionMetrics DecisionMetrics = DecisionMetrics{
+	VetoedSessions: &metrics.EmptyCounter{},
 }
 
 // Decision takes in whether or not the logic is currently considering staying on network next,
@@ -12,7 +24,7 @@ type Decision struct {
 // the stats of the last network next route,
 // and the stats of the direct route and decides whether or not to take the predicted network next route.
 // A reason is also provided for billing.
-type DecisionFunc func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats) Decision
+type DecisionFunc func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *DecisionMetrics) Decision
 
 // DecisionReason is the reason why a Decision was made.
 type DecisionReason uint64
@@ -94,7 +106,7 @@ const (
 // DecideUpgradeRTT will decide if the client should use the network next route if the RTT reduction is greater than the given threshold.
 // This decision only upgrades direct routes, so network next routes aren't considered.
 func DecideUpgradeRTT(rttThreshold float64) DecisionFunc {
-	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats) Decision {
+	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *DecisionMetrics) Decision {
 		// If upgrading to a nextwork next route would reduce RTT by at least the given threshold, upgrade
 		if !prevDecision.OnNetworkNext && directStats.RTT-predictedNextStats.RTT >= rttThreshold {
 			return Decision{true, DecisionRTTReduction}
@@ -108,7 +120,7 @@ func DecideUpgradeRTT(rttThreshold float64) DecisionFunc {
 // DecideDowngradeRTT will decide if the client should continue using the network next route if the network next RTT increase doesn't exceed the hysteresis value.
 // This decision only downgrades network next routes, so direct routes aren't considered.
 func DecideDowngradeRTT(rttHysteresis float64) DecisionFunc {
-	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats) Decision {
+	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *DecisionMetrics) Decision {
 		// If staying on a nextwork next route doesn't increase RTT by more than the given hysteresis value, stay
 		if prevDecision.OnNetworkNext {
 			if predictedNextStats.RTT-directStats.RTT <= rttHysteresis {
@@ -128,10 +140,13 @@ func DecideDowngradeRTT(rttHysteresis float64) DecisionFunc {
 // RTT by more than the RTT veto value, or increases packet loss if packet loss safety is enabled.
 // This decision only downgrades network next routes, so direct routes aren't considered.
 func DecideVeto(rttVeto float64, packetLossSafety bool, yolo bool) DecisionFunc {
-	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats) Decision {
+	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *DecisionMetrics) Decision {
 		if prevDecision.OnNetworkNext {
 			// Whether or not the network next route made the RTT worse than the veto value
 			if lastNextStats.RTT-directStats.RTT > rttVeto {
+				// Update veto metric
+				metrics.VetoedSessions.Add(1)
+
 				// If the buyer has YouOnlyLiveOnce safety setting enabled, add that reason to the DecisionReason
 				if yolo {
 					return Decision{false, DecisionVetoRTT | DecisionVetoYOLO}
@@ -176,7 +191,7 @@ func DecideVeto(rttVeto float64, packetLossSafety bool, yolo bool) DecisionFunc 
 
 // DecideCommitted is not yet implemented
 func DecideCommitted() DecisionFunc {
-	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats) Decision {
+	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *DecisionMetrics) Decision {
 		return Decision{prevDecision.OnNetworkNext, DecisionNoChange}
 	}
 }

--- a/routing/route_decision_test.go
+++ b/routing/route_decision_test.go
@@ -27,7 +27,7 @@ func TestDecideUpgradeRTT(t *testing.T) {
 	assert.Equal(
 		t,
 		routing.Decision{true, routing.DecisionRTTReduction},
-		routeDecisionFunc(routing.Decision{false, routing.DecisionNoChange}, predictedStats, routing.Stats{}, directStats),
+		routeDecisionFunc(routing.Decision{false, routing.DecisionNoChange}, predictedStats, routing.Stats{}, directStats, &routing.EmptyDecisionMetrics),
 	)
 
 	// Now test if the route is left alone
@@ -36,7 +36,7 @@ func TestDecideUpgradeRTT(t *testing.T) {
 	assert.Equal(
 		t,
 		routing.Decision{false, routing.DecisionNoChange},
-		routeDecisionFunc(routing.Decision{false, routing.DecisionNoChange}, predictedStats, routing.Stats{}, directStats),
+		routeDecisionFunc(routing.Decision{false, routing.DecisionNoChange}, predictedStats, routing.Stats{}, directStats, &routing.EmptyDecisionMetrics),
 	)
 }
 
@@ -58,18 +58,18 @@ func TestDecideDowngradeRTT(t *testing.T) {
 	routeDecisionFunc := routing.DecideDowngradeRTT(rttHyteresis)
 
 	decision := routing.Decision{true, routing.DecisionNoChange}
-	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats)
+	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats, &routing.EmptyDecisionMetrics)
 
 	assert.Equal(t, routing.Decision{true, routing.DecisionNoChange}, decision)
 
 	// Now test to see if the route gets downgraded to a direct route due to RTT
 	predictedStats.RTT = directStats.RTT + rttHyteresis + 1.0
 
-	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats)
+	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats, &routing.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionRTTIncrease}, decision)
 
 	// Now test if a direct route is given
-	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats)
+	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats, &routing.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionNoChange}, decision)
 }
 
@@ -91,14 +91,14 @@ func TestDecideVeto(t *testing.T) {
 	routeDecisionFunc := routing.DecideVeto(rttVeto, false, false)
 
 	decision := routing.Decision{true, routing.DecisionNoChange}
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoRTT}, decision)
 
 	// Now test for yolo reason
 	decision.OnNetworkNext = true
 	routeDecisionFunc = routing.DecideVeto(rttVeto, false, true)
 
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoRTT | routing.DecisionVetoYOLO}, decision)
 
 	// Now test if the route is vetoed for packet loss increases
@@ -107,14 +107,14 @@ func TestDecideVeto(t *testing.T) {
 	decision.OnNetworkNext = true
 	routeDecisionFunc = routing.DecideVeto(rttVeto, true, false)
 
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoPacketLoss}, decision)
 
 	// Now test for yolo reason
 	decision.OnNetworkNext = true
 	routeDecisionFunc = routing.DecideVeto(rttVeto, true, true)
 
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoPacketLoss | routing.DecisionVetoYOLO}, decision)
 
 	// Test if route isn't vetoed
@@ -122,12 +122,12 @@ func TestDecideVeto(t *testing.T) {
 	decision.OnNetworkNext = true
 	routeDecisionFunc = routing.DecideVeto(rttVeto, true, true)
 
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{true, routing.DecisionNoChange}, decision)
 
 	// Test if direct route isn't changed
 	decision.OnNetworkNext = false
 
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionNoChange}, decision)
 }

--- a/routing/route_test.go
+++ b/routing/route_test.go
@@ -50,7 +50,7 @@ func TestDecide(t *testing.T) {
 		// Loop through all permutations of the decision functions and test that the result is the same
 		perms := permutations(decisionFuncs)
 		for i := 0; i < len(perms); i++ {
-			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[i]...)
+			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[i]...)
 			assert.Equal(t, expected, decision)
 		}
 	}
@@ -97,7 +97,7 @@ func TestDecide(t *testing.T) {
 		// Loop through all permutations of the decision functions and test that the result is the same
 		perms := permutations(decisionFuncs)
 		for i := 0; i < len(perms); i++ {
-			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[i]...)
+			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[i]...)
 			assert.Equal(t, expected, decision)
 		}
 	}
@@ -144,7 +144,7 @@ func TestDecide(t *testing.T) {
 		// Loop through all permutations of the decision functions and test that the result is the same
 		perms := permutations(decisionFuncs)
 		for i := 0; i < len(perms); i++ {
-			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[i]...)
+			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[i]...)
 			assert.Equal(t, expected, decision)
 		}
 	}
@@ -198,7 +198,7 @@ func TestDecide(t *testing.T) {
 
 			for j := 0; j < len(perms); j++ {
 				perms[j] = append(perms[j], routing.DecideVeto(float64(routingRulesSettings.RTTVeto), routingRulesSettings.EnablePacketLossSafety, routingRulesSettings.EnableYouOnlyLiveOnce))
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -254,7 +254,7 @@ func TestDecide(t *testing.T) {
 
 			for j := 0; j < len(perms); j++ {
 				perms[j] = append(perms[j], routing.DecideVeto(float64(routingRulesSettings.RTTVeto), routingRulesSettings.EnablePacketLossSafety, routingRulesSettings.EnableYouOnlyLiveOnce))
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -311,7 +311,7 @@ func TestDecide(t *testing.T) {
 
 			for j := 0; j < len(perms); j++ {
 				perms[j] = append(perms[j], routing.DecideVeto(float64(routingRulesSettings.RTTVeto), routingRulesSettings.EnablePacketLossSafety, routingRulesSettings.EnableYouOnlyLiveOnce))
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -369,7 +369,7 @@ func TestDecide(t *testing.T) {
 
 			for j := 0; j < len(perms); j++ {
 				perms[j] = append(perms[j], routing.DecideVeto(float64(routingRulesSettings.RTTVeto), routingRulesSettings.EnablePacketLossSafety, routingRulesSettings.EnableYouOnlyLiveOnce))
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -420,7 +420,7 @@ func TestDecide(t *testing.T) {
 			perms := permutations(combs[i])
 
 			for j := 0; j < len(perms); j++ {
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -471,7 +471,7 @@ func TestDecide(t *testing.T) {
 			perms := permutations(combs[i])
 
 			for j := 0; j < len(perms); j++ {
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -525,7 +525,7 @@ func TestDecide(t *testing.T) {
 			perms := permutations(combs[i])
 
 			for j := 0; j < len(perms); j++ {
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -547,7 +547,7 @@ func TestDecide(t *testing.T) {
 			perms := permutations(combs[i])
 
 			for j := 0; j < len(perms); j++ {
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}


### PR DESCRIPTION
A quick fix to have `DecisionNoChange` actually not change the decision reason. What was happening was when the backend was going through the decision process, it would overwrite the decision reason for each step. This is intended except for `DecisionNoChange`, which should signal to keep the old decision reason. This would cause the last decision function in the logic `DecideVeto` to result in `DecisionNoChange` if the route wasn't vetoed, hiding the actual reason as to why the route was chosen.