### PR TITLE
Removed datacenter enabled check

### DIFF
--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -959,10 +959,6 @@ func (fs *Firestore) syncRelays(ctx context.Context) error {
 			continue
 		}
 
-		if !d.Enabled {
-			continue
-		}
-
 		datacenter := routing.Datacenter{
 			ID:      crypto.HashID(d.Name),
 			Name:    d.Name,


### PR DESCRIPTION
During the firestore sync, there was a check to see if the relay's datacenter was enabled, and if it wasn't, to skip the sync. This function was written a long time ago, and now that we have a better understanding of what we'll be using this data for we don't want to skip syncing relay data just because things might be disabled. So removing this check should list all relays appropriately.

The reason this check is hit in the first place is because in prod, not all datacenter entries have an enabled field. Not sure the best way to correct this, open to feedback on that.

This PR should close #272. 