### PR TITLE
Add Traffic Stats to Ops CLI

### DIFF
--- a/cmd/relay/relay.cpp
+++ b/cmd/relay/relay.cpp
@@ -4611,7 +4611,7 @@ int relay_update( CURL * curl, const char * hostname, const uint8_t * relay_toke
 
     uint32_t update_version = 0;
 
-    uint8_t update_data[10*1024 + 8 + 1]; // + 8 for the bytes received counter, + 1 for the shutdown flag
+    uint8_t update_data[10*1024 + 8 + 8 + 8 + 1]; // + 8 for the session count, + 8 for the bytes sent counter, + 8 for the bytes received counter, + 1 for the shutdown flag
 
     uint8_t * p = update_data;
     relay_write_uint32( &p, update_version );
@@ -4632,6 +4632,7 @@ int relay_update( CURL * curl, const char * hostname, const uint8_t * relay_toke
         relay_write_float32( &p, stats.relay_packet_loss[i] );
     }
 
+    relay_write_uint64(&p, relay->sessions->size());
     relay_write_uint64(&p, relay->bytes_sent.load());
     relay->bytes_sent.store(0);
     relay_write_uint64(&p, relay->bytes_received.load());

--- a/routing/geo.go
+++ b/routing/geo.go
@@ -88,8 +88,8 @@ type GeoClient struct {
 func (c *GeoClient) Add(r Relay) error {
 	geoloc := redis.GeoLocation{
 		Name:      strconv.FormatUint(r.ID, 10),
-		Latitude:  r.Latitude,
-		Longitude: r.Longitude,
+		Latitude:  r.Datacenter.Location.Latitude,
+		Longitude: r.Datacenter.Location.Longitude,
 	}
 
 	return c.RedisClient.GeoAdd(c.Namespace, &geoloc).Err()
@@ -123,9 +123,13 @@ func (c *GeoClient) RelaysWithin(lat float64, long float64, radius float64, uom 
 		}
 
 		relays[idx] = Relay{
-			ID:        id,
-			Latitude:  geoloc.Latitude,
-			Longitude: geoloc.Longitude,
+			ID: id,
+			Datacenter: Datacenter{
+				Location: Location{
+					Latitude:  geoloc.Latitude,
+					Longitude: geoloc.Longitude,
+				},
+			},
 		}
 	}
 

--- a/routing/geo_test.go
+++ b/routing/geo_test.go
@@ -93,17 +93,25 @@ func TestGeoClient(t *testing.T) {
 
 	t.Run("Add", func(t *testing.T) {
 		r1 := routing.Relay{
-			ID:        1,
-			Latitude:  38.115556,
-			Longitude: 13.361389,
+			ID: 1,
+			Datacenter: routing.Datacenter{
+				Location: routing.Location{
+					Latitude:  38.115556,
+					Longitude: 13.361389,
+				},
+			},
 		}
 		err := geoclient.Add(r1)
 		assert.NoError(t, err)
 
 		r2 := routing.Relay{
-			ID:        2,
-			Latitude:  37.502669,
-			Longitude: 15.087269,
+			ID: 2,
+			Datacenter: routing.Datacenter{
+				Location: routing.Location{
+					Latitude:  37.502669,
+					Longitude: 15.087269,
+				},
+			},
 		}
 		err = geoclient.Add(r2)
 		assert.NoError(t, err)
@@ -111,17 +119,25 @@ func TestGeoClient(t *testing.T) {
 
 	t.Run("RelaysWithin", func(t *testing.T) {
 		r1 := routing.Relay{
-			ID:        1,
-			Latitude:  38.115556,
-			Longitude: 13.361389,
+			ID: 1,
+			Datacenter: routing.Datacenter{
+				Location: routing.Location{
+					Latitude:  38.115556,
+					Longitude: 13.361389,
+				},
+			},
 		}
 		err := geoclient.Add(r1)
 		assert.NoError(t, err)
 
 		r2 := routing.Relay{
-			ID:        2,
-			Latitude:  37.502669,
-			Longitude: 15.087269,
+			ID: 2,
+			Datacenter: routing.Datacenter{
+				Location: routing.Location{
+					Latitude:  37.502669,
+					Longitude: 15.087269,
+				},
+			},
 		}
 		err = geoclient.Add(r2)
 		assert.NoError(t, err)

--- a/routing/stats_database_test.go
+++ b/routing/stats_database_test.go
@@ -441,7 +441,7 @@ func TestStatsDatabase(t *testing.T) {
 
 			var costMatrix routing.CostMatrix
 			err = statsdb.GetCostMatrix(&costMatrix, redisClient)
-			assert.EqualError(t, err, "failed to unmarshal relay when creating cost matrix: failed to unmarshal relay state")
+			assert.EqualError(t, err, "failed to unmarshal relay when creating cost matrix: failed to unmarshal relay bytes received")
 		})
 	})
 }

--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -51,8 +51,8 @@ type relay struct {
 	Address            string                 `firestore:"publicAddress"`
 	PublicKey          []byte                 `firestore:"publicKey"`
 	UpdateKey          []byte                 `firestore:"updateKey"`
-	NICSpeedMbps       int                    `firestore:"nicSpeedMbps"`
-	IncludedBandwithGB int                    `firestore:"includedBandwidthGB"`
+	NICSpeedMbps       int64                  `firestore:"nicSpeedMbps"`
+	IncludedBandwithGB int64                  `firestore:"includedBandwidthGB"`
 	Datacenter         *firestore.DocumentRef `firestore:"datacenter"`
 	Seller             *firestore.DocumentRef `firestore:"seller"`
 	ManagementAddress  string                 `firestore:"managementAddress"`
@@ -468,8 +468,8 @@ func (fs *Firestore) AddRelay(ctx context.Context, r routing.Relay) error {
 		Address:            r.Addr.String(),
 		PublicKey:          r.PublicKey,
 		UpdateKey:          r.PublicKey,
-		NICSpeedMbps:       r.NICSpeedMbps,
-		IncludedBandwithGB: r.IncludedBandwidthGB,
+		NICSpeedMbps:       int64(r.NICSpeedMbps),
+		IncludedBandwithGB: int64(r.IncludedBandwidthGB),
 		Datacenter:         datacenterRef,
 		Seller:             sellerRef,
 		ManagementAddress:  r.ManagementAddr,
@@ -937,8 +937,8 @@ func (fs *Firestore) syncRelays(ctx context.Context) error {
 				Port: int(iport),
 			},
 			PublicKey:           publicKey,
-			NICSpeedMbps:        r.NICSpeedMbps,
-			IncludedBandwidthGB: r.IncludedBandwithGB,
+			NICSpeedMbps:        uint64(r.NICSpeedMbps),
+			IncludedBandwidthGB: uint64(r.IncludedBandwithGB),
 			ManagementAddr:      r.ManagementAddress,
 			SSHUser:             r.SSHUser,
 			SSHPort:             r.SSHPort,
@@ -974,8 +974,6 @@ func (fs *Firestore) syncRelays(ctx context.Context) error {
 		}
 
 		relay.Datacenter = datacenter
-		relay.Latitude = float64(d.Latitude)
-		relay.Longitude = float64(d.Longitude)
 
 		// Get seller
 		sdoc, err := r.Seller.Get(ctx)

--- a/storage/firestore_test.go
+++ b/storage/firestore_test.go
@@ -1156,16 +1156,13 @@ func TestFirestore(t *testing.T) {
 			EgressPriceCents:  20,
 		}
 
-		lat := 70.5
-		long := 120.5
-
 		expectedDatacenter := routing.Datacenter{
 			ID:      crypto.HashID("local"),
 			Name:    "local",
 			Enabled: true,
 			Location: routing.Location{
-				Latitude:  lat,
-				Longitude: long,
+				Latitude:  70.5,
+				Longitude: 120.5,
 			},
 		}
 
@@ -1179,8 +1176,6 @@ func TestFirestore(t *testing.T) {
 			PublicKey:  make([]byte, crypto.KeySize),
 			Seller:     expectedSeller,
 			Datacenter: expectedDatacenter,
-			Latitude:   lat,
-			Longitude:  long,
 		}
 
 		err = fs.AddBuyer(ctx, expectedBuyer)

--- a/transport/jsonrpc/ops_test.go
+++ b/transport/jsonrpc/ops_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v7"
 	"github.com/networknext/backend/crypto"
 	"github.com/networknext/backend/routing"
 	"github.com/networknext/backend/storage"
@@ -314,8 +316,13 @@ func TestRelays(t *testing.T) {
 	storer.AddRelay(context.Background(), routing.Relay{ID: 1, Name: "local.local.1"})
 	storer.AddRelay(context.Background(), routing.Relay{ID: 2, Name: "local.local.2"})
 
+	redisServer, err := miniredis.Run()
+	assert.NoError(t, err)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+
 	svc := jsonrpc.OpsService{
-		Storage: &storer,
+		Storage:     &storer,
+		RedisClient: redisClient,
 	}
 
 	t.Run("list", func(t *testing.T) {

--- a/transport/relay_handler_test.go
+++ b/transport/relay_handler_test.go
@@ -119,8 +119,8 @@ func relayHandlerSuccessAssertions(t *testing.T, recorder *httptest.ResponseReco
 		relay := relaysInLocation[0]
 
 		assert.Equal(t, crypto.HashID(addr), relay.ID)
-		assert.Equal(t, location.Latitude, math.Round(relay.Latitude*1000)/1000)
-		assert.Equal(t, location.Longitude, math.Round(relay.Longitude*1000)/1000)
+		assert.Equal(t, location.Latitude, math.Round(relay.Datacenter.Location.Latitude*1000)/1000)
+		assert.Equal(t, location.Longitude, math.Round(relay.Datacenter.Location.Longitude*1000)/1000)
 	}
 
 	// Validate response header is correct
@@ -673,10 +673,12 @@ func TestRelayHandlerSuccess(t *testing.T) {
 		Datacenter: routing.Datacenter{
 			ID:   1,
 			Name: "some name",
+			Location: routing.Location{
+				Latitude:  13,
+				Longitude: 13,
+			},
 		},
 		PublicKey:      relayPublicKey,
-		Latitude:       13,
-		Longitude:      13,
 		LastUpdateTime: time.Now().Add(-time.Second),
 	}
 
@@ -740,7 +742,7 @@ func TestRelayHandlerSuccess(t *testing.T) {
 				PacketLoss: 12,
 			},
 		},
-		TrafficStats: transport.RelayTrafficStats{
+		TrafficStats: routing.RelayTrafficStats{
 			SessionCount:  10,
 			BytesSent:     1000000,
 			BytesReceived: 1000000,

--- a/transport/relay_init_handler_test.go
+++ b/transport/relay_init_handler_test.go
@@ -96,8 +96,12 @@ func pingRelayBackendInit(t *testing.T, contentType string, relay routing.Relay,
 		inMemory.AddRelay(context.Background(), routing.Relay{
 			ID:        crypto.HashID("127.0.0.1:40000"),
 			PublicKey: relayPublicKey,
-			Latitude:  13,
-			Longitude: 13,
+			Datacenter: routing.Datacenter{
+				Location: routing.Location{
+					Latitude:  13,
+					Longitude: 13,
+				},
+			},
 		})
 	}
 
@@ -169,8 +173,8 @@ func relayInitSuccessAssertions(t *testing.T, recorder *httptest.ResponseRecorde
 		relay := relaysInLocation[0]
 
 		assert.Equal(t, crypto.HashID(addr), relay.ID)
-		assert.Equal(t, location.Latitude, math.Round(relay.Latitude*1000)/1000)
-		assert.Equal(t, location.Longitude, math.Round(relay.Longitude*1000)/1000)
+		assert.Equal(t, location.Latitude, math.Round(relay.Datacenter.Location.Latitude*1000)/1000)
+		assert.Equal(t, location.Longitude, math.Round(relay.Datacenter.Location.Longitude*1000)/1000)
 	}
 
 	assert.Equal(t, routing.RelayStateEnabled, actual.State)
@@ -687,10 +691,12 @@ func TestRelayInitRelayIPLookupFailure(t *testing.T) {
 		ID: crypto.HashID(addr),
 		Datacenter: routing.Datacenter{
 			Name: "some datacenter",
+			Location: routing.Location{
+				Latitude:  13,
+				Longitude: 13,
+			},
 		},
 		PublicKey: relayPublicKey,
-		Latitude:  13,
-		Longitude: 13,
 	}
 
 	packet := transport.RelayInitRequest{

--- a/transport/session_update_handler_test.go
+++ b/transport/session_update_handler_test.go
@@ -752,9 +752,7 @@ func TestNoRoutesFound(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -847,9 +845,7 @@ func TestTokenEncryptionFailure(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -957,9 +953,7 @@ func TestBadWriteResponse(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -1074,9 +1068,7 @@ func TestBillingFailure(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -1194,9 +1186,7 @@ func TestNextRouteResponse(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -1310,9 +1300,7 @@ func TestContinueRouteResponse(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	geoClient.Add(nearbyRelay)
 
@@ -1433,9 +1421,7 @@ func TestCachedRouteResponse(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -1576,9 +1562,7 @@ func TestVetoedRTT(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -1697,9 +1681,7 @@ func TestVetoExpiredRTT(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -1818,9 +1800,7 @@ func TestVetoedPacketLoss(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -1939,9 +1919,7 @@ func TestVetoExpiredPacketLoss(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -2063,9 +2041,7 @@ func TestForceDirect(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)
@@ -2181,9 +2157,7 @@ func TestForceNext(t *testing.T) {
 	}
 
 	nearbyRelay := routing.Relay{
-		ID:        1,
-		Latitude:  0,
-		Longitude: 0,
+		ID: 1,
 	}
 	err = geoClient.Add(nearbyRelay)
 	assert.NoError(t, err)


### PR DESCRIPTION
Since the Ops CLI tool currently only pulls relay data from firestore with `next relays`, it can't get hot data such as the relay's traffic stats. This PR aims to add this by pulling the relay from redis and getting the traffic data from there in addition to the original firestore data.

While going through, I also cleaned up the `Relay` struct a little bit, updated marshaling/unmarshaling, the tests, etc. So that's why there are so many files changed in this PR.

I also added session count to the ref relay, since before it only sent up bytes sent and received.

If you check out this branch and run the happy path locally, you'll still see that the traffic stats are 0. This is because when running locally the local test relay isn't in firestore. However when testing I added some code to just show all relays in redis, and there were traffic stats being shown:

![image](https://user-images.githubusercontent.com/11426192/80417769-47de8180-88a4-11ea-8945-c55a71e8e6cf.png)

So once this goes in the dev environment and all the running relays are in firestore, that traffic data will be available.