### PR TITLE
Fix InMemory and nil ErrorMetrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ cover.out
 *.d
 .ycm_extra_conf.py
 .env
-.rdb
+*.rdb

--- a/cmd/server_backend/server_backend.go
+++ b/cmd/server_backend/server_backend.go
@@ -133,6 +133,8 @@ func main() {
 	// Create an in-memory db
 	var db storage.Storer = &storage.InMemory{}
 	db.AddBuyer(ctx, routing.Buyer{
+		ID:                   13672574147039585173,
+		Name:                 "local",
 		PublicKey:            customerPublicKey,
 		RoutingRulesSettings: routing.LocalRoutingRulesSettings,
 	})

--- a/metrics/metrics_types.go
+++ b/metrics/metrics_types.go
@@ -688,6 +688,7 @@ func NewServerUpdateMetrics(ctx context.Context, metricsHandler Handler) (*Serve
 	updateMetrics := ServerUpdateMetrics{
 		Invocations:   updateInvocationsCounter,
 		DurationGauge: updateDurationGauge,
+		ErrorMetrics:  EmptyServerUpdateErrorMetrics,
 	}
 
 	return &updateMetrics, nil
@@ -719,6 +720,7 @@ func NewRelayInitMetrics(ctx context.Context, metricsHandler Handler) (*RelayIni
 	initMetrics := RelayInitMetrics{
 		Invocations:   initCount,
 		DurationGauge: initDuration,
+		ErrorMetrics:  EmptyRelayInitErrorMetrics,
 	}
 
 	return &initMetrics, nil
@@ -750,6 +752,7 @@ func NewRelayUpdateMetrics(ctx context.Context, metricsHandler Handler) (*RelayU
 	updateMetrics := RelayUpdateMetrics{
 		Invocations:   updateCount,
 		DurationGauge: updateDuration,
+		ErrorMetrics:  EmptyRelayUpdateErrorMetrics,
 	}
 
 	return &updateMetrics, nil
@@ -781,6 +784,7 @@ func NewRelayHandlerMetrics(ctx context.Context, metricsHandler Handler) (*Relay
 	handerMetrics := RelayHandlerMetrics{
 		Invocations:   handlerCount,
 		DurationGauge: handlerDuration,
+		ErrorMetrics:  EmptyRelayHandlerErrorMetrics,
 	}
 
 	return &handerMetrics, nil

--- a/storage/in_memory.go
+++ b/storage/in_memory.go
@@ -84,6 +84,11 @@ func (m *InMemory) Relay(id uint64) (routing.Relay, error) {
 		}
 	}
 
+	// If the relay isn't found then just return the first one, since we need one for local dev
+	if len(m.localRelays) > 0 {
+		return m.localRelays[0], nil
+	}
+
 	return routing.Relay{}, fmt.Errorf("relay with id %d not found in memory storage", id)
 }
 
@@ -136,6 +141,12 @@ func (m *InMemory) SetRelay(ctx context.Context, relay routing.Relay) error {
 			m.localRelays[i] = relay
 			return nil
 		}
+	}
+
+	// If the relay isn't found then just set the first one, since we need to set one for local dev
+	if len(m.localRelays) > 0 {
+		m.localRelays[0] = relay
+		return nil
 	}
 
 	return fmt.Errorf("relay with id %d not found in memory storage", relay.ID)


### PR DESCRIPTION
This PR fixes a fews issues with my last few PRs that I missed. Namely, when running locally the relay backend couldn't find the relays since they weren't added to the InMemory storage. This has been fixed to reproduce the previous behavior of just returning the first relay in storage if lookup in memory fails. Also, the server backend couldn't find the buyer anymore because the ID wasn't set when adding the buyer locally, which I've fixed.
Lastly, the error metrics were nil, so if something ever went wrong the service would panic due to dereferencing a nil pointer. This has been fixed by setting the error metrics I added to empty.