### PR TITLE
specify at least a source relay to make output readable

### DIFF
--- a/cmd/tools/next/next.go
+++ b/cmd/tools/next/next.go
@@ -279,7 +279,7 @@ func main() {
 	routesfs := flag.NewFlagSet("routes", flag.ExitOnError)
 	routesfs.Var(&srcRelays, "src", "source relay names")
 	routesfs.Var(&destRelays, "dest", "destination relay names")
-	routesfs.Float64Var(&routeRTT, "rtt", 5, "route RTT required for selection")
+	routesfs.Float64Var(&routeRTT, "rtt", 0, "route RTT required for selection")
 	routesfs.Uint64Var(&routeHash, "hash", 0, "a previous hash to use")
 
 	root := &ffcli.Command{
@@ -379,12 +379,17 @@ func main() {
 				ShortHelp:  "List routes between relays",
 				Exec: func(_ context.Context, args []string) error {
 
-					if len(args) == 0 {
-						routes(rpcClient, env, []string{}, []string{}, 0, 0)
-						return nil
+					src := []string{}
+					if len(args) >= 1 {
+						src = append(src, args[0])
 					}
 
-					routes(rpcClient, env, []string{args[0]}, []string{args[1]}, 0, 0)
+					dest := []string{}
+					if len(args) == 2 {
+						dest = append(dest, args[1])
+					}
+
+					routes(rpcClient, env, src, dest, 0, 0)
 					return nil
 				},
 				Subcommands: []*ffcli.Command{

--- a/cmd/tools/next/routes.go
+++ b/cmd/tools/next/routes.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"text/tabwriter"
 
 	localjsonrpc "github.com/networknext/backend/transport/jsonrpc"
 	"github.com/ybbus/jsonrpc"
@@ -21,12 +23,18 @@ func routes(rpcClient jsonrpc.RPCClient, env Environment, srcrelays []string, de
 		return
 	}
 
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.TabIndent)
+
+	fmt.Fprint(tw, "Next\tDirect\tRoute\n")
 	for _, route := range reply.Routes {
-		fmt.Printf("Next RTT(%v) ", route.Stats.RTT)
-		fmt.Printf("Direct RTT(%v) ", route.DirectStats.RTT)
-		for _, relay := range route.Relays {
-			fmt.Print(relay.Name, " ")
+		fmt.Fprintf(tw, "%.1f\t%.1f\t", route.Stats.RTT, route.DirectStats.RTT)
+		for idx, relay := range route.Relays {
+			fmt.Fprint(tw, relay.Name)
+			if idx+1 < len(route.Relays) {
+				fmt.Fprint(tw, " - ")
+			}
 		}
-		fmt.Println()
+		fmt.Fprint(tw, "\n")
 	}
+	tw.Flush()
 }

--- a/transport/jsonrpc/ops.go
+++ b/transport/jsonrpc/ops.go
@@ -476,26 +476,28 @@ func (s *OpsService) RouteSelection(r *http.Request, args *RouteSelectionArgs, r
 	relays := s.Storage.Relays()
 
 	var srcrelays []routing.Relay
-	for _, relay := range relays {
-		for _, srcrelay := range args.SourceRelays {
-			if relay.Name == srcrelay {
-				srcrelays = append(srcrelays, relay)
+	if len(args.SourceRelays) > 0 {
+		for _, relay := range relays {
+			for _, srcrelay := range args.SourceRelays {
+				if relay.Name == srcrelay {
+					srcrelays = append(srcrelays, relay)
+				}
 			}
 		}
-	}
-	if len(srcrelays) == 0 {
+	} else {
 		srcrelays = relays
 	}
 
 	var destrelays []routing.Relay
-	for _, relay := range relays {
-		for _, destrelay := range args.SourceRelays {
-			if relay.Name == destrelay {
-				destrelays = append(destrelays, relay)
+	if len(args.DestinationRelays) > 0 {
+		for _, relay := range relays {
+			for _, destrelay := range args.SourceRelays {
+				if relay.Name == destrelay {
+					destrelays = append(destrelays, relay)
+				}
 			}
 		}
-	}
-	if len(destrelays) == 0 {
+	} else {
 		destrelays = relays
 	}
 
@@ -525,7 +527,7 @@ func (s *OpsService) RouteSelection(r *http.Request, args *RouteSelectionArgs, r
 	}
 
 	sort.Slice(routes, func(i int, j int) bool {
-		return routes[i].Stats.RTT < routes[j].Stats.RTT && routes[i].Relays[0].Name < routes[j].Relays[0].Name
+		return routes[i].Stats.RTT < routes[j].Stats.RTT
 	})
 
 	reply.Routes = routes


### PR DESCRIPTION
Dumping the fully connected graph of relays is not very readable so I opted to at least start with requiring only a starting relay to get the routes to every other relay.

```
./next routes amazon.sanjose.1              

Next   Direct   Route
1.0    1.0      amazon.sanjose.1 - linode.fremont
1.0    1.0      amazon.sanjose.1 - azure.sanfrancisco.1
2.0    2.0      amazon.sanjose.1 - vultr.sanjose
4.0    5.0      amazon.sanjose.1 - vultr.sanjose - digitalocean.sanfrancisco
5.0    5.0      amazon.sanjose.1 - digitalocean.sanfrancisco
9.0    9.0      amazon.sanjose.1 - vultr.losangeles
9.0    9.0      amazon.sanjose.1 - google.losangeles.1
...
```