### PR TITLE
adds -std=c++17 as a compile flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXX_FLAGS := -Wall -Wextra
+CXX_FLAGS := -Wall -Wextra -std=c++17
 GO = go
 GOFMT = gofmt
 


### PR DESCRIPTION
Recent GCC versions included c++11 features by default, but clang does not unless explicitly specified. To allow for compiling by clang I enabled the c++17 standard.

GCC-7 & Clang-5 and later versions for both all support c++17 in full. To fix the ref relay issue all that was needed was '11 support but just to futureproof it I went with '17. Hopefully, your eyes don't bleed with these intense changes