### PR TITLE
Fix domain names for Ops CLI

### DIFF
--- a/cmd/tools/next/env.go
+++ b/cmd/tools/next/env.go
@@ -12,8 +12,8 @@ import (
 
 const (
 	PortalHostnameLocal = "localhost:20000"
-	PortalHostnameDev   = "portal.dev.networknext.com"
-	PortalHostnameProd  = "portal.prod.networknext.com"
+	PortalHostnameDev   = "portal-dev.networknext.com"
+	PortalHostnameProd  = "portal.networknext.com"
 
 	RouterPublicKeyLocal = "SS55dEl9nTSnVVDrqwPeqRv/YcYOZZLXCWTpNBIyX0Y="
 	RouterPublicKeyDev   = "SS55dEl9nTSnVVDrqwPeqRv/YcYOZZLXCWTpNBIyX0Y="

--- a/cmd/tools/next/next.go
+++ b/cmd/tools/next/next.go
@@ -260,7 +260,7 @@ func main() {
 	}
 	env.Read()
 
-	rpcClient := jsonrpc.NewClientWithOpts("http://"+env.PortalHostname()+"/rpc", &jsonrpc.RPCClientOpts{
+	rpcClient := jsonrpc.NewClientWithOpts("https://"+env.PortalHostname()+"/rpc", &jsonrpc.RPCClientOpts{
 		CustomHeaders: map[string]string{
 			"Authorization": fmt.Sprintf("Bearer %s", env.AuthToken),
 		},


### PR DESCRIPTION
While trying to verify the dev and prod environments for the new backend I noticed that the ops CLI wasn't working with the new portal domain names. This PR just changes the domain names and changes the request to https so that the CLI will work properly again in both prod and dev.