### PR TITLE
Prepend/pad SessionIDs with zeroes

### DIFF
--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -979,7 +979,7 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 func updatePortalData(redisClientPortal redis.Cmdable, redisClientPortalExp time.Duration, packet SessionUpdatePacket, nnStats routing.Stats, directStats routing.Stats, relayHops []routing.Relay, onNetworkNext bool, datacenterName string, location routing.Location) error {
 	meta := routing.SessionMeta{
 		ID:            fmt.Sprintf("%016x", packet.SessionID),
-		UserHash:      fmt.Sprintf("%x", packet.UserHash),
+		UserHash:      fmt.Sprintf("%016x", packet.UserHash),
 		Datacenter:    datacenterName,
 		OnNetworkNext: onNetworkNext,
 		NextRTT:       nnStats.RTT,
@@ -1027,8 +1027,8 @@ func updatePortalData(redisClientPortal redis.Cmdable, redisClientPortalExp time
 	tx.Set(fmt.Sprintf("session-%016x-meta", packet.SessionID), meta, redisClientPortalExp)
 	tx.SAdd(fmt.Sprintf("session-%016x-slices", packet.SessionID), slice)
 	tx.Expire(fmt.Sprintf("session-%016x-slices", packet.SessionID), redisClientPortalExp)
-	tx.SAdd(fmt.Sprintf("user-%x-sessions", packet.UserHash), meta.ID)
-	tx.Expire(fmt.Sprintf("user-%x-sessions", packet.UserHash), redisClientPortalExp)
+	tx.SAdd(fmt.Sprintf("user-%016x-sessions", packet.UserHash), meta.ID)
+	tx.Expire(fmt.Sprintf("user-%016x-sessions", packet.UserHash), redisClientPortalExp)
 	tx.SAdd("map-points-global", meta.ID)
 	tx.SAdd(fmt.Sprintf("map-points-buyer-%x", packet.CustomerID), meta.ID)
 	tx.Expire(fmt.Sprintf("map-points-buyer-%x", packet.CustomerID), redisClientPortalExp)

--- a/transport/session_update_handler_test.go
+++ b/transport/session_update_handler_test.go
@@ -1575,8 +1575,8 @@ func TestNextRouteResponse(t *testing.T) {
 	assert.True(t, redisServer.Exists(fmt.Sprintf("session-%016x-slices", packet.SessionID)))
 	assert.Greater(t, redisServer.TTL(fmt.Sprintf("session-%016x-slices", packet.SessionID)).Hours(), float64(-1))
 
-	assert.True(t, redisServer.Exists(fmt.Sprintf("user-%x-sessions", 0)))
-	assert.Greater(t, redisServer.TTL(fmt.Sprintf("user-%x-sessions", 0)).Hours(), float64(-1))
+	assert.True(t, redisServer.Exists(fmt.Sprintf("user-%016x-sessions", 0)))
+	assert.Greater(t, redisServer.TTL(fmt.Sprintf("user-%016x-sessions", 0)).Hours(), float64(-1))
 
 	validateNextResponsePacket(t, resbuf, packet.SessionID, packet.Sequence, 5, routing.RouteTypeNew, sessionMetrics.NextSessions, sessionMetrics.DecisionMetrics.RTTReduction)
 }
@@ -1713,8 +1713,8 @@ func TestContinueRouteResponse(t *testing.T) {
 	assert.True(t, redisServer.Exists(fmt.Sprintf("session-%016x-slices", packet.SessionID)))
 	assert.Greater(t, redisServer.TTL(fmt.Sprintf("session-%016x-slices", packet.SessionID)).Hours(), float64(-1))
 
-	assert.True(t, redisServer.Exists(fmt.Sprintf("user-%0x-sessions", 0)))
-	assert.Greater(t, redisServer.TTL(fmt.Sprintf("user-%0x-sessions", 0)).Hours(), float64(-1))
+	assert.True(t, redisServer.Exists(fmt.Sprintf("user-%016x-sessions", 0)))
+	assert.Greater(t, redisServer.TTL(fmt.Sprintf("user-%016x-sessions", 0)).Hours(), float64(-1))
 
 	var actual transport.SessionResponsePacket
 	err = actual.UnmarshalBinary(resbuf.Bytes())


### PR DESCRIPTION
Modified `updatePortalData()` to prepend/pad hex SessionIds with 0s. All instances of `packet.SessionID` in that function are covered.