### PR TITLE
Session dashboard metrics

### DIFF
--- a/metrics/metrics_types.go
+++ b/metrics/metrics_types.go
@@ -38,6 +38,7 @@ type SessionErrorMetrics struct {
 	WriteCachedResponseFailure  Counter
 	ClientLocateFailure         Counter
 	NearRelaysLocateFailure     Counter
+	DatacenterDisabled          Counter
 	NoRelaysInDatacenter        Counter
 	RouteFailure                Counter
 	EncryptionFailure           Counter
@@ -62,6 +63,7 @@ var EmptySessionErrorMetrics SessionErrorMetrics = SessionErrorMetrics{
 	WriteCachedResponseFailure:  &EmptyCounter{},
 	ClientLocateFailure:         &EmptyCounter{},
 	NearRelaysLocateFailure:     &EmptyCounter{},
+	DatacenterDisabled:          &EmptyCounter{},
 	NoRelaysInDatacenter:        &EmptyCounter{},
 	RouteFailure:                &EmptyCounter{},
 	EncryptionFailure:           &EmptyCounter{},
@@ -611,6 +613,16 @@ func NewSessionMetrics(ctx context.Context, metricsHandler Handler) (*SessionMet
 		DisplayName: "Session Near Relays Locate Failure",
 		ServiceName: "server_backend",
 		ID:          "session.error.near_relays_locate_failure",
+		Unit:        "errors",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sessionMetrics.ErrorMetrics.DatacenterDisabled, err = metricsHandler.NewCounter(ctx, &Descriptor{
+		DisplayName: "Session Datacenter Disabled",
+		ServiceName: "server_backend",
+		ID:          "session.error.datacenter_disabled",
 		Unit:        "errors",
 	})
 	if err != nil {

--- a/routing/route_decision.go
+++ b/routing/route_decision.go
@@ -96,6 +96,7 @@ const (
 	DecisionNoNearRelays            DecisionReason = 1 << 17
 	DecisionRTTHysteresis           DecisionReason = 1 << 18
 	DecisionVetoCommit              DecisionReason = 1 << 19
+	DecisionDatacenterDisabled      DecisionReason = 1 << 20
 )
 
 // DecideUpgradeRTT will decide if the client should use the network next route if the RTT reduction is greater than the given threshold.

--- a/transport/session_update_handler_test.go
+++ b/transport/session_update_handler_test.go
@@ -824,6 +824,99 @@ func TestNoRelaysNearClient(t *testing.T) {
 	validateDirectResponsePacket(t, resbuf, sessionMetrics.DirectSessions, sessionMetrics.ErrorMetrics.NearRelaysLocateFailure)
 }
 
+func TestDatacenterDisabled(t *testing.T) {
+	redisServer, err := miniredis.Run()
+	assert.NoError(t, err)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+
+	sessionMetrics := metrics.EmptySessionMetrics
+	localMetrics := metrics.LocalHandler{}
+
+	errMetric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "err metric"})
+	assert.NoError(t, err)
+	directMetric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "direct metric"})
+	assert.NoError(t, err)
+
+	sessionMetrics.ErrorMetrics.DatacenterDisabled = errMetric
+	sessionMetrics.DirectSessions = directMetric
+
+	db := storage.InMemory{}
+	db.AddBuyer(context.Background(), routing.Buyer{
+		PublicKey: TestBuyersServerPublicKey,
+	})
+
+	iploc := routing.LocateIPFunc(func(ip net.IP) (routing.Location, error) {
+		return routing.Location{
+			Continent: "NA",
+			Country:   "US",
+			Region:    "NY",
+			City:      "Troy",
+			Latitude:  0,
+			Longitude: 0,
+		}, nil
+	})
+
+	geoClient := routing.GeoClient{
+		RedisClient: redisClient,
+		Namespace:   "GEO_TEST",
+	}
+
+	nearbyRelay := routing.Relay{
+		ID: 1,
+	}
+	err = geoClient.Add(nearbyRelay)
+	assert.NoError(t, err)
+
+	rp := mockRouteProvider{}
+
+	addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:13")
+	assert.NoError(t, err)
+
+	serverCacheEntry := transport.ServerCacheEntry{
+		Sequence: 13,
+		Server: routing.Server{
+			Addr:      *addr,
+			PublicKey: TestServerBackendPublicKey,
+		},
+	}
+	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
+	assert.NoError(t, err)
+
+	err = redisServer.Set("SERVER-0-0.0.0.0:13", string(serverCacheEntryData))
+	assert.NoError(t, err)
+
+	sessionCacheEntry := transport.SessionCacheEntry{
+		SessionID: 9999,
+		Sequence:  13,
+	}
+	sessionCacheEntryData, err := sessionCacheEntry.MarshalBinary()
+	assert.NoError(t, err)
+
+	err = redisServer.Set("SESSION-0-9999", string(sessionCacheEntryData))
+	assert.NoError(t, err)
+
+	packet := transport.SessionUpdatePacket{
+		SessionID:     9999,
+		Sequence:      14,
+		ServerAddress: net.UDPAddr{IP: net.IPv4zero, Port: 13},
+
+		ClientRoutePublicKey: make([]byte, crypto.KeySize),
+
+		Signature: make([]byte, ed25519.SignatureSize),
+	}
+	packet.Signature = crypto.Sign(TestBuyersServerPrivateKey, packet.GetSignData())
+
+	data, err := packet.MarshalBinary()
+	assert.NoError(t, err)
+
+	var resbuf bytes.Buffer
+
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, redisClient, &db, &rp, &iploc, &geoClient, &sessionMetrics, &billing.NoOpBiller{}, TestServerBackendPrivateKey, nil)
+	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
+
+	validateDirectResponsePacket(t, resbuf, sessionMetrics.DirectSessions, sessionMetrics.ErrorMetrics.DatacenterDisabled)
+}
+
 func TestNoRelaysInDatacenter(t *testing.T) {
 	redisServer, err := miniredis.Run()
 	assert.NoError(t, err)
@@ -877,6 +970,9 @@ func TestNoRelaysInDatacenter(t *testing.T) {
 		Server: routing.Server{
 			Addr:      *addr,
 			PublicKey: TestServerBackendPublicKey,
+		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
 		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
@@ -973,6 +1069,9 @@ func TestNoRoutesFound(t *testing.T) {
 		Server: routing.Server{
 			Addr:      *addr,
 			PublicKey: TestServerBackendPublicKey,
+		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
 		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
@@ -1080,6 +1179,9 @@ func TestTokenEncryptionFailure(t *testing.T) {
 		Server: routing.Server{
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
+		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
 		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
@@ -1426,6 +1528,9 @@ func TestNextRouteResponse(t *testing.T) {
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
 		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
+		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
 	assert.NoError(t, err)
@@ -1561,6 +1666,9 @@ func TestContinueRouteResponse(t *testing.T) {
 		Server: routing.Server{
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
+		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
 		},
 	}
 	se, err := expected.MarshalBinary()
@@ -1707,6 +1815,9 @@ func TestCachedRouteResponse(t *testing.T) {
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
 		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
+		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
 	assert.NoError(t, err)
@@ -1850,6 +1961,9 @@ func TestVetoedRTT(t *testing.T) {
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
 		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
+		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
 	assert.NoError(t, err)
@@ -1970,6 +2084,9 @@ func TestVetoExpiredRTT(t *testing.T) {
 		Server: routing.Server{
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
+		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
 		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
@@ -2092,6 +2209,9 @@ func TestVetoedPacketLoss(t *testing.T) {
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
 		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
+		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
 	assert.NoError(t, err)
@@ -2212,6 +2332,9 @@ func TestVetoExpiredPacketLoss(t *testing.T) {
 		Server: routing.Server{
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
+		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
 		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
@@ -2337,6 +2460,9 @@ func TestVetoYOLONoReturn(t *testing.T) {
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
 		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
+		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
 	assert.NoError(t, err)
@@ -2461,6 +2587,9 @@ func TestForceDirect(t *testing.T) {
 				Addr:      *addr,
 				PublicKey: TestBuyersServerPublicKey[:],
 			},
+			Datacenter: routing.Datacenter{
+				Enabled: true,
+			},
 		}
 		serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
 		assert.NoError(t, err)
@@ -2577,6 +2706,9 @@ func TestForceDirect(t *testing.T) {
 			Server: routing.Server{
 				Addr:      *addr,
 				PublicKey: TestBuyersServerPublicKey[:],
+			},
+			Datacenter: routing.Datacenter{
+				Enabled: true,
 			},
 		}
 		serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
@@ -2697,6 +2829,9 @@ func TestForceNext(t *testing.T) {
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
 		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
+		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
 	assert.NoError(t, err)
@@ -2813,6 +2948,9 @@ func TestABTest(t *testing.T) {
 		Server: routing.Server{
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
+		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
 		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
@@ -2932,6 +3070,9 @@ func TestVetoCommit(t *testing.T) {
 		Server: routing.Server{
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
+		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
 		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
@@ -3063,6 +3204,9 @@ func TestCommitted(t *testing.T) {
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
 		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
+		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
 	assert.NoError(t, err)
@@ -3193,6 +3337,9 @@ func TestMultipathRTT(t *testing.T) {
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
 		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
+		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
 	assert.NoError(t, err)
@@ -3315,6 +3462,9 @@ func TestMultipathJitter(t *testing.T) {
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
 		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
+		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
 	assert.NoError(t, err)
@@ -3436,6 +3586,9 @@ func TestMultipathPacketLoss(t *testing.T) {
 		Server: routing.Server{
 			Addr:      *addr,
 			PublicKey: TestBuyersServerPublicKey[:],
+		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
 		},
 	}
 	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()


### PR DESCRIPTION
This PR adds some of the metrics from the session dashboard that we were missing in the new backend. Notably, this brings over Unserviceable Update for both server updates and session updates, Early Fallback To Direct which previously we weren't tracking, and Datacenter Disabled which previously we weren't tracking.
There is a separate metric for early fallback to direct because this should indicate a problem: since the backend always sends a direct route on the first slice of a new session, if that session falls back to direct on the next slice, then it's considered an "early fallback". This shouldn't happen since the session shouldn't have had anything to fallback from.

We also weren't actually checking the datacenter's enabled flag, so I added that check with the associated metric and session handler test case.

I was unable to bring over the actual datacenter name label for datacenter related metrics since the metrics API we built would just constantly append the datacenter name to the metric without ever clearing it. Fixing this would probably require reworking the metrics API so I decided to leave it out in this PR and I can go back and redo it later in another PR if need be.

If there are any other metrics I missed or that we should add for the New Backend dashboard, let me know and I can add them in this PR.