### PR TITLE
Relay new/throughput accuracy

### DIFF
--- a/cmd/relay_new/src/core/packet_processor.cpp
+++ b/cmd/relay_new/src/core/packet_processor.cpp
@@ -99,7 +99,7 @@ namespace core
 
     if (packet.Addr.Type == net::AddressType::IPv4) {
       headerBytes = IPv4UDPHeaderSize;
-    } else if (packet.Addr.Type == net::AddressType::IPv4) {
+    } else if (packet.Addr.Type == net::AddressType::IPv6) {
       headerBytes = IPv6UDPHeaderSize;
     }
 


### PR DESCRIPTION
When going through the old relay I noticed it accounted for all the bytes of the packet, not just the data, so now the new relay does too to make benchmarking more accurate.