### PR TITLE
Update Tool Generates new Update Keypair

### DIFF
--- a/cmd/tools/next/relay.go
+++ b/cmd/tools/next/relay.go
@@ -10,6 +10,7 @@ import (
 	"github.com/networknext/backend/routing"
 	localjsonrpc "github.com/networknext/backend/transport/jsonrpc"
 	"github.com/ybbus/jsonrpc"
+	"golang.org/x/crypto/ed25519"
 	"golang.org/x/crypto/nacl/box"
 )
 
@@ -139,6 +140,16 @@ func updateRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []str
 			log.Fatal("could not generate public private keypair")
 		}
 
+		// Generate old backend update keypair
+		v3UpdatePublicKey, v3UpdatePrivateKey, err := ed25519.GenerateKey(nil)
+
+		v3UpdatePublicKeyB64 := base64.StdEncoding.EncodeToString(v3UpdatePublicKey)
+		v3UpdatePrivateKeyB64 := base64.StdEncoding.EncodeToString(v3UpdatePrivateKey)
+
+		if err != nil {
+			log.Fatal("could not generate v3 update public private keypair")
+		}
+
 		routerPublicKey, err := env.RouterPublicKey()
 
 		if err != nil {
@@ -166,7 +177,7 @@ func updateRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []str
 		envvars["RELAY_V3_ENABLED"] = "1"
 		envvars["RELAY_V3_BACKEND_HOSTNAME"] = oldBackendHostname
 		envvars["RELAY_V3_BACKEND_PORT"] = "40000"
-		envvars["RELAY_V3_UPDATE_KEY"] = info.updateKey
+		envvars["RELAY_V3_UPDATE_KEY"] = v3UpdatePrivateKeyB64
 		envvars["RELAY_V3_SPEED"] = info.nicSpeed
 		envvars["RELAY_V3_NAME"] = info.firestoreID
 
@@ -180,9 +191,10 @@ func updateRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []str
 		args := localjsonrpc.RelayPublicKeyUpdateArgs{
 			RelayID:        info.id,
 			RelayPublicKey: publicKeyB64,
+			RelayUpdateKey: v3UpdatePublicKeyB64,
 		}
 
-		var reply localjsonrpc.RelayStateUpdateReply
+		var reply localjsonrpc.RelayPublicKeyUpdateReply
 
 		if err := rpcClient.CallFor(&reply, "OpsService.RelayPublicKeyUpdate", &args); err != nil {
 			log.Fatalf("could not update relay public key: %v", err)

--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -572,7 +572,7 @@ func (fs *Firestore) RemoveRelay(ctx context.Context, id uint64) error {
 	return &DoesNotExistError{resourceType: "relay", resourceRef: id}
 }
 
-// Only relay state, public key, and NIC speed are updated in firestore for now
+// Only relay state, public key, update key, last update time, and NIC speed are updated in firestore for now
 func (fs *Firestore) SetRelay(ctx context.Context, r routing.Relay) error {
 	// Get a copy of the relay in cached storage
 	fs.relayMutex.RLock()
@@ -613,6 +613,7 @@ func (fs *Firestore) SetRelay(ctx context.Context, r routing.Relay) error {
 				"lastUpdateTime":  lastUpdateTime,
 				"stateUpdateTime": time.Now(),
 				"publicKey":       r.PublicKey,
+				"updateKey":       r.UpdateKey,
 				"nicSpeedMbps":    int64(r.NICSpeedMbps),
 			}
 

--- a/transport/jsonrpc/ops.go
+++ b/transport/jsonrpc/ops.go
@@ -349,6 +349,7 @@ func (s *OpsService) RelayStateUpdate(r *http.Request, args *RelayStateUpdateArg
 type RelayPublicKeyUpdateArgs struct {
 	RelayID        uint64 `json:"relay_id"`
 	RelayPublicKey string `json:"relay_public_key"`
+	RelayUpdateKey string `json:"relay_update_key"`
 }
 
 type RelayPublicKeyUpdateReply struct {
@@ -361,10 +362,20 @@ func (s *OpsService) RelayPublicKeyUpdate(r *http.Request, args *RelayPublicKeyU
 		return err
 	}
 
-	relay.PublicKey, err = base64.StdEncoding.DecodeString(args.RelayPublicKey)
+	if args.RelayPublicKey != "" {
+		relay.PublicKey, err = base64.StdEncoding.DecodeString(args.RelayPublicKey)
 
-	if err != nil {
-		return fmt.Errorf("could not decode relay public key: %v", err)
+		if err != nil {
+			return fmt.Errorf("could not decode relay public key: %v", err)
+		}
+	}
+
+	if args.RelayUpdateKey != "" {
+		relay.UpdateKey, err = base64.StdEncoding.DecodeString(args.RelayUpdateKey)
+
+		if err != nil {
+			return fmt.Errorf("could not decode relay update key: %v", err)
+		}
 	}
 
 	return s.Storage.SetRelay(context.Background(), relay)

--- a/transport/jsonrpc/ops_test.go
+++ b/transport/jsonrpc/ops_test.go
@@ -611,6 +611,7 @@ func TestRelayPublicKeyUpdate(t *testing.T) {
 		err := storer.AddRelay(context.Background(), routing.Relay{
 			ID:         1,
 			PublicKey:  []byte("oldpublickey"),
+			UpdateKey:  []byte("oldupdatekey"),
 			Seller:     seller,
 			Datacenter: datacenter,
 		})
@@ -618,6 +619,7 @@ func TestRelayPublicKeyUpdate(t *testing.T) {
 		err = storer.AddRelay(context.Background(), routing.Relay{
 			ID:         2,
 			PublicKey:  []byte("oldpublickey"),
+			UpdateKey:  []byte("oldupdatekey"),
 			Seller:     seller,
 			Datacenter: datacenter,
 		})
@@ -633,16 +635,19 @@ func TestRelayPublicKeyUpdate(t *testing.T) {
 		err := svc.RelayPublicKeyUpdate(nil, &jsonrpc.RelayPublicKeyUpdateArgs{
 			RelayID:        1,
 			RelayPublicKey: "newpublickey",
+			RelayUpdateKey: "newupdatekey",
 		}, &jsonrpc.RelayPublicKeyUpdateReply{})
 		assert.NoError(t, err)
 
 		relay, err := svc.Storage.Relay(1)
 		assert.NoError(t, err)
 		assert.Equal(t, "newpublickey", base64.StdEncoding.EncodeToString(relay.PublicKey))
+		assert.Equal(t, "newupdatekey", base64.StdEncoding.EncodeToString(relay.UpdateKey))
 
 		relay, err = svc.Storage.Relay(2)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("oldpublickey"), relay.PublicKey)
+		assert.Equal(t, []byte("oldupdatekey"), relay.UpdateKey)
 	})
 
 	t.Run("not found", func(t *testing.T) {
@@ -650,16 +655,37 @@ func TestRelayPublicKeyUpdate(t *testing.T) {
 		err := svc.RelayPublicKeyUpdate(nil, &jsonrpc.RelayPublicKeyUpdateArgs{
 			RelayID:        987654321,
 			RelayPublicKey: "newpublickey",
+			RelayUpdateKey: "newupdatekey",
 		}, &jsonrpc.RelayPublicKeyUpdateReply{})
 		assert.Error(t, err)
 
 		relay, err := svc.Storage.Relay(1)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("oldpublickey"), relay.PublicKey)
+		assert.Equal(t, []byte("oldupdatekey"), relay.UpdateKey)
 
 		relay, err = svc.Storage.Relay(2)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("oldpublickey"), relay.PublicKey)
+		assert.Equal(t, []byte("oldupdatekey"), relay.UpdateKey)
+	})
+
+	t.Run("no change", func(t *testing.T) {
+		svc := makeSvc()
+		err := svc.RelayPublicKeyUpdate(nil, &jsonrpc.RelayPublicKeyUpdateArgs{
+			RelayID: 1,
+		}, &jsonrpc.RelayPublicKeyUpdateReply{})
+		assert.NoError(t, err)
+
+		relay, err := svc.Storage.Relay(1)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("oldpublickey"), relay.PublicKey)
+		assert.Equal(t, []byte("oldupdatekey"), relay.UpdateKey)
+
+		relay, err = svc.Storage.Relay(2)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("oldpublickey"), relay.PublicKey)
+		assert.Equal(t, []byte("oldupdatekey"), relay.UpdateKey)
 	})
 }
 


### PR DESCRIPTION
This PR closes #429. 

Because we didn't realize that the update key is actually a keypair instead of a symmetric key, the update tool will use the key in firestore when updating the relay. This is actually supposed to be the relay's public key, but the relay needs a private key too when updating. To fix this, a similar method is used for the new backend relay keypair: When updating the relay, generate a new update keypair and assign the public key to firestore and the private key to the relay's update key env var.

I've made the public key and update key in the RelayPublicKeyUpdate function optional arguments, so that if they are empty strings they won't overwrite the current key in firestore. This way we can still use that function for updating the relay's public key for the new backend without needing to also provide an update key for the old backend or vice versa.