### PR TITLE
Fix for old backend getting bad json

### DIFF
--- a/cmd/relay_new/src/core/packet_processor.cpp
+++ b/cmd/relay_new/src/core/packet_processor.cpp
@@ -126,18 +126,23 @@ namespace core
 
     bool isSigned;
     if (crypto::IsNetworkNextPacket(packet.Buffer, packet.Len)) {
-      LogDebug("packet is from network next");
       type = static_cast<packets::Type>(packet.Buffer[crypto::PacketHashLength]);
       isSigned = true;
     } else {
-      LogDebug("packet is not on network next");
       // TODO uncomment below once all packets coming through have the hash
       // return;
       type = static_cast<packets::Type>(packet.Buffer[0]);
       isSigned = false;
     }
 
-    LogDebug("incoming packet, type = ", type);
+    if (type != packets::Type::NewRelayPing && type != packets::Type::NewRelayPong) {
+      if (isSigned) {
+        LogDebug("packet is from network next");
+      } else {
+        LogDebug("packet is not on network next");
+      }
+      LogDebug("incoming packet, type = ", type);
+    }
     switch (type) {
       case packets::Type::NewRelayPing: {
         if (!mShouldProcess) {

--- a/cmd/relay_new/src/legacy/v3/backend.cpp
+++ b/cmd/relay_new/src/legacy/v3/backend.cpp
@@ -76,7 +76,7 @@ namespace legacy
 
       std::vector<uint8_t> reqData(std::begin(InitKey), std::end(InitKey));
 
-      BackendRequest request = {};
+      BackendRequest request;
       {
         request.Type = core::packets::Type::V3InitRequest;
       }
@@ -130,7 +130,7 @@ namespace legacy
         }
       }
 
-      BackendRequest request = {};
+      BackendRequest request;
       {
         request.Type = core::packets::Type::V3ConfigRequest;
       }
@@ -196,7 +196,7 @@ namespace legacy
         return false;
       }
 
-      BackendRequest request = {};
+      BackendRequest request;
       {
         request.Type = core::packets::Type::V3UpdateRequest;
       }
@@ -378,7 +378,13 @@ namespace legacy
 
         auto total = bytesPerSecInvalidRx + bytesPerSecPaidRx + bytesPerSecManagementRx + bytesPerSecMeasurementRx +
                      bytesPerSecPaidTx + bytesPerSecManagementTx + bytesPerSecManagementTx;
-        double usage = 100.0 * (8.0 * total) / mSpeed;
+
+        double usage = 100.0;
+
+        if (mSpeed > 0) {
+          usage *= 8.0 * total / mSpeed;
+        }
+
         doc.set(usage, "Usage");
       }
 


### PR DESCRIPTION
When calculating the usage I didn't account for firestore entries having a 0 value for relay speed. So if that happened to be the case the relay would have a divide by 0 situation which would give the value of infinity, and apparently rapidjson doesn't assert anything for that under the hood like everything else so it just silently corrupted the document. 