### PR TITLE
Add Back LastUpdateTime to Firestore Relay

### DIFF
--- a/transport/jsonrpc/ops.go
+++ b/transport/jsonrpc/ops.go
@@ -259,6 +259,7 @@ func (s *OpsService) Relays(r *http.Request, args *RelaysArgs, reply *RelaysRepl
 			SSHUser:             r.SSHUser,
 			SSHPort:             r.SSHPort,
 			State:               r.State.String(),
+			LastUpdateTime:      r.LastUpdateTime,
 			PublicKey:           base64.StdEncoding.EncodeToString(r.PublicKey),
 			UpdateKey:           base64.StdEncoding.EncodeToString(r.UpdateKey),
 			FirestoreID:         r.FirestoreID,


### PR DESCRIPTION
Realized that if there isn't a field for LastUpdateTime on the firestore relay then there won't be any data for the ops tool to pull from when the relay is offline.