### PR TITLE
Relay backend unit tests fix

### DIFF
--- a/transport/relay_init_handler_test.go
+++ b/transport/relay_init_handler_test.go
@@ -6,13 +6,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"math"
 	mrand "math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -335,7 +335,9 @@ func TestRelayInitAddressIsInvalid(t *testing.T) {
 	{
 		buff, err := packet.MarshalJSON()
 		assert.NoError(t, err)
-		offset := len(fmt.Sprintf("{\"encrypted_token\":\"%s\",\"magic_request_protection\":%d,\"nonce\":\"%s\",\"relay_address\":\"", base64.StdEncoding.EncodeToString(packet.EncryptedToken), packet.Magic, base64.StdEncoding.EncodeToString(packet.Nonce)))
+
+		offset := strings.Index(string(buff), "127.0.0.1:40000")
+		assert.GreaterOrEqual(t, offset, 0)
 		buff[offset] = 'x' // first number in ip address is now 'x'
 		relayInitAssertions(t, "application/json", relay, buff, http.StatusBadRequest, nil, nil, nil, nil, routerPrivateKey[:])
 	}


### PR DESCRIPTION
This PR should close #199 when merged.

During my last refactor PR I made a silly mistake when adding JSON versions of some tests. In short, when marshaling JSON I made the assumption that struct order is preserved when it isn't, since the way it's marshaled is by populating a map and marshaling that map.

This PR fixes the test by getting the index of the relay address in the marshaled JSON with `strings.Index()` instead of assuming that the marshaled JSON is constant.

This only appears to fix the first failing test in issue #199 however, and I'm still unsure if the second test failure is a separate issue or a side effect of the first test failure. Since only @MichaelLarkin could repro this bug, I'll keep it as a draft until he can confirm that this PR actually fixes all the tests.