### PR TITLE
Fixed no datacenter in server init

### DIFF
--- a/cmd/tools/scripts/test-func-parallel.sh
+++ b/cmd/tools/scripts/test-func-parallel.sh
@@ -11,15 +11,10 @@ function remove_containers() {
 tests=(
     test_direct_default
     test_direct_upgrade
-    test_direct_no_upgrade
-    test_direct_with_backend
-    test_fallback_to_direct_without_backend
-    test_fallback_to_direct_is_not_sticky
-    test_packets_over_next_with_relay_and_backend
-    test_idempotent
-    test_fallback_to_direct_when_backend_goes_down
-    test_network_next_disabled_server
-    test_network_next_disabled_client
+    test_network_next
+    test_fallback_to_direct
+    test_disable_network_next_on_server
+    test_disable_network_next_on_client
     test_server_under_load
     test_reconnect_direct
     test_reconnect_next
@@ -33,6 +28,7 @@ tests=(
     test_user_flags
     test_packet_loss_direct
     test_packet_loss_next
+    test_idempotent
 )
 
 for test in "${tests[@]}"; do

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -130,7 +130,7 @@ func ServerInitHandlerFunc(logger log.Logger, storer storage.Storer, metrics *me
 
 		_, err := storer.Datacenter(packet.DatacenterID)
 		if err != nil {
-			level.Error(locallogger).Log("msg", "failed to get buyer from storage", "err", err)
+			level.Error(locallogger).Log("msg", "failed to get datacenter from storage", "err", err)
 			response.Response = InitResponseUnknownDatacenter
 			metrics.ErrorMetrics.DatacenterNotFound.Add(1)
 			return


### PR DESCRIPTION
The server backend creates a buyer in the in memory db when running locally, but doesn't create a datacenter, so the new server init endpoint failed when trying to find a datacenter with the name "local". This PR fixes that issue by adding a local datacenter in the server backend.

I also updated the parallel func test script to match the new func test changes, since in the 3.4.4 SDK PR some were renamed/removed but the parallel func test script wasn't updated.