### PR TITLE
log relay addresses for route debugging

### DIFF
--- a/routing/relay.go
+++ b/routing/relay.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
@@ -349,4 +350,14 @@ func (l LegacyPingToken) MarshalBinary() (data []byte, err error) {
 type LegacyPingData struct {
 	RelayPingData
 	PingToken string `json:"ping_info"` // base64 of LegacyPingToken binary form
+}
+
+func RelayAddrs(relays []Relay) string {
+	var b strings.Builder
+	for _, relay := range relays {
+		b.WriteString("{")
+		b.WriteString(relay.Addr.String())
+		b.WriteString("}")
+	}
+	return b.String()
 }

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -741,7 +741,7 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 
 		dsRelays := rp.RelaysIn(serverCacheEntry.Datacenter)
 
-		level.Debug(locallogger).Log("num_datacenter_relays", len(dsRelays), "num_client_relays", len(clientRelays))
+		level.Debug(locallogger).Log("datacenter_relays", routing.RelayAddrs(dsRelays), "client_relays", routing.RelayAddrs(clientRelays))
 
 		if len(dsRelays) == 0 {
 			sentry.CaptureMessage(fmt.Sprintf("No relays in datacenter %s", serverCacheEntry.Datacenter.Name))
@@ -900,6 +900,7 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 			nextRoute := routes[0]
 
 			level.Debug(locallogger).Log(
+				"relays", routing.RelayAddrs(nextRoute.Relays),
 				"selected_next_route_stats", nextRoute.Stats.String(),
 				"packet_next_stats", nnStats.String(),
 				"packet_direct_stats", directStats.String(),


### PR DESCRIPTION
These addrs can be seen in the GCP logs for the backend VMs.