### PR TITLE
Fix Fallback to Direct Metric

### DIFF
--- a/metrics/metrics_types.go
+++ b/metrics/metrics_types.go
@@ -25,7 +25,6 @@ var EmptySessionMetrics SessionMetrics = SessionMetrics{
 type SessionErrorMetrics struct {
 	UnserviceableUpdate         Counter
 	ReadPacketFailure           Counter
-	FallbackToDirect            Counter
 	EarlyFallbackToDirect       Counter
 	PipelineExecFailure         Counter
 	GetServerDataFailure        Counter
@@ -50,7 +49,6 @@ type SessionErrorMetrics struct {
 var EmptySessionErrorMetrics SessionErrorMetrics = SessionErrorMetrics{
 	UnserviceableUpdate:         &EmptyCounter{},
 	ReadPacketFailure:           &EmptyCounter{},
-	FallbackToDirect:            &EmptyCounter{},
 	EarlyFallbackToDirect:       &EmptyCounter{},
 	PipelineExecFailure:         &EmptyCounter{},
 	GetServerDataFailure:        &EmptyCounter{},
@@ -563,16 +561,6 @@ func NewSessionMetrics(ctx context.Context, metricsHandler Handler) (*SessionMet
 		DisplayName: "Session Encryption Failure",
 		ServiceName: "server_backend",
 		ID:          "session.error.encryption_failure",
-		Unit:        "errors",
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	sessionMetrics.ErrorMetrics.FallbackToDirect, err = metricsHandler.NewCounter(ctx, &Descriptor{
-		DisplayName: "Session Fallback To Direct",
-		ServiceName: "server_backend",
-		ID:          "session.error.fallback_to_direct",
 		Unit:        "errors",
 	})
 	if err != nil {

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -63,7 +63,7 @@ func (m *UDPServerMux) handler(ctx context.Context, id int) {
 	for {
 
 		data := make([]byte, m.MaxPacketSize)
-		
+
 		numbytes, addr, _ := m.Conn.ReadFromUDP(data)
 		if numbytes <= 0 {
 			continue
@@ -425,7 +425,11 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 					// This error case should never happen, can't produce it in test cases, but leaving it in anyway
 					sentry.CaptureException(err)
 					level.Error(locallogger).Log("msg", "failed to get session bytes", "err", err)
-					writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.GetSessionDataFailure)
+					if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.GetSessionDataFailure); err != nil {
+						sentry.CaptureException(err)
+						level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+						metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+					}
 					return
 				}
 
@@ -433,7 +437,11 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 					if err := sessionCacheEntry.UnmarshalBinary(sessionCacheData); err != nil {
 						sentry.CaptureException(err)
 						level.Error(locallogger).Log("msg", "failed to unmarshal session bytes", "err", err)
-						writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.UnmarshalSessionDataFailure)
+						if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.UnmarshalSessionDataFailure); err != nil {
+							sentry.CaptureException(err)
+							level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+							metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+						}
 						return
 					}
 				}
@@ -455,7 +463,11 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 		if err != nil {
 			sentry.CaptureException(err)
 			level.Error(locallogger).Log("msg", "failed to get buyer from storage", "err", err, "customer_id", packet.CustomerID)
-			writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.BuyerNotFound)
+			if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.BuyerNotFound); err != nil {
+				sentry.CaptureException(err)
+				level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+				metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+			}
 			return
 		}
 
@@ -465,7 +477,11 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 			sentry.CaptureException(err)
 			err := errors.New("failed to verify packet signature with buyer public key")
 			level.Error(locallogger).Log("err", err)
-			writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.VerifyFailure)
+			if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.VerifyFailure); err != nil {
+				sentry.CaptureException(err)
+				level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+				metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+			}
 			return
 		}
 
@@ -474,7 +490,11 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 			err := fmt.Errorf("packet sequence too old. current_sequence %v, previous sequence %v", packet.Sequence, sessionCacheEntry.Sequence)
 			sentry.CaptureException(err)
 			level.Error(locallogger).Log("err", err)
-			writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.OldSequence)
+			if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.OldSequence); err != nil {
+				sentry.CaptureException(err)
+				level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+				metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+			}
 			return
 		case seq == sessionCacheEntry.Sequence:
 			if _, err := w.Write(sessionCacheEntry.Response); err != nil {
@@ -528,11 +548,27 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 			if timestampNow.Sub(sessionCacheEntry.TimestampStart) < (billing.BillingSliceSeconds*1.5*time.Second) &&
 				timestampNow.Sub(sessionCacheEntry.TimestampStart) > (billing.BillingSliceSeconds*0.5*time.Second) {
 				level.Error(logger).Log("err", "early fallback to direct")
-				writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.EarlyFallbackToDirect)
-			} else {
-				level.Error(logger).Log("err", "fallback to direct")
-				writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.FallbackToDirect)
+				if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.EarlyFallbackToDirect); err != nil {
+					sentry.CaptureException(err)
+					level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+					metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+				}
+				return
 			}
+
+			level.Error(logger).Log("err", "fallback to direct")
+
+			if _, err = writeSessionResponse(w, response, serverPrivateKey); err != nil {
+				sentry.CaptureException(err)
+				level.Error(locallogger).Log("msg", "failed to write session response", "err", err)
+				metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+				return
+			}
+
+			metrics.DirectSessions.Add(1)
+
+			routeDecision = routing.Decision{OnNetworkNext: false, Reason: routing.DecisionFallbackToDirect}
+			addRouteDecisionMetric(routeDecision, metrics)
 
 			if err := updatePortalData(redisClientPortal, redisClientPortalExp, packet, nnStats, directStats, chosenRoute.Relays, routeDecision.OnNetworkNext, serverCacheEntry.Datacenter.Name, routing.LocationNullIsland); err != nil {
 				sentry.CaptureException(err)
@@ -540,7 +576,7 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 			}
 
 			if err := submitBillingEntry(biller, serverCacheEntry, sessionCacheEntry, packet, response, buyer, chosenRoute, routing.LocationNullIsland, storer, nil,
-				routing.Decision{OnNetworkNext: false, Reason: routing.DecisionFallbackToDirect}, sliceDuration, timestampStart, timestampNow, newSession); err != nil {
+				routeDecision, sliceDuration, timestampStart, timestampNow, newSession); err != nil {
 				sentry.CaptureException(err)
 				level.Error(locallogger).Log("msg", "billing failed", "err", err)
 				metrics.ErrorMetrics.BillingFailure.Add(1)
@@ -554,7 +590,12 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 		if err != nil {
 			sentry.CaptureException(err)
 			level.Error(locallogger).Log("msg", "failed to locate client", "err", err)
-			writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.ClientLocateFailure)
+			if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.ClientLocateFailure); err != nil {
+				sentry.CaptureException(err)
+				level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+				metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+				return
+			}
 
 			if err := updatePortalData(redisClientPortal, redisClientPortalExp, packet, nnStats, directStats, chosenRoute.Relays, routeDecision.OnNetworkNext, serverCacheEntry.Datacenter.Name, location); err != nil {
 				sentry.CaptureException(err)
@@ -580,7 +621,12 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 			}
 
 			level.Error(locallogger).Log("msg", "failed to locate relays near client", "err", err)
-			writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.NearRelaysLocateFailure)
+			if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.NearRelaysLocateFailure); err != nil {
+				sentry.CaptureException(err)
+				level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+				metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+				return
+			}
 
 			if err := updatePortalData(redisClientPortal, redisClientPortalExp, packet, nnStats, directStats, chosenRoute.Relays, routeDecision.OnNetworkNext, serverCacheEntry.Datacenter.Name, location); err != nil {
 				sentry.CaptureException(err)
@@ -612,7 +658,12 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 			// datacenter is disabled, so next routes can't be made
 			sentry.CaptureMessage(fmt.Sprintf("Datacenter %s is disabled", serverCacheEntry.Datacenter.Name))
 			level.Error(locallogger).Log("msg", "datacenter is disabled", "datacenter", serverCacheEntry.Datacenter.Name)
-			writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.DatacenterDisabled)
+			if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.DatacenterDisabled); err != nil {
+				sentry.CaptureException(err)
+				level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+				metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+				return
+			}
 
 			if err := updatePortalData(redisClientPortal, redisClientPortalExp, packet, nnStats, directStats, chosenRoute.Relays, routeDecision.OnNetworkNext, serverCacheEntry.Datacenter.Name, location); err != nil {
 				sentry.CaptureException(err)
@@ -636,7 +687,12 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 		if len(dsRelays) == 0 {
 			sentry.CaptureMessage(fmt.Sprintf("No relays in datacenter %s", serverCacheEntry.Datacenter.Name))
 			level.Error(locallogger).Log("msg", "no relays in datacenter", "datacenter", serverCacheEntry.Datacenter.Name)
-			writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.NoRelaysInDatacenter)
+			if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.NoRelaysInDatacenter); err != nil {
+				sentry.CaptureException(err)
+				level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+				metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+				return
+			}
 
 			if err := updatePortalData(redisClientPortal, redisClientPortalExp, packet, nnStats, directStats, chosenRoute.Relays, routeDecision.OnNetworkNext, serverCacheEntry.Datacenter.Name, location); err != nil {
 				sentry.CaptureException(err)
@@ -700,7 +756,12 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 			)
 			if err != nil {
 				level.Error(locallogger).Log("err", err)
-				writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.RouteFailure)
+				if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.RouteFailure); err != nil {
+					sentry.CaptureException(err)
+					level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+					metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+					return
+				}
 
 				if err := updatePortalData(redisClientPortal, redisClientPortalExp, packet, nnStats, directStats, chosenRoute.Relays, routeDecision.OnNetworkNext, serverCacheEntry.Datacenter.Name, location); err != nil {
 					sentry.CaptureException(err)
@@ -822,7 +883,11 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 				if err != nil {
 					sentry.CaptureException(err)
 					level.Error(locallogger).Log("msg", "failed to encrypt route token", "err", err)
-					writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.WriteResponseFailure, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.EncryptionFailure)
+					if err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.EncryptionFailure); err != nil {
+						sentry.CaptureException(err)
+						level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
+						metrics.ErrorMetrics.WriteResponseFailure.Add(1)
+					}
 					return
 				}
 
@@ -1063,14 +1128,15 @@ func writeSessionResponse(w io.Writer, response SessionResponsePacket, privateKe
 	return responseData, nil
 }
 
-func writeSessionErrorResponse(w io.Writer, response SessionResponsePacket, privateKey []byte, directSessions metrics.Counter, writeResponseFailure metrics.Counter, unserviceableUpdateCounter metrics.Counter, errCounter metrics.Counter) {
+func writeSessionErrorResponse(w io.Writer, response SessionResponsePacket, privateKey []byte, directSessions metrics.Counter, unserviceableUpdateCounter metrics.Counter, errCounter metrics.Counter) error {
 	if _, err := writeSessionResponse(w, response, privateKey); err != nil {
-		writeResponseFailure.Add(1)
-		return
+		return err
 	}
 
 	directSessions.Add(1)
 
 	unserviceableUpdateCounter.Add(1)
 	errCounter.Add(1)
+
+	return nil
 }

--- a/transport/session_update_handler_test.go
+++ b/transport/session_update_handler_test.go
@@ -534,7 +534,7 @@ func TestFallbackToDirect(t *testing.T) {
 	directMetric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "direct metric"})
 	assert.NoError(t, err)
 
-	sessionMetrics.ErrorMetrics.FallbackToDirect = errMetric
+	sessionMetrics.DecisionMetrics.FallbackToDirect = errMetric
 	sessionMetrics.DirectSessions = directMetric
 
 	db := storage.InMemory{}
@@ -589,7 +589,7 @@ func TestFallbackToDirect(t *testing.T) {
 	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, redisClient, 10*time.Second, &db, nil, nil, nil, &sessionMetrics, &billing.NoOpBiller{}, TestServerBackendPrivateKey, nil)
 	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
 
-	validateDirectResponsePacket(t, resbuf, sessionMetrics.DirectSessions, sessionMetrics.ErrorMetrics.FallbackToDirect)
+	validateDirectResponsePacket(t, resbuf, sessionMetrics.DirectSessions, sessionMetrics.DecisionMetrics.FallbackToDirect)
 }
 
 func TestEarlyFallbackToDirect(t *testing.T) {


### PR DESCRIPTION
While debugging the raspberry pis in the dev environment I noticed from the logs that they were all falling back to direct but the metrics didn't indicate that. This is because there are actually two separate metrics for fallback to direct: one that's considered an "error" metric and a "decision" metric. I removed the "error" metric version and made sure that the correct counter was incremented.

I also noticed that if the session handler somehow failed to send an error response that it would still create a portal and billing entry, so I changed the function call to not handle the write failure directly and made sure the handler returned if that happens.