### PR TITLE
Portal GPU Aggregation

### DIFF
--- a/cmd/portal/public/js/portal.js
+++ b/cmd/portal/public/js/portal.js
@@ -167,7 +167,6 @@ MapHandler = {
 				});
 
 				const cellSize = 10, aggregation = 'MEAN';
-				console.log(navigator.appVersion.indexOf("Win") != -1)
 				let gpuAggregation = navigator.appVersion.indexOf("Win") == -1;
 
 				data = onNN;


### PR DESCRIPTION
In order for GPU aggregation to work browsers need to support webGL2. This should fix @rpj5582 's issue with windows chrome not loading map points