### PR TITLE
Calming down sentry

### DIFF
--- a/cmd/relay_backend/relay_backend.go
+++ b/cmd/relay_backend/relay_backend.go
@@ -293,6 +293,10 @@ func main() {
 
 			level.Info(logger).Log("matrix", "route", "entries", len(routematrix.Entries))
 
+			if len(routematrix.Entries) == 0 {
+				sentry.CaptureMessage("no routes within route matrix")
+			}
+
 			time.Sleep(10 * time.Second)
 		}
 	}()

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -558,7 +558,6 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 				routing.SelectRoutesByRandomDestRelay(rand.NewSource(rand.Int63())),
 				routing.SelectRandomRoute(rand.NewSource(rand.Int63())))
 			if err != nil {
-				sentry.CaptureException(err)
 				level.Error(locallogger).Log("err", err)
 				writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.RouteFailure)
 				return


### PR DESCRIPTION
So sentry doesn't end up logging another 300k errors, took out the sentry capture in the server backend when the number of routes is 0 and instead checked the route matrix length > 0 in the relay backend