### PR TITLE
Clean Lingering Relays

### DIFF
--- a/transport/relay_update_handler_test.go
+++ b/transport/relay_update_handler_test.go
@@ -48,7 +48,6 @@ func pingRelayBackendUpdate(t *testing.T, contentType string, body []byte, metri
 	request.Header.Add("Content-Type", contentType)
 
 	handler := transport.RelayUpdateHandlerFunc(log.NewNopLogger(), log.NewNopLogger(), &transport.RelayUpdateHandlerConfig{
-		HTTPClient:            NoopHTTPClient,
 		RedisClient:           redisClient,
 		GeoClient:             geoClient,
 		StatsDb:               statsdb,


### PR DESCRIPTION
If the relay backend was down for any reason (deploy, crash, etc.) and a relay key would expire in redis, then the relay backend wouldn't know to remove it from the ALL_RELAYS hash set when it spins back up. This PR will check this set for any lingering relays on startup and clean them up before accepting any connections.

I've also moved the quarantine check to the relay backend instead of in `transport.RemoveRelayCacheEntry` because the quarantine check should only happen during that expiry callback, not every time we want to remove a relay from redis.