### PR TITLE
Refactor metrics structs

### DIFF
--- a/metrics/metrics_types.go
+++ b/metrics/metrics_types.go
@@ -1,0 +1,35 @@
+package metrics
+
+type DecisionMetrics struct {
+	VetoedSessions Counter
+}
+
+var EmptyDecisionMetrics DecisionMetrics = DecisionMetrics{
+	VetoedSessions: &EmptyCounter{},
+}
+
+type SessionMetrics struct {
+	Invocations     Counter
+	DirectSessions  Counter
+	NextSessions    Counter
+	DurationGauge   Gauge
+	DecisionMetrics DecisionMetrics
+}
+
+var EmptySessionMetrics SessionMetrics = SessionMetrics{
+	Invocations:     &EmptyCounter{},
+	DirectSessions:  &EmptyCounter{},
+	NextSessions:    &EmptyCounter{},
+	DurationGauge:   &EmptyGauge{},
+	DecisionMetrics: EmptyDecisionMetrics,
+}
+
+type ServerUpdateMetrics struct {
+	Invocations   Counter
+	DurationGauge Gauge
+}
+
+var EmptyServerUpdateMetrics ServerUpdateMetrics = ServerUpdateMetrics{
+	Invocations:   &EmptyCounter{},
+	DurationGauge: &EmptyGauge{},
+}

--- a/routing/route.go
+++ b/routing/route.go
@@ -3,6 +3,8 @@ package routing
 import (
 	"encoding/binary"
 	"hash/fnv"
+
+	"github.com/networknext/backend/metrics"
 )
 
 type Route struct {
@@ -10,7 +12,7 @@ type Route struct {
 	Stats  Stats
 }
 
-func (r *Route) Decide(prevDecision Decision, nnStats Stats, directStats Stats, metrics *DecisionMetrics, routeDecisions ...DecisionFunc) Decision {
+func (r *Route) Decide(prevDecision Decision, nnStats Stats, directStats Stats, metrics *metrics.DecisionMetrics, routeDecisions ...DecisionFunc) Decision {
 	nextDecision := prevDecision
 	for _, routeDecision := range routeDecisions {
 		decision := routeDecision(nextDecision, r.Stats, nnStats, directStats, metrics)

--- a/routing/route_decision.go
+++ b/routing/route_decision.go
@@ -11,20 +11,12 @@ type Decision struct {
 	Reason        DecisionReason
 }
 
-type DecisionMetrics struct {
-	VetoedSessions metrics.Counter
-}
-
-var EmptyDecisionMetrics DecisionMetrics = DecisionMetrics{
-	VetoedSessions: &metrics.EmptyCounter{},
-}
-
 // Decision takes in whether or not the logic is currently considering staying on network next,
 // the stats of the predicted network next route,
 // the stats of the last network next route,
 // and the stats of the direct route and decides whether or not to take the predicted network next route.
 // A reason is also provided for billing.
-type DecisionFunc func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *DecisionMetrics) Decision
+type DecisionFunc func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *metrics.DecisionMetrics) Decision
 
 // DecisionReason is the reason why a Decision was made.
 type DecisionReason uint64
@@ -106,7 +98,7 @@ const (
 // DecideUpgradeRTT will decide if the client should use the network next route if the RTT reduction is greater than the given threshold.
 // This decision only upgrades direct routes, so network next routes aren't considered.
 func DecideUpgradeRTT(rttThreshold float64) DecisionFunc {
-	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *DecisionMetrics) Decision {
+	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *metrics.DecisionMetrics) Decision {
 		// If upgrading to a nextwork next route would reduce RTT by at least the given threshold, upgrade
 		if !prevDecision.OnNetworkNext && directStats.RTT-predictedNextStats.RTT >= rttThreshold {
 			return Decision{true, DecisionRTTReduction}
@@ -120,7 +112,7 @@ func DecideUpgradeRTT(rttThreshold float64) DecisionFunc {
 // DecideDowngradeRTT will decide if the client should continue using the network next route if the network next RTT increase doesn't exceed the hysteresis value.
 // This decision only downgrades network next routes, so direct routes aren't considered.
 func DecideDowngradeRTT(rttHysteresis float64) DecisionFunc {
-	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *DecisionMetrics) Decision {
+	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *metrics.DecisionMetrics) Decision {
 		// If staying on a nextwork next route doesn't increase RTT by more than the given hysteresis value, stay
 		if prevDecision.OnNetworkNext {
 			if predictedNextStats.RTT-directStats.RTT <= rttHysteresis {
@@ -140,7 +132,7 @@ func DecideDowngradeRTT(rttHysteresis float64) DecisionFunc {
 // RTT by more than the RTT veto value, or increases packet loss if packet loss safety is enabled.
 // This decision only downgrades network next routes, so direct routes aren't considered.
 func DecideVeto(rttVeto float64, packetLossSafety bool, yolo bool) DecisionFunc {
-	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *DecisionMetrics) Decision {
+	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *metrics.DecisionMetrics) Decision {
 		if prevDecision.OnNetworkNext {
 			// Whether or not the network next route made the RTT worse than the veto value
 			if lastNextStats.RTT-directStats.RTT > rttVeto {
@@ -191,7 +183,7 @@ func DecideVeto(rttVeto float64, packetLossSafety bool, yolo bool) DecisionFunc 
 
 // DecideCommitted is not yet implemented
 func DecideCommitted() DecisionFunc {
-	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *DecisionMetrics) Decision {
+	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats, metrics *metrics.DecisionMetrics) Decision {
 		return Decision{prevDecision.OnNetworkNext, DecisionNoChange}
 	}
 }

--- a/routing/route_decision_test.go
+++ b/routing/route_decision_test.go
@@ -3,6 +3,7 @@ package routing_test
 import (
 	"testing"
 
+	"github.com/networknext/backend/metrics"
 	"github.com/networknext/backend/routing"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,7 +28,7 @@ func TestDecideUpgradeRTT(t *testing.T) {
 	assert.Equal(
 		t,
 		routing.Decision{true, routing.DecisionRTTReduction},
-		routeDecisionFunc(routing.Decision{false, routing.DecisionNoChange}, predictedStats, routing.Stats{}, directStats, &routing.EmptyDecisionMetrics),
+		routeDecisionFunc(routing.Decision{false, routing.DecisionNoChange}, predictedStats, routing.Stats{}, directStats, &metrics.EmptyDecisionMetrics),
 	)
 
 	// Now test if the route is left alone
@@ -36,7 +37,7 @@ func TestDecideUpgradeRTT(t *testing.T) {
 	assert.Equal(
 		t,
 		routing.Decision{false, routing.DecisionNoChange},
-		routeDecisionFunc(routing.Decision{false, routing.DecisionNoChange}, predictedStats, routing.Stats{}, directStats, &routing.EmptyDecisionMetrics),
+		routeDecisionFunc(routing.Decision{false, routing.DecisionNoChange}, predictedStats, routing.Stats{}, directStats, &metrics.EmptyDecisionMetrics),
 	)
 }
 
@@ -58,18 +59,18 @@ func TestDecideDowngradeRTT(t *testing.T) {
 	routeDecisionFunc := routing.DecideDowngradeRTT(rttHyteresis)
 
 	decision := routing.Decision{true, routing.DecisionNoChange}
-	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats, &routing.EmptyDecisionMetrics)
+	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats, &metrics.EmptyDecisionMetrics)
 
 	assert.Equal(t, routing.Decision{true, routing.DecisionNoChange}, decision)
 
 	// Now test to see if the route gets downgraded to a direct route due to RTT
 	predictedStats.RTT = directStats.RTT + rttHyteresis + 1.0
 
-	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats, &routing.EmptyDecisionMetrics)
+	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats, &metrics.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionRTTIncrease}, decision)
 
 	// Now test if a direct route is given
-	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats, &routing.EmptyDecisionMetrics)
+	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats, &metrics.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionNoChange}, decision)
 }
 
@@ -91,14 +92,14 @@ func TestDecideVeto(t *testing.T) {
 	routeDecisionFunc := routing.DecideVeto(rttVeto, false, false)
 
 	decision := routing.Decision{true, routing.DecisionNoChange}
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &metrics.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoRTT}, decision)
 
 	// Now test for yolo reason
 	decision.OnNetworkNext = true
 	routeDecisionFunc = routing.DecideVeto(rttVeto, false, true)
 
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &metrics.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoRTT | routing.DecisionVetoYOLO}, decision)
 
 	// Now test if the route is vetoed for packet loss increases
@@ -107,14 +108,14 @@ func TestDecideVeto(t *testing.T) {
 	decision.OnNetworkNext = true
 	routeDecisionFunc = routing.DecideVeto(rttVeto, true, false)
 
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &metrics.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoPacketLoss}, decision)
 
 	// Now test for yolo reason
 	decision.OnNetworkNext = true
 	routeDecisionFunc = routing.DecideVeto(rttVeto, true, true)
 
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &metrics.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoPacketLoss | routing.DecisionVetoYOLO}, decision)
 
 	// Test if route isn't vetoed
@@ -122,12 +123,12 @@ func TestDecideVeto(t *testing.T) {
 	decision.OnNetworkNext = true
 	routeDecisionFunc = routing.DecideVeto(rttVeto, true, true)
 
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &metrics.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{true, routing.DecisionNoChange}, decision)
 
 	// Test if direct route isn't changed
 	decision.OnNetworkNext = false
 
-	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &routing.EmptyDecisionMetrics)
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats, &metrics.EmptyDecisionMetrics)
 	assert.Equal(t, routing.Decision{false, routing.DecisionNoChange}, decision)
 }

--- a/routing/route_test.go
+++ b/routing/route_test.go
@@ -3,6 +3,7 @@ package routing_test
 import (
 	"testing"
 
+	"github.com/networknext/backend/metrics"
 	"github.com/networknext/backend/routing"
 	"github.com/stretchr/testify/assert"
 )
@@ -50,7 +51,7 @@ func TestDecide(t *testing.T) {
 		// Loop through all permutations of the decision functions and test that the result is the same
 		perms := permutations(decisionFuncs)
 		for i := 0; i < len(perms); i++ {
-			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[i]...)
+			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[i]...)
 			assert.Equal(t, expected, decision)
 		}
 	}
@@ -97,7 +98,7 @@ func TestDecide(t *testing.T) {
 		// Loop through all permutations of the decision functions and test that the result is the same
 		perms := permutations(decisionFuncs)
 		for i := 0; i < len(perms); i++ {
-			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[i]...)
+			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[i]...)
 			assert.Equal(t, expected, decision)
 		}
 	}
@@ -144,7 +145,7 @@ func TestDecide(t *testing.T) {
 		// Loop through all permutations of the decision functions and test that the result is the same
 		perms := permutations(decisionFuncs)
 		for i := 0; i < len(perms); i++ {
-			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[i]...)
+			decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[i]...)
 			assert.Equal(t, expected, decision)
 		}
 	}
@@ -198,7 +199,7 @@ func TestDecide(t *testing.T) {
 
 			for j := 0; j < len(perms); j++ {
 				perms[j] = append(perms[j], routing.DecideVeto(float64(routingRulesSettings.RTTVeto), routingRulesSettings.EnablePacketLossSafety, routingRulesSettings.EnableYouOnlyLiveOnce))
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -254,7 +255,7 @@ func TestDecide(t *testing.T) {
 
 			for j := 0; j < len(perms); j++ {
 				perms[j] = append(perms[j], routing.DecideVeto(float64(routingRulesSettings.RTTVeto), routingRulesSettings.EnablePacketLossSafety, routingRulesSettings.EnableYouOnlyLiveOnce))
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -311,7 +312,7 @@ func TestDecide(t *testing.T) {
 
 			for j := 0; j < len(perms); j++ {
 				perms[j] = append(perms[j], routing.DecideVeto(float64(routingRulesSettings.RTTVeto), routingRulesSettings.EnablePacketLossSafety, routingRulesSettings.EnableYouOnlyLiveOnce))
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -369,7 +370,7 @@ func TestDecide(t *testing.T) {
 
 			for j := 0; j < len(perms); j++ {
 				perms[j] = append(perms[j], routing.DecideVeto(float64(routingRulesSettings.RTTVeto), routingRulesSettings.EnablePacketLossSafety, routingRulesSettings.EnableYouOnlyLiveOnce))
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -420,7 +421,7 @@ func TestDecide(t *testing.T) {
 			perms := permutations(combs[i])
 
 			for j := 0; j < len(perms); j++ {
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -471,7 +472,7 @@ func TestDecide(t *testing.T) {
 			perms := permutations(combs[i])
 
 			for j := 0; j < len(perms); j++ {
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -525,7 +526,7 @@ func TestDecide(t *testing.T) {
 			perms := permutations(combs[i])
 
 			for j := 0; j < len(perms); j++ {
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}
@@ -547,7 +548,7 @@ func TestDecide(t *testing.T) {
 			perms := permutations(combs[i])
 
 			for j := 0; j < len(perms); j++ {
-				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &routing.EmptyDecisionMetrics, perms[j]...)
+				decision := route.Decide(startingDecision, lastNNStats, lastDirectStats, &metrics.EmptyDecisionMetrics, perms[j]...)
 				assert.Equal(t, expected, decision)
 			}
 		}

--- a/transport/udp_server_update_handler_test.go
+++ b/transport/udp_server_update_handler_test.go
@@ -24,7 +24,7 @@ func TestFailToUnmarshalServerUpdate(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:13")
 	assert.NoError(t, err)
 
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, &metrics.EmptyServerUpdateMetrics)
 	handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: []byte("this is not a proper packet")})
 
 	_, err = redisServer.Get("SERVER-0.0.0.0:13")
@@ -54,7 +54,7 @@ func TestSDKVersionTooOld(t *testing.T) {
 	data, err := packet.MarshalBinary()
 	assert.NoError(t, err)
 
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, &metrics.EmptyServerUpdateMetrics)
 	handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	_, err = redisServer.Get("SERVER-0.0.0.0:13")
@@ -86,7 +86,7 @@ func TestBuyerNotFound(t *testing.T) {
 	data, err := packet.MarshalBinary()
 	assert.NoError(t, err)
 
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyServerUpdateMetrics)
 	handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	_, err = redisServer.Get("SERVER-0.0.0.0:13")
@@ -122,7 +122,7 @@ func TestWrongBuyerPublicKey(t *testing.T) {
 	data, err := packet.MarshalBinary()
 	assert.NoError(t, err)
 
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyServerUpdateMetrics)
 	handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	_, err = redisServer.Get("SERVER-0.0.0.0:13")
@@ -169,7 +169,7 @@ func TestServerPacketSequenceTooOld(t *testing.T) {
 	err = redisServer.Set("SERVER-0.0.0.0:13", string(se))
 	assert.NoError(t, err)
 
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyServerUpdateMetrics)
 	handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
 	ds, err := redisServer.Get("SERVER-0.0.0.0:13")
@@ -225,7 +225,7 @@ func TestSuccessfulUpdate(t *testing.T) {
 	}
 
 	// Initialize the UDP handler with the required redis client
-	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyGauge{}, &metrics.EmptyCounter{})
+	handler := transport.ServerUpdateHandlerFunc(log.NewNopLogger(), redisClient, &db, &metrics.EmptyServerUpdateMetrics)
 
 	// Invoke the handler with the data packet and address it is coming from
 	handler(&buf, &incoming)


### PR DESCRIPTION
Took all of the metrics related structs from `routing` and `transport` and moved them into `metrics` for consistency. I also created a `ServerUpdateMetrics` struct for passing metrics to the server update handler.