### PR TITLE
Functional test on_on_off

### DIFF
--- a/cmd/tools/functional/backend/func_backend.go
+++ b/cmd/tools/functional/backend/func_backend.go
@@ -38,11 +38,12 @@ const BACKEND_MODE_FORCE_DIRECT = 1
 const BACKEND_MODE_RANDOM = 2
 const BACKEND_MODE_MULTIPATH = 3
 const BACKEND_MODE_ON_OFF = 4
-const BACKEND_MODE_ROUTE_SWITCHING = 5
-const BACKEND_MODE_UNCOMMITTED = 6
-const BACKEND_MODE_UNCOMMITTED_TO_COMMITTED = 7
-const BACKEND_MODE_USER_FLAGS = 8
-const BACKEND_MODE_IDEMPOTENT = 9
+const BACKEND_MODE_ON_ON_OFF = 5
+const BACKEND_MODE_ROUTE_SWITCHING = 6
+const BACKEND_MODE_UNCOMMITTED = 7
+const BACKEND_MODE_UNCOMMITTED_TO_COMMITTED = 8
+const BACKEND_MODE_USER_FLAGS = 9
+const BACKEND_MODE_IDEMPOTENT = 10
 
 type Backend struct {
 	mutex           sync.RWMutex
@@ -186,6 +187,10 @@ func main() {
 
 	if os.Getenv("BACKEND_MODE") == "ON_OFF" {
 		backend.mode = BACKEND_MODE_ON_OFF
+	}
+
+	if os.Getenv("BACKEND_MODE") == "ON_ON_OFF" {
+		backend.mode = BACKEND_MODE_ON_ON_OFF
 	}
 
 	if os.Getenv("BACKEND_MODE") == "ROUTE_SWITCHING" {
@@ -352,6 +357,13 @@ func main() {
 			if backend.mode == BACKEND_MODE_ON_OFF {
 				// Alternate between direct and next routes for each slice
 				if (sessionUpdate.Sequence & 1) == 0 {
+					takeNetworkNext = false
+				}
+			}
+
+			if backend.mode == BACKEND_MODE_ON_ON_OFF {
+				// Alternate between direct, a new route token and a continue route token for every 3 slices
+				if (sessionUpdate.Sequence & 2) == 0 {
 					takeNetworkNext = false
 				}
 			}

--- a/cmd/tools/functional/tests/func_tests.go
+++ b/cmd/tools/functional/tests/func_tests.go
@@ -1018,6 +1018,64 @@ func test_on_off() {
 }
 
 /*
+	Put the backend into a mode where every three slices, it serves two slices on network next, and the third slice going direct.
+	Verify that the SDK is able to handle transitioning from direct -> next -> continue -> direct without dropping packets or falling back to direct.
+*/
+
+func test_on_on_off() {
+
+	fmt.Printf("test_on_on_off\n")
+
+	clientConfig := &ClientConfig{}
+	clientConfig.duration = 60.0
+	clientConfig.customer_public_key = "leN7D7+9vr24uT4f1Ba8PEEvIQA/UkGZLlT+sdeLRHKsVqaZq723Zw=="
+
+	client_cmd, client_stdout, client_stderr := client(clientConfig)
+
+	serverConfig := &ServerConfig{}
+	serverConfig.customer_private_key = "leN7D7+9vr3TEZexVmvbYzdH1hbpwBvioc6y1c9Dhwr4ZaTkEWyX2Li5Ph/UFrw8QS8hAD9SQZkuVP6x14tEcqxWppmrvbdn"
+
+	server_cmd, server_stdout := server(serverConfig)
+
+	relay_1_cmd, _ := relay()
+	relay_2_cmd, _ := relay()
+	relay_3_cmd, _ := relay()
+
+	backend_cmd, backend_stdout := backend("ON_ON_OFF")
+
+	client_cmd.Wait()
+
+	server_cmd.Process.Signal(os.Interrupt)
+	backend_cmd.Process.Signal(os.Interrupt)
+	relay_1_cmd.Process.Signal(os.Interrupt)
+	relay_2_cmd.Process.Signal(os.Interrupt)
+	relay_3_cmd.Process.Signal(os.Interrupt)
+
+	server_cmd.Wait()
+	backend_cmd.Wait()
+	relay_1_cmd.Wait()
+	relay_2_cmd.Wait()
+	relay_3_cmd.Wait()
+
+	client_counters := read_client_counters(client_stderr.String())
+
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_OPEN_SESSION] == 1)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_CLOSE_SESSION] == 1)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_UPGRADE_SESSION] == 1)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_FALLBACK_TO_DIRECT] == 0)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_PACKET_SENT_DIRECT] > 0)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_PACKET_RECEIVED_DIRECT] > 0)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_PACKET_SENT_NEXT] > 0)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_PACKET_RECEIVED_NEXT] > 0)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_PACKET_SENT_DIRECT]+client_counters[NEXT_CLIENT_COUNTER_PACKET_SENT_NEXT] > 3300)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_PACKET_RECEIVED_DIRECT]+client_counters[NEXT_CLIENT_COUNTER_PACKET_RECEIVED_NEXT] > 3300)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_MULTIPATH] == 0)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_CLIENT_TO_SERVER_PACKET_LOSS] == 0)
+	client_check(client_counters, client_stdout, server_stdout, backend_stdout, client_counters[NEXT_CLIENT_COUNTER_SERVER_TO_CLIENT_PACKET_LOSS] == 0)
+
+}
+
+/*
 	Multipath feature sends packets across network next and direct at the same time.
 	Verify that it actually works as advertised, by making sure we see send and received packets across both network next and direct.
 */
@@ -1437,6 +1495,7 @@ func main() {
 		test_connect_to_another_server_next,
 		test_route_switching,
 		test_on_off,
+		test_on_on_off,
 		test_multipath,
 		test_uncommitted,
 		test_uncommitted_to_committed,

--- a/cmd/tools/scripts/test-func-parallel.sh
+++ b/cmd/tools/scripts/test-func-parallel.sh
@@ -22,6 +22,7 @@ tests=(
     test_connect_to_another_server_next
     test_route_switching
     test_on_off
+    test_on_on_off
     test_multipath
     test_uncommitted
     test_uncommitted_to_committed


### PR DESCRIPTION
This PR closes #456.

Added functional test for on_on_off as described in the issue. Since the functional tests all use the functional/reference implementations this won't actually help us tell what caused the logs shown in that issue, it'll just help guard against that case in future changes.