### PR TITLE
Add user flags to billing slice

### DIFF
--- a/billing/types.go
+++ b/billing/types.go
@@ -124,6 +124,7 @@ type RouteRequest struct {
 	FallbackFlags             uint32                `protobuf:"varint,34,opt,name=fallbackFlags,proto3" json:"fallbackFlags,omitempty"`
 	IssuedNearRelays          []*IssuedNearRelay    `protobuf:"bytes,35,rep,name=issuedNearRelays,proto3" json:"issuedNearRelays,omitempty"`
 	Committed                 bool                  `protobuf:"varint,36,opt,name=committed,proto3" json:"committed,omitempty"`
+	UserFlags                 uint64                `protobuf:"varint,37,opt,name=userFlags,proto3" json:"userFlags,omitempty"`
 }
 
 func (req *RouteRequest) Reset() {

--- a/transport/billing_entry_helpers.go
+++ b/transport/billing_entry_helpers.go
@@ -83,6 +83,7 @@ func NewRouteRequest(updatePacket SessionUpdatePacket, buyer *routing.Buyer, ser
 		PacketsLostServerToClient: updatePacket.PacketsLostServerToClient,
 		FallbackFlags:             updatePacket.Flags,
 		Committed:                 updatePacket.Committed,
+		UserFlags:                 updatePacket.UserFlags,
 	}
 }
 


### PR DESCRIPTION
All this PR does is adds the user flags to the billing slice sent to pub/sub.

The companion PR to get that data into bigquery is here: https://github.com/networknext/next/pull/2864