### PR TITLE
Add AB test check to session handler

### DIFF
--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -534,7 +534,8 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 			timestampExpire = timestampExpire.Add(time.Duration(sliceDuration) * time.Second)
 		}
 
-		if buyer.RoutingRulesSettings.Mode == routing.ModeForceDirect || int64(packet.SessionID%100) > buyer.RoutingRulesSettings.SelectionPercentage {
+		if buyer.RoutingRulesSettings.Mode == routing.ModeForceDirect || int64(packet.SessionID%100) > buyer.RoutingRulesSettings.SelectionPercentage ||
+			(buyer.RoutingRulesSettings.EnableABTest && packet.SessionID%2 == 1) {
 			shouldSelect = false
 			routeDecision = routing.Decision{
 				OnNetworkNext: false,

--- a/transport/session_update_handler_test.go
+++ b/transport/session_update_handler_test.go
@@ -2065,7 +2065,7 @@ func TestForceDirect(t *testing.T) {
 		sessionMetrics.DecisionMetrics.ForceDirect = decisionMetric
 		sessionMetrics.DirectSessions = directMetric
 
-		routeRuleSettings := routing.DefaultRoutingRulesSettings
+		routeRuleSettings := routing.LocalRoutingRulesSettings
 		routeRuleSettings.SelectionPercentage = 50
 		db := storage.InMemory{}
 		db.AddBuyer(context.Background(), routing.Buyer{
@@ -2130,11 +2130,127 @@ func TestForceDirect(t *testing.T) {
 		sessionCacheEntryData, err := sessionCacheEntry.MarshalBinary()
 		assert.NoError(t, err)
 
-		err = redisServer.Set("SESSION-0-99", string(sessionCacheEntryData))
+		err = redisServer.Set("SESSION-0-9999", string(sessionCacheEntryData))
 		assert.NoError(t, err)
 
 		packet := transport.SessionUpdatePacket{
-			SessionID:     99,
+			SessionID:     9999,
+			Sequence:      14,
+			ServerAddress: net.UDPAddr{IP: net.IPv4zero, Port: 13},
+
+			NumNearRelays:       1,
+			NearRelayIDs:        []uint64{1},
+			NearRelayMinRTT:     []float32{1},
+			NearRelayMaxRTT:     []float32{1},
+			NearRelayMeanRTT:    []float32{1},
+			NearRelayJitter:     []float32{1},
+			NearRelayPacketLoss: []float32{1},
+
+			ClientAddress: net.UDPAddr{
+				IP:   net.ParseIP("0.0.0.0"),
+				Port: 1234,
+			},
+			ClientRoutePublicKey: TestBuyersClientPublicKey[:],
+		}
+		packet.Signature = crypto.Sign(TestBuyersServerPrivateKey, packet.GetSignData())
+
+		data, err := packet.MarshalBinary()
+		assert.NoError(t, err)
+
+		var resbuf bytes.Buffer
+
+		handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, redisClient, &db, &rp, &iploc, &geoClient, &sessionMetrics, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
+		handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
+
+		validateDirectResponsePacket(t, resbuf, sessionMetrics.DirectSessions, sessionMetrics.DecisionMetrics.ForceDirect)
+	})
+
+	t.Run("by AB test", func(t *testing.T) {
+		redisServer, err := miniredis.Run()
+		assert.NoError(t, err)
+		redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+
+		sessionMetrics := metrics.EmptySessionMetrics
+		localMetrics := metrics.LocalHandler{}
+
+		decisionMetric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "decision metric"})
+		assert.NoError(t, err)
+		directMetric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "route metric"})
+		assert.NoError(t, err)
+
+		sessionMetrics.DecisionMetrics.ForceDirect = decisionMetric
+		sessionMetrics.DirectSessions = directMetric
+
+		routeRuleSettings := routing.LocalRoutingRulesSettings
+		routeRuleSettings.EnableABTest = true
+		db := storage.InMemory{}
+		db.AddBuyer(context.Background(), routing.Buyer{
+			PublicKey:            TestBuyersServerPublicKey,
+			RoutingRulesSettings: routeRuleSettings,
+		})
+
+		iploc := routing.LocateIPFunc(func(ip net.IP) (routing.Location, error) {
+			return routing.Location{
+				Continent: "NA",
+				Country:   "US",
+				Region:    "NY",
+				City:      "Troy",
+				Latitude:  0,
+				Longitude: 0,
+			}, nil
+		})
+
+		geoClient := routing.GeoClient{
+			RedisClient: redisClient,
+			Namespace:   "GEO_TEST",
+		}
+
+		nearbyRelay := routing.Relay{
+			ID: 1,
+		}
+		err = geoClient.Add(nearbyRelay)
+		assert.NoError(t, err)
+
+		rp := mockRouteProvider{
+			routes: []routing.Route{
+				{
+					Relays: []routing.Relay{
+						{ID: 1, Addr: net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 123}, PublicKey: TestRelayPublicKey[:]},
+						{ID: 2, Addr: net.UDPAddr{IP: net.ParseIP("127.0.0.2"), Port: 123}, PublicKey: TestRelayPublicKey[:]},
+						{ID: 3, Addr: net.UDPAddr{IP: net.ParseIP("127.0.0.3"), Port: 123}, PublicKey: TestRelayPublicKey[:]},
+					},
+				},
+			},
+		}
+
+		addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:13")
+		assert.NoError(t, err)
+
+		serverCacheEntry := transport.ServerCacheEntry{
+			Sequence: 13,
+			Server: routing.Server{
+				Addr:      *addr,
+				PublicKey: TestBuyersServerPublicKey[:],
+			},
+		}
+		serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
+		assert.NoError(t, err)
+
+		err = redisServer.Set("SERVER-0-0.0.0.0:13", string(serverCacheEntryData))
+		assert.NoError(t, err)
+
+		sessionCacheEntry := transport.SessionCacheEntry{
+			SessionID: 9999,
+			Sequence:  13,
+		}
+		sessionCacheEntryData, err := sessionCacheEntry.MarshalBinary()
+		assert.NoError(t, err)
+
+		err = redisServer.Set("SESSION-0-9999", string(sessionCacheEntryData))
+		assert.NoError(t, err)
+
+		packet := transport.SessionUpdatePacket{
+			SessionID:     9999,
 			Sequence:      14,
 			ServerAddress: net.UDPAddr{IP: net.IPv4zero, Port: 13},
 
@@ -2181,7 +2297,7 @@ func TestForceDirect(t *testing.T) {
 		sessionMetrics.DecisionMetrics.ForceDirect = decisionMetric
 		sessionMetrics.DirectSessions = directMetric
 
-		routeRuleSettings := routing.DefaultRoutingRulesSettings
+		routeRuleSettings := routing.LocalRoutingRulesSettings
 		routeRuleSettings.Mode = routing.ModeForceDirect
 		db := storage.InMemory{}
 		db.AddBuyer(context.Background(), routing.Buyer{
@@ -2298,7 +2414,7 @@ func TestForceNext(t *testing.T) {
 	sessionMetrics.DecisionMetrics.ForceNext = decisionMetric
 	sessionMetrics.NextSessions = nextMetric
 
-	routeRuleSettings := routing.DefaultRoutingRulesSettings
+	routeRuleSettings := routing.LocalRoutingRulesSettings
 	routeRuleSettings.Mode = routing.ModeForceNext
 	routeRuleSettings.SelectionPercentage = 100
 	db := storage.InMemory{}


### PR DESCRIPTION
This PR closes #297 by adding an AB test check in the session handler. If the session ID is odd, then it will follow the same code path as being forced to direct.