### PR TITLE
Func Backend Token Encryption Failure

### DIFF
--- a/cmd/tools/functional/backend/func_backend.go
+++ b/cmd/tools/functional/backend/func_backend.go
@@ -145,6 +145,7 @@ func (backend *Backend) GetNearRelays() []routing.Relay {
 			ID:         r.ID,
 			Addr:       r.Addr,
 			Datacenter: r.Datacenter,
+			PublicKey:  r.PublicKey,
 		})
 	}
 	sort.SliceStable(nearRelays[:], func(i, j int) bool { return nearRelays[i].ID < nearRelays[j].ID })
@@ -485,7 +486,11 @@ func main() {
 					}
 				}
 
-				tokens, numtokens, _ := token.Encrypt(crypto.RouterPrivateKey)
+				tokens, numtokens, err := token.Encrypt(crypto.RouterPrivateKey)
+				if err != nil {
+					fmt.Printf("error: failed to encrypt route token: %v\n", err)
+					return
+				}
 				sessionEntry.RouteHash = nextRoute.Hash64()
 
 				sessionResponse = &transport.SessionResponsePacket{


### PR DESCRIPTION
The func backend was not handling a token encryption failure due to public keys not be added from the relay cache entries into relays.

There is still a matter of `test_server_under_load` now not passing. [test-func-fail.txt](https://github.com/networknext/backend/files/4702906/test-func-fail.txt)
