### PR TITLE
next env feature expansion

### DIFF
--- a/cmd/tools/next/README.md
+++ b/cmd/tools/next/README.md
@@ -4,17 +4,6 @@
 
 Run `./next` in the root of the repo for available commands.
 
-## Env
-
-Set the tools current environment. If the environment is set to one of local, dev, or prod, the tool will use preconfigured settings for each respective environment.
-
-If the environment does not match one of those three the tool will be pointed to whatever the value is as a url value.
-
-Examples: \
-&nbsp;&nbsp;`next env local` \
-&nbsp;&nbsp;`next env localhost:20000` \
-&nbsp;&nbsp;`next env portal.dev.networknext.com`
-
 ## SSH
 
 SSH into a remote device. You must set the SSH key before attempting to connect to a device, otherwise you will get denied.

--- a/cmd/tools/next/env.go
+++ b/cmd/tools/next/env.go
@@ -12,7 +12,7 @@ import (
 const (
 	PortalHostnameLocal = "localhost:20000"
 	PortalHostnameDev   = "portal.dev.networknext.com"
-	PortalHostnameProd  = "portal.dev.networknext.com"
+	PortalHostnameProd  = "portal.prod.networknext.com"
 )
 
 type Environment struct {


### PR DESCRIPTION
Allows certain env values to make the next tool behave in preconfigured ways.

'dev' will point the tool to the dev portal, 'prod' to prod, and 'local' to localhost:20000. However if what was set matches none of those three the value will instead be used directly, allowing for some flexibility when needed.