### PR TITLE
Fix billing slice duration

### DIFF
--- a/transport/udp.go
+++ b/transport/udp.go
@@ -443,7 +443,6 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClient redis.Cmdable, stor
 				"buyer_yolo", buyer.RoutingRulesSettings.EnableYouOnlyLiveOnce,
 			)
 
-			// Session hasn't been vetoed, perform route decision as normal
 			routeDecision = nextRoute.Decide(sessionCacheEntry.RouteDecision, nnStats, directStats,
 				routing.DecideUpgradeRTT(float64(buyer.RoutingRulesSettings.RTTThreshold)),
 				routing.DecideDowngradeRTT(float64(buyer.RoutingRulesSettings.RTTHysteresis), buyer.RoutingRulesSettings.EnableYouOnlyLiveOnce),


### PR DESCRIPTION
When looking through some of the billing stuff to try and get committed flag and user flags in the billing entry, I noticed that the slice duration and the initial slice flag were wrong, now that we have the backend sending out token expire times properly. This PR refactors the session handler a little and fixes those billing values.