### PR TITLE
Fix CLI Add Relay

### DIFF
--- a/cmd/tools/next/next.go
+++ b/cmd/tools/next/next.go
@@ -236,7 +236,6 @@ type relay struct {
 	Name                string
 	Addr                string
 	PublicKey           string
-	UpdateKey           string
 	SellerID            string
 	DatacenterName      string
 	NicSpeedMbps        uint64
@@ -645,18 +644,12 @@ func main() {
 								log.Fatalf("Could not decode bas64 public key %s: %v", relay.PublicKey, err)
 							}
 
-							updateKey, err := base64.StdEncoding.DecodeString(relay.UpdateKey)
-							if err != nil {
-								log.Fatalf("Could not decode bas64 update key %s: %v", relay.UpdateKey, err)
-							}
-
 							// Build the actual Relay struct from the input relay struct
 							realRelay := routing.Relay{
 								ID:        crypto.HashID(relay.Addr),
 								Name:      relay.Name,
 								Addr:      *addr,
 								PublicKey: publicKey,
-								UpdateKey: updateKey,
 								Seller: routing.Seller{
 									ID: relay.SellerID,
 								},
@@ -686,7 +679,6 @@ func main() {
 										Name:                "name",
 										Addr:                "127.0.0.1:40000",
 										PublicKey:           "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-										UpdateKey:           "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
 										SellerID:            "sellerID",
 										DatacenterName:      "datacenter.name",
 										NicSpeedMbps:        1000,


### PR DESCRIPTION
Using `next relays add` wasn't working as intended for a few reasons:

1. The `Customer` object in Firestore didn't have the appropriate `Seller` linked properly so the sellers weren't syncing with the portal. Sellers and Datacenters are necessary entries to have before adding a relay so it would fail. Editing Firestore to make those connections solved this part of the issue.

2. The `Relay` struct used to send relay data to the portal wasn't marshaling all of the fields to JSON when performing the RPC call. This means that the `Seller` and `Datacenter` fields were empty and therefore not found in the portal, preventing the command from succeeding.