### PR TITLE
Add firestore unit tests to semaphore

### DIFF
--- a/cmd/tools/scripts/test-with-firestore-emulator.sh
+++ b/cmd/tools/scripts/test-with-firestore-emulator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 printf "Starting firestore emulator...\n\n"
-setsid gcloud beta emulators firestore start --host-port $FIRESTORE_EMULATOR_HOST &
+setsid gcloud beta emulators firestore start --host-port $FIRESTORE_EMULATOR_HOST --no-user-output-enabled &
 sessionID=$! # Get the session ID of this process so we can close it later
 
 # Trap kill the process group so all firestore emulator processes are closed properly


### PR DESCRIPTION
So turns out adding the Firestore emulator to Semaphore was easier than I thought, since gcloud is already installed. All I had to do was install the firestore emulator and then set the environment variable and everything just worked. Only issue I ran into was that I couldn't use port 8000, I guess Semaphore is already using that port for something else, so I just changed it to 11000.