### PR TITLE
Fix up YOLO logic

### DIFF
--- a/routing/route_test.go
+++ b/routing/route_test.go
@@ -140,7 +140,7 @@ func TestDecideDowngradeRTTHysteresisYOLO(t *testing.T) {
 
 	expected := routing.Decision{
 		OnNetworkNext: false,
-		Reason:        routing.DecisionVetoRTT | routing.DecisionVetoYOLO,
+		Reason:        routing.DecisionRTTHysteresis | routing.DecisionVetoYOLO,
 	}
 
 	// Loop through all permutations and combinations of the decision functions and test that the result is the same
@@ -540,9 +540,9 @@ func TestDecideCommitVeto(t *testing.T) {
 
 	decisionFuncs := []routing.DecisionFunc{
 		routing.DecideUpgradeRTT(float64(routingRulesSettings.RTTThreshold)),
-		routing.DecideDowngradeRTT(float64(routingRulesSettings.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
+		routing.DecideDowngradeRTT(float64(routingRulesSettings.RTTHysteresis), routingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(float64(routingRulesSettings.RTTVeto), routingRulesSettings.EnablePacketLossSafety, routingRulesSettings.EnableYouOnlyLiveOnce),
-		routing.DecideCommitted(true, uint8(routingRulesSettings.TryBeforeYouBuyMaxSlices), &commitPending, &commitObservedSliceCounter, &committed),
+		routing.DecideCommitted(true, uint8(routingRulesSettings.TryBeforeYouBuyMaxSlices), routingRulesSettings.EnableYouOnlyLiveOnce, &commitPending, &commitObservedSliceCounter, &committed),
 	}
 
 	lastNNStats := routing.Stats{
@@ -608,9 +608,9 @@ func TestValidateCommitted(t *testing.T) {
 
 	decisionFuncs := []routing.DecisionFunc{
 		routing.DecideUpgradeRTT(float64(routingRulesSettings.RTTThreshold)),
-		routing.DecideDowngradeRTT(float64(routingRulesSettings.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
+		routing.DecideDowngradeRTT(float64(routingRulesSettings.RTTHysteresis), routingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(float64(routingRulesSettings.RTTVeto), routingRulesSettings.EnablePacketLossSafety, routingRulesSettings.EnableYouOnlyLiveOnce),
-		routing.DecideCommitted(true, uint8(routingRulesSettings.TryBeforeYouBuyMaxSlices), &commitPending, &commitObservedSliceCounter, &committed),
+		routing.DecideCommitted(true, uint8(routingRulesSettings.TryBeforeYouBuyMaxSlices), routingRulesSettings.EnableYouOnlyLiveOnce, &commitPending, &commitObservedSliceCounter, &committed),
 	}
 
 	lastNNStats := routing.Stats{

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -514,13 +514,17 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 		routeDecision := sessionCacheEntry.RouteDecision
 
 		if routing.IsVetoed(routeDecision) && sessionCacheEntry.VetoTimestamp.Before(timestampNow) {
-			// Veto expired, bring the session back on with an initial slice
-			routeDecision = routing.Decision{
-				OnNetworkNext: false,
-				Reason:        routing.DecisionInitialSlice,
-			}
 			shouldSelect = false
-			newSession = true
+
+			// Don't allow sessions vetoed with YOLO to come back on
+			if routeDecision.Reason&routing.DecisionVetoYOLO == 0 {
+				// Veto expired, bring the session back on with an initial slice
+				routeDecision = routing.Decision{
+					OnNetworkNext: false,
+					Reason:        routing.DecisionInitialSlice,
+				}
+				newSession = true
+			}
 		}
 
 		// Purchase 20 seconds ahead for new sessions and 10 seconds ahead for existing ones
@@ -594,7 +598,7 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 
 				if buyer.RoutingRulesSettings.EnableTryBeforeYouBuy {
 					deciderFuncs = append(deciderFuncs,
-						routing.DecideCommitted(sessionCacheEntry.RouteDecision.OnNetworkNext, uint8(buyer.RoutingRulesSettings.TryBeforeYouBuyMaxSlices),
+						routing.DecideCommitted(sessionCacheEntry.RouteDecision.OnNetworkNext, uint8(buyer.RoutingRulesSettings.TryBeforeYouBuyMaxSlices), buyer.RoutingRulesSettings.EnableYouOnlyLiveOnce,
 							&sessionCacheEntry.CommitPending, &sessionCacheEntry.CommitObservedSliceCounter, &sessionCacheEntry.Committed))
 				}
 

--- a/transport/session_update_handler_test.go
+++ b/transport/session_update_handler_test.go
@@ -2058,6 +2058,130 @@ func TestVetoExpiredPacketLoss(t *testing.T) {
 	validateDirectResponsePacket(t, resbuf, sessionMetrics.DirectSessions, sessionMetrics.DecisionMetrics.InitialSlice)
 }
 
+func TestVetoYOLONoReturn(t *testing.T) {
+	redisServer, err := miniredis.Run()
+	assert.NoError(t, err)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+
+	sessionMetrics := metrics.EmptySessionMetrics
+	localMetrics := metrics.LocalHandler{}
+
+	decisionMetric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "decision metric"})
+	assert.NoError(t, err)
+	directMetric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "route metric"})
+	assert.NoError(t, err)
+
+	sessionMetrics.DecisionMetrics.VetoRTTYOLO = decisionMetric
+	sessionMetrics.DirectSessions = directMetric
+
+	rrs := routing.LocalRoutingRulesSettings
+	rrs.EnableYouOnlyLiveOnce = true
+
+	db := storage.InMemory{}
+	db.AddBuyer(context.Background(), routing.Buyer{
+		PublicKey:            TestBuyersServerPublicKey,
+		RoutingRulesSettings: rrs,
+	})
+
+	iploc := routing.LocateIPFunc(func(ip net.IP) (routing.Location, error) {
+		return routing.Location{
+			Continent: "NA",
+			Country:   "US",
+			Region:    "NY",
+			City:      "Troy",
+			Latitude:  0,
+			Longitude: 0,
+		}, nil
+	})
+
+	geoClient := routing.GeoClient{
+		RedisClient: redisClient,
+		Namespace:   "GEO_TEST",
+	}
+
+	nearbyRelay := routing.Relay{
+		ID: 1,
+	}
+	err = geoClient.Add(nearbyRelay)
+	assert.NoError(t, err)
+
+	rp := mockRouteProvider{
+		datacenterRelays: []routing.Relay{{}},
+		routes: []routing.Route{
+			{
+				Relays: []routing.Relay{
+					{ID: 1, Addr: net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 123}, PublicKey: TestRelayPublicKey[:]},
+					{ID: 2, Addr: net.UDPAddr{IP: net.ParseIP("127.0.0.2"), Port: 123}, PublicKey: TestRelayPublicKey[:]},
+					{ID: 3, Addr: net.UDPAddr{IP: net.ParseIP("127.0.0.3"), Port: 123}, PublicKey: TestRelayPublicKey[:]},
+				},
+			},
+		},
+	}
+
+	addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:13")
+	assert.NoError(t, err)
+
+	serverCacheEntry := transport.ServerCacheEntry{
+		Sequence: 13,
+		Server: routing.Server{
+			Addr:      *addr,
+			PublicKey: TestBuyersServerPublicKey[:],
+		},
+	}
+	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
+	assert.NoError(t, err)
+
+	err = redisServer.Set("SERVER-0-0.0.0.0:13", string(serverCacheEntryData))
+	assert.NoError(t, err)
+
+	sessionCacheEntry := transport.SessionCacheEntry{
+		SessionID:      9999,
+		Sequence:       13,
+		TimestampStart: time.Now().Add(-5 * time.Second),
+		VetoTimestamp:  time.Now().Add(-5 * time.Second),
+		RouteDecision: routing.Decision{
+			OnNetworkNext: false,
+			Reason:        routing.DecisionVetoRTT | routing.DecisionVetoYOLO,
+		},
+	}
+	sessionCacheEntryData, err := sessionCacheEntry.MarshalBinary()
+	assert.NoError(t, err)
+
+	err = redisServer.Set("SESSION-0-9999", string(sessionCacheEntryData))
+	assert.NoError(t, err)
+
+	packet := transport.SessionUpdatePacket{
+		SessionID:     9999,
+		Sequence:      14,
+		ServerAddress: net.UDPAddr{IP: net.IPv4zero, Port: 13},
+
+		NumNearRelays:       1,
+		NearRelayIDs:        []uint64{1},
+		NearRelayMinRTT:     []float32{1},
+		NearRelayMaxRTT:     []float32{1},
+		NearRelayMeanRTT:    []float32{1},
+		NearRelayJitter:     []float32{1},
+		NearRelayPacketLoss: []float32{1},
+
+		ClientAddress: net.UDPAddr{
+			IP:   net.ParseIP("0.0.0.0"),
+			Port: 1234,
+		},
+		ClientRoutePublicKey: TestBuyersClientPublicKey[:],
+	}
+	packet.Signature = crypto.Sign(TestBuyersServerPrivateKey, packet.GetSignData())
+
+	data, err := packet.MarshalBinary()
+	assert.NoError(t, err)
+
+	var resbuf bytes.Buffer
+
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, redisClient, &db, &rp, &iploc, &geoClient, &sessionMetrics, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
+	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
+
+	validateDirectResponsePacket(t, resbuf, sessionMetrics.DirectSessions, sessionMetrics.DecisionMetrics.VetoRTTYOLO)
+}
+
 func TestForceDirect(t *testing.T) {
 	t.Run("by selection percentage", func(t *testing.T) {
 		redisServer, err := miniredis.Run()


### PR DESCRIPTION
This PR addresses the final point, point 3, in #314. If merged, this will close #314. 

The YOLO logic only required some minor tweaking. The way the backend handles YOLO now is whenever a route is vetoed and YOLO enabled, add the YOLO reason to the bitfield. Also, if a session would go from next -> direct due to RTT hysteresis, then veto the session instead when YOLO is enabled.

In this PR, the logic is slightly changed so that when YOLO is enabled, veto ANY session that goes from next -> direct and make that veto permanent instead of expiring after 1 hour. Since the logic was mostly there, I just had to add the YOLO check to `DecideCommitted()` and then add the check to prevent sessions vetoed with YOLO enabled from coming back on. I also wrote a test to verify that sessions vetoed with YOLO won't come back after an hour.