### PR TITLE
Fix Relay Timestamp

### DIFF
--- a/cmd/relay_new/src/legacy/v3/backend.cpp
+++ b/cmd/relay_new/src/legacy/v3/backend.cpp
@@ -107,7 +107,7 @@ namespace legacy
       }
 
       // "Timestamp" is in milliseconds, convert to nanos
-      mInitTimestamp = doc.get<uint64_t>("Timestamp") / 1000000 - (response.At - request.At) / 2;
+      mInitTimestamp = doc.get<uint64_t>("Timestamp") * 1000000 - (response.At - request.At) / 2;
       auto b64TokenBuff = doc.get<std::string>("Token");
       std::array<uint8_t, TokenBytes> tokenBuff;
       if (encoding::base64::Decode(b64TokenBuff, tokenBuff) == 0) {

--- a/cmd/relay_new/src/legacy/v3/backend.hpp
+++ b/cmd/relay_new/src/legacy/v3/backend.hpp
@@ -46,7 +46,7 @@ namespace legacy
       core::RelayManager<core::V3Relay>& mRelayManager;
       const size_t mSpeed;  // Relay nic speed in bits/second
       BackendToken mToken;
-      uint64_t mInitTimestamp; // in seconds
+      uint64_t mInitTimestamp; // in nanoseconds
       uint64_t mInitReceived; // in nanoseconds
       const uint64_t mRelayID;
       std::string mGroup;


### PR DESCRIPTION
This PR closes #416. Just a typo when converting the timestamp from milliseconds to nanoseconds. As stated in the issue, this won't help fix the signature verification with the old backend, but should be fixed nonetheless.