### PR TITLE
Relay update scripts binary flag

### DIFF
--- a/cmd/tools/scripts/update-relay/update-digitalocean-dev-relays.sh
+++ b/cmd/tools/scripts/update-relay/update-digitalocean-dev-relays.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export SSH_KEY
+export BINARY
 
 ips=(
     165.227.10.28
@@ -28,6 +29,11 @@ do
         shift
         shift
         ;;
+        -b|--binary)
+        BINARY="$2"
+        shift
+        shift
+        ;;
     esac
 done
 
@@ -36,7 +42,12 @@ if [ -z $SSH_KEY ]; then
     exit
 fi
 
+if [ -z $BINARY ]; then
+    echo "No relay binary provided - use -b or --binary to provide a file path to the relay binary"
+    exit
+fi
+
 for i in ${!ips[@]}; do
     echo Updating relay at ip ${ips[$i]}
-    ./cmd/tools/scripts/update-relay/update.sh -u root -i ${ips[$i]} -p ${public_keys[$i]} -s ${private_keys[$i]} -f $SSH_KEY
+    ./cmd/tools/scripts/update-relay/update.sh -u root -i ${ips[$i]} -p ${public_keys[$i]} -s ${private_keys[$i]} -f $SSH_KEY -b $BINARY
 done

--- a/cmd/tools/scripts/update-relay/update-vultr-dev-relays.sh
+++ b/cmd/tools/scripts/update-relay/update-vultr-dev-relays.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 export SSH_KEY
+export BINARY
 
 ips=(
     144.202.31.156
@@ -37,6 +38,11 @@ do
         shift
         shift
         ;;
+        -b|--binary)
+        BINARY="$2"
+        shift
+        shift
+        ;;
     esac
 done
 
@@ -45,7 +51,12 @@ if [ -z $SSH_KEY ]; then
     exit
 fi
 
+if [ -z $BINARY ]; then
+    echo "No relay binary provided - use -b or --binary to provide a file path to the relay binary"
+    exit
+fi
+
 for i in ${!ips[@]}; do
     echo Updating relay at ip ${ips[$i]}
-    ./cmd/tools/scripts/update-relay/update.sh -u root -i ${ips[$i]} -p ${public_keys[$i]} -s ${private_keys[$i]} -f $SSH_KEY
+    ./cmd/tools/scripts/update-relay/update.sh -u root -i ${ips[$i]} -p ${public_keys[$i]} -s ${private_keys[$i]} -f $SSH_KEY -b $BINARY
 done

--- a/cmd/tools/scripts/update-relay/update.sh
+++ b/cmd/tools/scripts/update-relay/update.sh
@@ -5,7 +5,7 @@ export IP_ADDRESS
 export PUBLIC_KEY
 export PRIVATE_KEY
 export SSH_KEY
-export BINARY=./dist/relay
+export BINARY
 
 for arg in "$@"
 do


### PR DESCRIPTION
Added a binary parameter to the relay update scripts for vultr and digital ocean. The underlying update script had it before, but it was optional and defaulted to `./dist/relay`. Now the flag is required. Hopefully this will help make swapping out between the reference relay and the new relay easier.