### PR TITLE
Add 10 Second Timeout to next relay update

### DIFF
--- a/cmd/tools/next/relay.go
+++ b/cmd/tools/next/relay.go
@@ -235,6 +235,7 @@ func updateRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []str
 
 		// Give the relay backend enough time to pull down the new public key so that
 		// we don't get crypto open failed logs when the relay tries to initialize at first
+		fmt.Println("Waiting for backend to sync changes...")
 		time.Sleep(10 * time.Second)
 
 		// Run the relay update script


### PR DESCRIPTION
This PR closes #475.

When a relay is updated, a new public/private key pair is generated for that relay. This is done so that the update command is idempotent and can be used to both create and update relay binaries. Due to the way the backend syncs data from firestore, it can take up to 10 seconds for the backend to get that public key. So to compensate, this PR makes the update command wait 10 seconds in between updating the public key in firestore and actually updating and turning on the relay. This way we won't get any erroneous logs of the relay failing to initialize.
I also refactored the update script a little bit to avoid using the anonymous function, since that was a point of confusion in the past.