### PR TITLE
Revert "Update Tool Generates new Update Keypair"

### DIFF
--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -572,7 +572,7 @@ func (fs *Firestore) RemoveRelay(ctx context.Context, id uint64) error {
 	return &DoesNotExistError{resourceType: "relay", resourceRef: id}
 }
 
-// Only relay state, public key, update key, last update time, and NIC speed are updated in firestore for now
+// Only relay state, public key, and NIC speed are updated in firestore for now
 func (fs *Firestore) SetRelay(ctx context.Context, r routing.Relay) error {
 	// Get a copy of the relay in cached storage
 	fs.relayMutex.RLock()
@@ -613,7 +613,6 @@ func (fs *Firestore) SetRelay(ctx context.Context, r routing.Relay) error {
 				"lastUpdateTime":  lastUpdateTime,
 				"stateUpdateTime": time.Now(),
 				"publicKey":       r.PublicKey,
-				"updateKey":       r.UpdateKey,
 				"nicSpeedMbps":    int64(r.NICSpeedMbps),
 			}
 

--- a/transport/jsonrpc/ops.go
+++ b/transport/jsonrpc/ops.go
@@ -349,7 +349,6 @@ func (s *OpsService) RelayStateUpdate(r *http.Request, args *RelayStateUpdateArg
 type RelayPublicKeyUpdateArgs struct {
 	RelayID        uint64 `json:"relay_id"`
 	RelayPublicKey string `json:"relay_public_key"`
-	RelayUpdateKey string `json:"relay_update_key"`
 }
 
 type RelayPublicKeyUpdateReply struct {
@@ -362,20 +361,10 @@ func (s *OpsService) RelayPublicKeyUpdate(r *http.Request, args *RelayPublicKeyU
 		return err
 	}
 
-	if args.RelayPublicKey != "" {
-		relay.PublicKey, err = base64.StdEncoding.DecodeString(args.RelayPublicKey)
+	relay.PublicKey, err = base64.StdEncoding.DecodeString(args.RelayPublicKey)
 
-		if err != nil {
-			return fmt.Errorf("could not decode relay public key: %v", err)
-		}
-	}
-
-	if args.RelayUpdateKey != "" {
-		relay.UpdateKey, err = base64.StdEncoding.DecodeString(args.RelayUpdateKey)
-
-		if err != nil {
-			return fmt.Errorf("could not decode relay update key: %v", err)
-		}
+	if err != nil {
+		return fmt.Errorf("could not decode relay public key: %v", err)
 	}
 
 	return s.Storage.SetRelay(context.Background(), relay)

--- a/transport/jsonrpc/ops_test.go
+++ b/transport/jsonrpc/ops_test.go
@@ -611,7 +611,6 @@ func TestRelayPublicKeyUpdate(t *testing.T) {
 		err := storer.AddRelay(context.Background(), routing.Relay{
 			ID:         1,
 			PublicKey:  []byte("oldpublickey"),
-			UpdateKey:  []byte("oldupdatekey"),
 			Seller:     seller,
 			Datacenter: datacenter,
 		})
@@ -619,7 +618,6 @@ func TestRelayPublicKeyUpdate(t *testing.T) {
 		err = storer.AddRelay(context.Background(), routing.Relay{
 			ID:         2,
 			PublicKey:  []byte("oldpublickey"),
-			UpdateKey:  []byte("oldupdatekey"),
 			Seller:     seller,
 			Datacenter: datacenter,
 		})
@@ -635,19 +633,16 @@ func TestRelayPublicKeyUpdate(t *testing.T) {
 		err := svc.RelayPublicKeyUpdate(nil, &jsonrpc.RelayPublicKeyUpdateArgs{
 			RelayID:        1,
 			RelayPublicKey: "newpublickey",
-			RelayUpdateKey: "newupdatekey",
 		}, &jsonrpc.RelayPublicKeyUpdateReply{})
 		assert.NoError(t, err)
 
 		relay, err := svc.Storage.Relay(1)
 		assert.NoError(t, err)
 		assert.Equal(t, "newpublickey", base64.StdEncoding.EncodeToString(relay.PublicKey))
-		assert.Equal(t, "newupdatekey", base64.StdEncoding.EncodeToString(relay.UpdateKey))
 
 		relay, err = svc.Storage.Relay(2)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("oldpublickey"), relay.PublicKey)
-		assert.Equal(t, []byte("oldupdatekey"), relay.UpdateKey)
 	})
 
 	t.Run("not found", func(t *testing.T) {
@@ -655,37 +650,16 @@ func TestRelayPublicKeyUpdate(t *testing.T) {
 		err := svc.RelayPublicKeyUpdate(nil, &jsonrpc.RelayPublicKeyUpdateArgs{
 			RelayID:        987654321,
 			RelayPublicKey: "newpublickey",
-			RelayUpdateKey: "newupdatekey",
 		}, &jsonrpc.RelayPublicKeyUpdateReply{})
 		assert.Error(t, err)
 
 		relay, err := svc.Storage.Relay(1)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("oldpublickey"), relay.PublicKey)
-		assert.Equal(t, []byte("oldupdatekey"), relay.UpdateKey)
 
 		relay, err = svc.Storage.Relay(2)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("oldpublickey"), relay.PublicKey)
-		assert.Equal(t, []byte("oldupdatekey"), relay.UpdateKey)
-	})
-
-	t.Run("no change", func(t *testing.T) {
-		svc := makeSvc()
-		err := svc.RelayPublicKeyUpdate(nil, &jsonrpc.RelayPublicKeyUpdateArgs{
-			RelayID: 1,
-		}, &jsonrpc.RelayPublicKeyUpdateReply{})
-		assert.NoError(t, err)
-
-		relay, err := svc.Storage.Relay(1)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte("oldpublickey"), relay.PublicKey)
-		assert.Equal(t, []byte("oldupdatekey"), relay.UpdateKey)
-
-		relay, err = svc.Storage.Relay(2)
-		assert.NoError(t, err)
-		assert.Equal(t, []byte("oldpublickey"), relay.PublicKey)
-		assert.Equal(t, []byte("oldupdatekey"), relay.UpdateKey)
 	})
 }
 


### PR DESCRIPTION
Reverts networknext/backend#430

Reverting this PR until we can come up with a better way to maintain the old update key that already exists on the relay since the update public key in configstore doesn't update unless it's manually changed through configstore and not firestore.