### PR TITLE
Fix relay update command for Ops CLI

### DIFF
--- a/cmd/tools/next/relay.go
+++ b/cmd/tools/next/relay.go
@@ -169,7 +169,7 @@ func updateRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []str
 		}
 	}
 
-	if !runCommandEnv("make", []string{"build-relay"}, nil) {
+	if !runCommandEnv("make", []string{"build-relay-new"}, nil) {
 		log.Fatal("Failed to build relay")
 	}
 


### PR DESCRIPTION
Just a quick fix from #330 forgetting to update `build-relay` command to `build-relay-new` in ops CLI update command