### PR TITLE
SessionID padded with zeroes in updatePortalData()

### DIFF
--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -978,7 +978,7 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 
 func updatePortalData(redisClientPortal redis.Cmdable, redisClientPortalExp time.Duration, packet SessionUpdatePacket, nnStats routing.Stats, directStats routing.Stats, relayHops []routing.Relay, onNetworkNext bool, datacenterName string, location routing.Location) error {
 	meta := routing.SessionMeta{
-		ID:            fmt.Sprintf("%x", packet.SessionID),
+		ID:            fmt.Sprintf("%016x", packet.SessionID),
 		UserHash:      fmt.Sprintf("%x", packet.UserHash),
 		Datacenter:    datacenterName,
 		OnNetworkNext: onNetworkNext,


### PR DESCRIPTION
I changed one line in `server_handler.go`. This results in any zero-padded session ID entries being filtered _out_ of the session id list in the portal. Not sure where. Also, if you put a printf where meta is loaded in buyer.go you see that relevant zero padded ID is replaced with the id prior to it in the sorting list. I think. See attached image.

![buyer-go](https://user-images.githubusercontent.com/14285373/82487462-5f2c1b80-9aac-11ea-9b39-615627e7169a.png)
