### PR TITLE
Fallback to direct metric

### DIFF
--- a/metrics/metrics_types.go
+++ b/metrics/metrics_types.go
@@ -48,6 +48,7 @@ var EmptyDecisionMetrics DecisionMetrics = DecisionMetrics{
 
 type SessionErrorMetrics struct {
 	ReadPacketFailure           Counter
+	FallbackToDirect            Counter
 	PipelineExecFailure         Counter
 	GetServerDataFailure        Counter
 	UnmarshalServerDataFailure  Counter
@@ -68,6 +69,7 @@ type SessionErrorMetrics struct {
 
 var EmptySessionErrorMetrics SessionErrorMetrics = SessionErrorMetrics{
 	ReadPacketFailure:           &EmptyCounter{},
+	FallbackToDirect:            &EmptyCounter{},
 	PipelineExecFailure:         &EmptyCounter{},
 	GetServerDataFailure:        &EmptyCounter{},
 	UnmarshalServerDataFailure:  &EmptyCounter{},
@@ -377,6 +379,16 @@ func NewSessionMetrics(ctx context.Context, metricsHandler Handler) (*SessionMet
 		DisplayName: "Session Encryption Failure",
 		ServiceName: "server_backend",
 		ID:          "session.error.encryption_failure",
+		Unit:        "errors",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sessionMetrics.SessionErrorMetrics.FallbackToDirect, err = metricsHandler.NewCounter(ctx, &Descriptor{
+		DisplayName: "Session Fallback To Direct",
+		ServiceName: "server_backend",
+		ID:          "session.error.fallback_to_direct",
 		Unit:        "errors",
 	})
 	if err != nil {

--- a/transport/udp.go
+++ b/transport/udp.go
@@ -237,6 +237,7 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClient redis.Cmdable, stor
 
 		if packet.FallbackToDirect {
 			level.Error(logger).Log("err", "fallback to direct")
+			metrics.SessionErrorMetrics.FallbackToDirect.Add(1)
 			return
 		}
 

--- a/transport/udp_session_update_handler_test.go
+++ b/transport/udp_session_update_handler_test.go
@@ -84,6 +84,43 @@ func TestFailToUnmarshalPacket(t *testing.T) {
 	assert.Equal(t, 1.0, sessionMetrics.SessionErrorMetrics.ReadPacketFailure.Value())
 }
 
+func TestFallbackToDirect(t *testing.T) {
+	redisServer, _ := miniredis.Run()
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+
+	addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:13")
+	assert.NoError(t, err)
+
+	sessionMetrics := metrics.EmptySessionMetrics
+	localMetrics := metrics.LocalHandler{}
+
+	metric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "test metric"})
+	assert.NoError(t, err)
+
+	sessionMetrics.SessionErrorMetrics.FallbackToDirect = metric
+
+	packet := transport.SessionUpdatePacket{
+		Sequence:             13,
+		ServerAddress:        net.UDPAddr{IP: net.IPv4zero, Port: 13},
+		ClientRoutePublicKey: make([]byte, crypto.KeySize),
+		FallbackToDirect:     true,
+	}
+
+	packet.Signature = crypto.Sign(TestBuyersServerPrivateKey, packet.GetSignData())
+
+	data, err := packet.MarshalBinary()
+	assert.NoError(t, err)
+
+	var resbuf bytes.Buffer
+
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, nil, nil, nil, nil, &sessionMetrics, nil, nil, nil)
+	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
+
+	assert.Equal(t, 0, resbuf.Len())
+
+	assert.Equal(t, 1.0, sessionMetrics.SessionErrorMetrics.FallbackToDirect.Value())
+}
+
 func TestFailToExecPipeline(t *testing.T) {
 	redisServer, _ := miniredis.Run()
 	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})


### PR DESCRIPTION
Added a metric and unit test for fallback to direct. I noticed when looking through the func_backend for func_tests that we weren't actually handling if the fallback to direct flag on the packet was set, so I added that into our backend on my past PR. This PR just adds a metric for that case for StackDriver and a unit test.