### PR TITLE
continue tokens are now truncated at the right index

### DIFF
--- a/cmd/tools/tokens/tokens.go
+++ b/cmd/tools/tokens/tokens.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/networknext/backend/routing"
-	"github.com/networknext/backend/transport"
 )
 
 type relayaddrFlags []string
@@ -97,9 +96,11 @@ func main() {
 
 	var routeToken routing.Token
 	tokenTypeIdentifyingByte := make([]byte, 1)
+	clientCutoffIndex := 0
 	switch *token {
 	case "new":
 		tokenTypeIdentifyingByte[0] = routing.TokenTypeRouteRequest
+		clientCutoffIndex = routing.EncryptedNextRouteTokenSize
 		nextRouteToken := routing.NextRouteToken{
 			Expires: uint64(time.Now().Add(*expires).Unix()),
 
@@ -128,6 +129,7 @@ func main() {
 		routeToken = &nextRouteToken
 	case "continue":
 		tokenTypeIdentifyingByte[0] = routing.TokenTypeContinueRequest
+		clientCutoffIndex = routing.EncryptedContinueRouteTokenSize
 		continueRouteToken := routing.ContinueRouteToken{
 			Expires: uint64(time.Now().Add(*expires).Unix()),
 
@@ -164,7 +166,7 @@ func main() {
 	}
 
 	if *clientkey == "" {
-		enc = append(tokenTypeIdentifyingByte, enc[transport.EncryptedTokenRouteSize:]...)
+		enc = append(tokenTypeIdentifyingByte, enc[clientCutoffIndex:]...)
 	}
 
 	_, err = os.Stdout.Write(enc)

--- a/transport/packet_server.go
+++ b/transport/packet_server.go
@@ -20,7 +20,6 @@ const (
 	MaxNearRelays = 32
 	MaxTokens     = 7
 
-	EncryptedTokenRouteSize = 117
 	// EncryptedTokenContinueSize = 58
 	MTUSize = 1300
 


### PR DESCRIPTION
When I originally made the edit to the token tool I trimmed the client segment out at the 117'th byte, but the continue token has a different segment size so I edited the tool to trim out the right segment when making a continue token.