### PR TITLE
Fixed invalid address tests

### DIFF
--- a/transport/relay_init_handler_test.go
+++ b/transport/relay_init_handler_test.go
@@ -278,8 +278,6 @@ func TestRelayInitVersionIsInvalid(t *testing.T) {
 }
 
 func TestRelayInitAddressIsInvalid(t *testing.T) {
-	t.Skip("Test can fail on certain machines due to relay address being unmarshaled and interpreted as correct. Needs more work to determine the cause.")
-
 	relayPublicKey, relayPrivateKey := getRelayKeyPair(t)
 	routerPublicKey, routerPrivateKey, err := box.GenerateKey(crand.Reader)
 	assert.NoError(t, err)
@@ -316,7 +314,10 @@ func TestRelayInitAddressIsInvalid(t *testing.T) {
 	{
 		buff, err := packet.MarshalBinary()
 		assert.NoError(t, err)
-		buff[4+4+crypto.NonceSize+4] = 'x' // first number in ip address is now 'x'
+		badAddr := "invalid address"        // "invalid address" is luckily the same number of characters as "127.0.0.1:40000"
+		for i := 0; i < len(badAddr); i++ { // Replace the address with the bad address character by character
+			buff[4+4+crypto.NonceSize+4+i] = badAddr[i]
+		}
 		relayInitAssertions(t, "application/octet-stream", relay, buff, http.StatusBadRequest, nil, nil, nil, nil, routerPrivateKey[:])
 	}
 
@@ -327,7 +328,10 @@ func TestRelayInitAddressIsInvalid(t *testing.T) {
 
 		offset := strings.Index(string(buff), addr)
 		assert.GreaterOrEqual(t, offset, 0)
-		buff[offset] = 'x' // first number in ip address is now 'x'
+		badAddr := "invalid address"        // "invalid address" is luckily the same number of characters as "127.0.0.1:40000"
+		for i := 0; i < len(badAddr); i++ { // Replace the address with the bad address character by character
+			buff[offset+i] = badAddr[i]
+		}
 		relayInitAssertions(t, "application/json", relay, buff, http.StatusBadRequest, nil, nil, nil, nil, routerPrivateKey[:])
 	}
 }

--- a/transport/relay_update_handler_test.go
+++ b/transport/relay_update_handler_test.go
@@ -187,7 +187,10 @@ func TestRelayUpdateInvalidAddress(t *testing.T) {
 	{
 		buff, err := packet.MarshalBinary()
 		assert.NoError(t, err)
-		buff[8] = 'x' // assign this index (which should be the first item in the address) as the letter 'x' making it invalid
+		badAddr := "invalid address"        // "invalid address" is luckily the same number of characters as "127.0.0.1:40000"
+		for i := 0; i < len(badAddr); i++ { // Replace the address with the bad address character by character
+			buff[8+i] = badAddr[i]
+		}
 		relayUpdateAssertions(t, "application/octet-stream", buff, http.StatusBadRequest, nil, nil)
 	}
 
@@ -198,7 +201,10 @@ func TestRelayUpdateInvalidAddress(t *testing.T) {
 
 		offset := strings.Index(string(buff), "127.0.0.1:40000")
 		assert.GreaterOrEqual(t, offset, 0)
-		buff[offset] = 'x' // assign this index (which should be the first item in the address) as the letter 'x' making it invalid
+		badAddr := "invalid address"        // "invalid address" is luckily the same number of characters as "127.0.0.1:40000"
+		for i := 0; i < len(badAddr); i++ { // Replace the address with the bad address character by character
+			buff[offset+i] = badAddr[i]
+		}
 		relayUpdateAssertions(t, "application/json", buff, http.StatusBadRequest, nil, nil)
 	}
 }


### PR DESCRIPTION
Finally got those relay backend unit tests passing on Michael's machine. Turns out the issue was that for some reason his machine was resolving `x27.0.0.1:4000` as a valid address while ours were not. Not sure why this is, I would have to dig into Go's IP resolver implementation to potentially find out why. It was an easy fix though once I found that out, I just set the entire address to "invalid address" so that there was no chance it would be interpreted correctly.