### PR TITLE
Don't store client ip addr

### DIFF
--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -1087,7 +1087,11 @@ func updatePortalData(redisClientPortal redis.Cmdable, redisClientPortalExp time
 		return nil
 	}
 
-	clientIP := AnonymizeIP(packet.ClientAddress.IP)
+	clientAddr := AnonymizeAddr(packet.ClientAddress)
+
+	if clientAddr.IP == nil {
+		return fmt.Errorf("failed to anonymize client addr")
+	}
 
 	meta := routing.SessionMeta{
 		ID:            fmt.Sprintf("%016x", packet.SessionID),
@@ -1098,7 +1102,7 @@ func updatePortalData(redisClientPortal redis.Cmdable, redisClientPortalExp time
 		DirectRTT:     directStats.RTT,
 		DeltaRTT:      directStats.RTT - nnStats.RTT,
 		Location:      location,
-		ClientAddr:    clientIP.String(),
+		ClientAddr:    clientAddr.String(),
 		ServerAddr:    packet.ServerAddress.String(),
 		Hops:          relayHops,
 		SDK:           packet.Version.String(),
@@ -1286,22 +1290,4 @@ func writeSessionErrorResponse(w io.Writer, response SessionResponsePacket, priv
 	errCounter.Add(1)
 
 	return responseData, nil
-}
-
-func AnonymizeIP(ip net.IP) net.IP {
-	// If it is IPv4 make a []byte of 4 "segments" of an IP so they are all "0"
-	// then copy only the first 3 "segments" leaving the last "segment" as a "0"
-	if ipv4 := ip.To4(); ipv4 != nil {
-		buf := make([]byte, 4)
-		copy(buf, ipv4[0:3])
-		return net.IP(buf)
-	}
-
-	// Do the same just in case it is IPv6 for whatever reason
-	if ipv6 := ip.To16(); ipv6 != nil {
-		buf := make([]byte, 16)
-		copy(buf, ipv6[0:6])
-		return net.IP(buf)
-	}
-	return nil
 }

--- a/transport/utils.go
+++ b/transport/utils.go
@@ -1,0 +1,29 @@
+package transport
+
+import (
+	"net"
+)
+
+func AnonymizeAddr(addr net.UDPAddr) net.UDPAddr {
+	// If it is IPv4 make a []byte of 4 "segments" of an IP so they are all "0"
+	// then copy only the first 3 "segments" leaving the last "segment" as a "0"
+	if ipv4 := addr.IP.To4(); ipv4 != nil {
+		buf := make([]byte, 4)
+		copy(buf, ipv4[0:3])
+		return net.UDPAddr{
+			IP:   buf,
+			Zone: addr.Zone,
+		}
+	}
+
+	// Do the same just in case it is IPv6 for whatever reason
+	if ipv6 := addr.IP.To16(); ipv6 != nil {
+		buf := make([]byte, 16)
+		copy(buf, ipv6[0:6])
+		return net.UDPAddr{
+			IP:   buf,
+			Zone: addr.Zone,
+		}
+	}
+	return net.UDPAddr{}
+}

--- a/transport/utils_test.go
+++ b/transport/utils_test.go
@@ -1,0 +1,33 @@
+package transport_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/networknext/backend/transport"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnonAddr(t *testing.T) {
+	t.Run("anon addr", func(t *testing.T) {
+		addr4 := net.UDPAddr{IP: net.ParseIP("68.14.255.202"), Port: 1313}
+		anonAddr4 := transport.AnonymizeAddr(addr4)
+		assert.Equal(t, "68.14.255.0:0", anonAddr4.String())
+		assert.Equal(t, "68.14.255.0", anonAddr4.IP.String())
+		assert.Equal(t, 0, anonAddr4.Port)
+		assert.NotEqual(t, addr4, anonAddr4)
+
+		addr6 := net.UDPAddr{IP: net.ParseIP("2607:f0d0:1002:51::4"), Port: 1313}
+		anonAddr6 := transport.AnonymizeAddr(addr6)
+		assert.Equal(t, "[2607:f0d0:1002::]:0", anonAddr6.String())
+		assert.Equal(t, "2607:f0d0:1002::", anonAddr6.IP.String())
+		assert.Equal(t, 0, anonAddr6.Port)
+		assert.NotEqual(t, addr6, anonAddr6)
+	})
+
+	t.Run("anon addr failure", func(t *testing.T) {
+		addr4 := net.UDPAddr{}
+		anonAddr4 := transport.AnonymizeAddr(addr4)
+		assert.Equal(t, addr4.IP, anonAddr4.IP)
+	})
+}


### PR DESCRIPTION
This makes the last tuple in the client ip addr 0 before it goes into redis for the portal and addresses #470 