### PR TITLE
Fixed potential timing bug

### DIFF
--- a/cmd/relay_new/src/core/continue_token.hpp
+++ b/cmd/relay_new/src/core/continue_token.hpp
@@ -1,17 +1,17 @@
 #ifndef CORE_CONTINUE_TOKEN_HPP
 #define CORE_CONTINUE_TOKEN_HPP
 
-#include "token.hpp"
-#include "packet.hpp"
-
 #include "crypto/keychain.hpp"
+#include "packet.hpp"
+#include "router_info.hpp"
+#include "token.hpp"
 
 namespace core
 {
   class ContinueToken: public Token
   {
    public:
-    ContinueToken(const util::Clock& relayClock);
+    ContinueToken(const util::Clock& relayClock, const RouterInfo& routerInfo);
     virtual ~ContinueToken() override = default;
 
     static const size_t ByteSize = Token::ByteSize;
@@ -54,7 +54,9 @@ namespace core
      const size_t nonceIndex);
   };
 
-  inline ContinueToken::ContinueToken(const util::Clock& relayClock): Token(relayClock) {}
+  inline ContinueToken::ContinueToken(const util::Clock& relayClock, const RouterInfo& routerInfo)
+   : Token(relayClock, routerInfo)
+  {}
 }  // namespace core
 
 namespace legacy

--- a/cmd/relay_new/src/core/expireable.hpp
+++ b/cmd/relay_new/src/core/expireable.hpp
@@ -22,15 +22,18 @@ namespace core
     uint64_t ExpireTimestamp;
 
    protected:
-    Expireable(const util::Clock& relayClock);
+    Expireable(const util::Clock& relayClock, const RouterInfo& routerInfo);
 
    private:
     const util::Clock& mRelayClock;
+    const RouterInfo& mRouterInfo;
 
     inline auto timestamp() -> uint64_t;
   };
 
-  inline Expireable::Expireable(const util::Clock& relayClock): mRelayClock(relayClock) {}
+  inline Expireable::Expireable(const util::Clock& relayClock, const RouterInfo& routerInfo)
+   : mRelayClock(relayClock), mRouterInfo(routerInfo)
+  {}
 
   inline auto Expireable::expired() -> bool
   {
@@ -44,7 +47,8 @@ namespace core
 
   inline auto Expireable::timestamp() -> uint64_t
   {
-    return mRelayClock.unixTime<util::Second>();
+    // elapsed time is the amount of seconds since the relay initialized with the backend
+    return mRouterInfo.InitializeTimeInSeconds + mRelayClock.elapsed<util::Second>();
   }
 }  // namespace core
 #endif

--- a/cmd/relay_new/src/core/handlers/continue_request_handler.hpp
+++ b/cmd/relay_new/src/core/handlers/continue_request_handler.hpp
@@ -8,6 +8,7 @@
 #include "legacy/v3/traffic_stats.hpp"
 #include "os/platform.hpp"
 #include "util/throughput_recorder.hpp"
+#include "core/router_info.hpp"
 
 namespace core
 {
@@ -22,7 +23,8 @@ namespace core
        core::SessionMap& sessions,
        const crypto::Keychain& keychain,
        util::ThroughputRecorder& recorder,
-       legacy::v3::TrafficStats& stats);
+       legacy::v3::TrafficStats& stats,
+       const RouterInfo& routerInfo);
 
       template <size_t Size>
       void handle(core::GenericPacketBuffer<Size>& buff, const os::Socket& socket, bool isSigned);
@@ -33,6 +35,7 @@ namespace core
       const crypto::Keychain& mKeychain;
       util::ThroughputRecorder& mRecorder;
       legacy::v3::TrafficStats& mStats;
+      const RouterInfo& mRouterInfo;
     };
 
     inline ContinueRequestHandler::ContinueRequestHandler(
@@ -41,13 +44,15 @@ namespace core
      core::SessionMap& sessions,
      const crypto::Keychain& keychain,
      util::ThroughputRecorder& recorder,
-     legacy::v3::TrafficStats& stats)
+     legacy::v3::TrafficStats& stats,
+     const RouterInfo& routerInfo)
      : BaseHandler(packet),
        mRelayClock(relayClock),
        mSessionMap(sessions),
        mKeychain(keychain),
        mRecorder(recorder),
-       mStats(stats)
+       mStats(stats),
+       mRouterInfo(routerInfo)
     {}
 
     template <size_t Size>
@@ -73,7 +78,7 @@ namespace core
       }
 
       size_t index = 1;
-      core::ContinueToken token(mRelayClock);
+      core::ContinueToken token(mRelayClock, mRouterInfo);
       if (!token.readEncrypted(data, length, index, mKeychain.RouterPublicKey, mKeychain.RelayPrivateKey)) {
         Log("ignoring continue request. could not read continue token");
         return;

--- a/cmd/relay_new/src/core/packet_processor.cpp
+++ b/cmd/relay_new/src/core/packet_processor.cpp
@@ -38,7 +38,8 @@ namespace core
    util::Sender<GenericPacket<>>& sender,
    legacy::v3::TrafficStats& stats,
    const uint64_t oldRelayID,
-   const std::atomic<legacy::v3::ResponseState>& state)
+   const std::atomic<legacy::v3::ResponseState>& state,
+   const RouterInfo& routerInfo)
    : mShouldReceive(shouldReceive),
      mSocket(socket),
      mRelayClock(relayClock),
@@ -51,7 +52,8 @@ namespace core
      mChannel(sender),
      mStats(stats),
      mOldRelayID(oldRelayID),
-     mState(state)
+     mState(state),
+     mRouterInfo(routerInfo)
   {}
 
   void PacketProcessor::process(std::atomic<bool>& readyToReceive)
@@ -208,7 +210,7 @@ namespace core
         mRecorder.addToReceived(wholePacketSize);
         mStats.BytesPerSecManagementRx += wholePacketSize;
 
-        handlers::RouteRequestHandler handler(mRelayClock, packet, packet.Addr, mKeychain, mSessionMap, mRecorder, mStats);
+        handlers::RouteRequestHandler handler(mRelayClock, packet, packet.Addr, mKeychain, mSessionMap, mRecorder, mStats, mRouterInfo);
 
         handler.handle(outputBuff, mSocket, isSigned);
       } break;
@@ -224,7 +226,7 @@ namespace core
         mRecorder.addToReceived(wholePacketSize);
         mStats.BytesPerSecManagementRx += wholePacketSize;
 
-        handlers::ContinueRequestHandler handler(mRelayClock, packet, mSessionMap, mKeychain, mRecorder, mStats);
+        handlers::ContinueRequestHandler handler(mRelayClock, packet, mSessionMap, mKeychain, mRecorder, mStats, mRouterInfo);
 
         handler.handle(outputBuff, mSocket, isSigned);
       } break;

--- a/cmd/relay_new/src/core/packet_processor.hpp
+++ b/cmd/relay_new/src/core/packet_processor.hpp
@@ -36,7 +36,8 @@ namespace core
      util::Sender<GenericPacket<>>& sender,
      legacy::v3::TrafficStats& stats,
      const uint64_t oldRelayID,
-     const std::atomic<legacy::v3::ResponseState>& state);
+     const std::atomic<legacy::v3::ResponseState>& state,
+     const RouterInfo& routerInfo);
     ~PacketProcessor() = default;
 
     void process(std::atomic<bool>& readyToReceive);
@@ -55,6 +56,7 @@ namespace core
     legacy::v3::TrafficStats& mStats;
     const uint64_t mOldRelayID;
     const std::atomic<legacy::v3::ResponseState>& mState;
+    const RouterInfo& mRouterInfo;
 
 
     void processPacket(GenericPacket<>& packet, GenericPacketBuffer<MaxPacketsToSend>& outputBuff);

--- a/cmd/relay_new/src/core/route_token.hpp
+++ b/cmd/relay_new/src/core/route_token.hpp
@@ -1,19 +1,18 @@
 #ifndef CORE_ROUTE_TOKEN_HPP
 #define CORE_ROUTE_TOKEN_HPP
 
-#include "token.hpp"
-#include "packet.hpp"
-
 #include "crypto/keychain.hpp"
-
 #include "net/address.hpp"
+#include "packet.hpp"
+#include "router_info.hpp"
+#include "token.hpp"
 
 namespace core
 {
   class RouteToken: public Token
   {
    public:
-    RouteToken(const util::Clock& relayClock);
+    RouteToken(const util::Clock& relayClock, const RouterInfo& routerInfo);
     virtual ~RouteToken() override = default;
     // KbpsUp (4) +
     // KbpsDown (4) +
@@ -63,7 +62,7 @@ namespace core
      const size_t nonceIndex);
   };
 
-  inline RouteToken::RouteToken(const util::Clock& relayClock): Token(relayClock) {}
+  inline RouteToken::RouteToken(const util::Clock& relayClock, const RouterInfo& routerInfo): Token(relayClock, routerInfo) {}
 }  // namespace core
 
 namespace legacy

--- a/cmd/relay_new/src/core/session.hpp
+++ b/cmd/relay_new/src/core/session.hpp
@@ -5,13 +5,14 @@
 #include "net/address.hpp"
 #include "replay_protection.hpp"
 #include "util/logger.hpp"
+#include "router_info.hpp"
 
 namespace core
 {
   class Session: public Expireable
   {
    public:
-    Session(const util::Clock& relayClock);
+    Session(const util::Clock& relayClock, const RouterInfo& routerInfo);
     virtual ~Session() override = default;
 
     uint64_t SessionID;
@@ -30,7 +31,7 @@ namespace core
     legacy::relay_replay_protection_t ClientToServerProtection;
   };
 
-  inline Session::Session(const util::Clock& relayClock): Expireable(relayClock) {}
+  inline Session::Session(const util::Clock& relayClock, const RouterInfo& routerInfo): Expireable(relayClock, routerInfo) {}
 
   using SessionPtr = std::shared_ptr<Session>;
 

--- a/cmd/relay_new/src/core/token.hpp
+++ b/cmd/relay_new/src/core/token.hpp
@@ -5,13 +5,14 @@
 #include "encoding/write.hpp"
 #include "expireable.hpp"
 #include "packet.hpp"
+#include "router_info.hpp"
 
 namespace core
 {
   class Token: public Expireable
   {
    public:
-    Token(const util::Clock& relayClock);
+    Token(const util::Clock& relayClock, const RouterInfo& routerInfo);
     virtual ~Token() override = default;
     // Expireable (8) +
     // session id (8) +
@@ -30,7 +31,7 @@ namespace core
     void read(uint8_t* packetData, size_t packetLength, size_t& index);
   };
 
-  inline Token::Token(const util::Clock& relayClock): Expireable(relayClock) {}
+  inline Token::Token(const util::Clock& relayClock, const RouterInfo& routerInfo): Expireable(relayClock, routerInfo) {}
 
   [[gnu::always_inline]] inline uint64_t Token::key()
   {

--- a/cmd/relay_new/src/main.cpp
+++ b/cmd/relay_new/src/main.cpp
@@ -183,7 +183,7 @@ int main(int argc, const char* argv[])
   return 0;
 #endif
 
-  const util::Clock relayClock;
+  util::Clock relayClock;
 
   std::cout << "\nNetwork Next Relay\n";
 
@@ -335,7 +335,8 @@ int main(int argc, const char* argv[])
                                                    &sender,
                                                    &v3TrafficStats,
                                                    relayID,
-                                                   &state] {
+                                                   &state,
+                                                   &routerInfo] {
         core::PacketProcessor processor(
          shouldReceive,
          *socket,
@@ -349,7 +350,8 @@ int main(int argc, const char* argv[])
          sender,
          v3TrafficStats,
          relayID,
-         state);
+         state,
+         routerInfo);
         processor.process(socketAndThreadReady);
       });
 
@@ -498,6 +500,7 @@ int main(int argc, const char* argv[])
   }
 
   Log("relay initialized with new backend");
+  relayClock.reset();
 
   bool success = false;
 

--- a/cmd/relay_new/src/testing/core/backend.test.cpp
+++ b/cmd/relay_new/src/testing/core/backend.test.cpp
@@ -240,7 +240,7 @@ Test(core_Backend_update_valid)
   auto backend = std::move(makeBackend(routerInfo, manager, sessions));
   util::ThroughputRecorder recorder;
 
-  sessions.set(1234, std::make_shared<core::Session>(clock));  // just add one thing to the map to make it non-zero
+  sessions.set(1234, std::make_shared<core::Session>(clock, routerInfo));  // just add one thing to the map to make it non-zero
 
   // seed relay manager
   {

--- a/cmd/relay_new/src/testing/core/continue_token.test.cpp
+++ b/cmd/relay_new/src/testing/core/continue_token.test.cpp
@@ -9,8 +9,9 @@ namespace
 {
   core::ContinueToken makeToken()
   {
-    util::Clock clock;
-    return core::ContinueToken(clock);
+    static util::Clock clock;
+    static core::RouterInfo info;
+    return core::ContinueToken(clock, info);
   }
 }  // namespace
 

--- a/cmd/relay_new/src/testing/core/route_token.test.cpp
+++ b/cmd/relay_new/src/testing/core/route_token.test.cpp
@@ -8,6 +8,7 @@
 Test(core_RouteToken_general)
 {
   util::Clock clock;
+  core::RouterInfo info;
   core::GenericPacket<> packet;
 
   std::array<uint8_t, crypto_box_PUBLICKEYBYTES> sender_public_key;
@@ -37,7 +38,7 @@ Test(core_RouteToken_general)
   std::array<uint8_t, crypto_box_SECRETKEYBYTES> PrivateKey;
   crypto::RandomBytes(PrivateKey, PrivateKey.size());
 
-  core::RouteToken inputToken(clock);
+  core::RouteToken inputToken(clock, info);
   {
     inputToken.ExpireTimestamp = ExpireTimestamp;
     inputToken.SessionID = SessionID;
@@ -55,7 +56,7 @@ Test(core_RouteToken_general)
      inputToken.writeEncrypted(packet.Buffer.data(), packet.Buffer.size(), index, sender_private_key, receiver_public_key));
   }
 
-  core::RouteToken outputToken(clock);
+  core::RouteToken outputToken(clock, info);
   {
     size_t index = 0;
     check(


### PR DESCRIPTION
Made the logic for token & session expire timestamps back to what it was. Changed it months ago when debugging and it slipped through. Now it mimics the reference relay accurately again. The issue would only occur if the relays weren't all seemingly pre-configured with the GMT timezone.