### PR TITLE
Fallback To Direct Flags

### DIFF
--- a/transport/packet_server.go
+++ b/transport/packet_server.go
@@ -41,6 +41,19 @@ const (
 	PlatformTypePS4     = 5
 	PlatformTypeIOS     = 6
 	PlatformTypeXBOXOne = 7
+
+	FallbackFlagsBadRouteToken              = (1 << 0)
+	FallbackFlagsNoNextRouteToContinue      = (1 << 1)
+	FallbackFlagsPreviousUpdateStillPending = (1 << 2)
+	FallbackFlagsBadContinueToken           = (1 << 3)
+	FallbackFlagsRouteExpired               = (1 << 4)
+	FallbackFlagsRouteRequestTimedOut       = (1 << 5)
+	FallbackFlagsContinueRequestTimedOut    = (1 << 6)
+	FallbackFlagsClientTimedOut             = (1 << 7)
+	FallbackFlagsTryBeforeYouBuyAbort       = (1 << 8)
+	FallbackFlagsDirectRouteExpired         = (1 << 9)
+	FallbackFlagsUpgradeResponseTimedOut    = (1 << 10)
+	FallbackFlagsCount                      = 11
 )
 
 // ConnectionTypeText is similar to http.StatusText(int) which converts the code to a readable text format
@@ -74,6 +87,36 @@ func PlatformTypeText(platformType uint64) string {
 		return "IOS"
 	case PlatformTypeXBOXOne:
 		return "XBOXOne"
+	default:
+		return "unknown"
+	}
+}
+
+// FallbackFlagText is similar to http.StatusText(int) which converts the code to a readable text format
+func FallbackFlagText(fallbackFlag uint32) string {
+	switch fallbackFlag {
+	case FallbackFlagsBadRouteToken:
+		return "bad route token"
+	case FallbackFlagsNoNextRouteToContinue:
+		return "no next route to continue"
+	case FallbackFlagsPreviousUpdateStillPending:
+		return "previous update still pending"
+	case FallbackFlagsBadContinueToken:
+		return "bad continue token"
+	case FallbackFlagsRouteExpired:
+		return "route expired"
+	case FallbackFlagsRouteRequestTimedOut:
+		return "route request timed out"
+	case FallbackFlagsContinueRequestTimedOut:
+		return "continue request timed out"
+	case FallbackFlagsClientTimedOut:
+		return "client timed out"
+	case FallbackFlagsTryBeforeYouBuyAbort:
+		return "try before you buy abort"
+	case FallbackFlagsDirectRouteExpired:
+		return "direct route expired"
+	case FallbackFlagsUpgradeResponseTimedOut:
+		return "upgrade response timed out"
 	default:
 		return "unknown"
 	}

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -574,7 +574,7 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 			// at this point, and thus they shouldn't be falling back from anything.
 			if timestampNow.Sub(timestampStart) < (billing.BillingSliceSeconds*1.5*time.Second) &&
 				timestampNow.Sub(timestampStart) > (billing.BillingSliceSeconds*0.5*time.Second) {
-				level.Error(logger).Log("err", "early fallback to direct")
+				level.Error(locallogger).Log("err", "early fallback to direct", "flag", FallbackFlagText(packet.Flags))
 				if _, err := writeSessionErrorResponse(w, response, serverPrivateKey, metrics.DirectSessions, metrics.ErrorMetrics.UnserviceableUpdate, metrics.ErrorMetrics.EarlyFallbackToDirect); err != nil {
 					sentry.CaptureException(err)
 					level.Error(locallogger).Log("msg", "failed to write session error response", "err", err)
@@ -583,7 +583,7 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 				return
 			}
 
-			level.Error(logger).Log("err", "fallback to direct")
+			level.Error(locallogger).Log("err", "fallback to direct", "flag", FallbackFlagText(packet.Flags))
 
 			responseData, err := writeSessionResponse(w, response, serverPrivateKey)
 			if err != nil {


### PR DESCRIPTION
This PR closes #531.

The incoming session update packet has a `Flags` field that was previously unused, but now we've learned that it is used to give a reason as to why a client fell back to direct. This PR adds this fallback reason to the stackdriver logs so that we can see why a session fell back to direct.