### PR TITLE
Created test for ghost relay 404 return

### DIFF
--- a/transport/relay_update_handler_test.go
+++ b/transport/relay_update_handler_test.go
@@ -731,3 +731,61 @@ func TestRelayUpdateSuccess(t *testing.T) {
 		relayUpdateSuccessAssertions(t, recorder, "application/json", updateMetrics.ErrorMetrics, entry, redisClient, inMemory, statsdb, statIps, addr)
 	}
 }
+
+func TestGhostRelayIgnore(t *testing.T) {
+	redisServer, err := miniredis.Run()
+	assert.NoError(t, err)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	addr := "127.0.0.1:40000"
+	udp, err := net.ResolveUDPAddr("udp", addr)
+	assert.NoError(t, err)
+
+	packet := transport.RelayUpdateRequest{
+		Address:   *udp,
+		Token:     make([]byte, crypto.KeySize),
+		PingStats: make([]routing.RelayStatsPing, 0),
+	}
+
+	storedToken := make([]byte, crypto.KeySize)
+	entry := routing.RelayCacheEntry{
+		ID:   crypto.HashID(addr),
+		Addr: *udp,
+		Datacenter: routing.Datacenter{
+			ID:   1,
+			Name: "some name",
+		},
+		PublicKey:      storedToken,
+		LastUpdateTime: time.Now().Add(-time.Second)}
+
+	redisServer.Set(entry.Key(), "0")
+	redisServer.HSet(routing.HashKeyAllRelays, entry.Key(), "invalid relay data")
+
+	geoClient := &routing.GeoClient{
+		RedisClient: redisClient,
+	}
+
+	updateMetrics := metrics.EmptyRelayUpdateMetrics
+	localMetrics := metrics.LocalHandler{}
+
+	metric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "test metric"})
+	assert.NoError(t, err)
+
+	updateMetrics.ErrorMetrics.RelayNotFound = metric
+
+	// No InMemory provided, no storage, so 404
+	// Binary version
+	{
+		buff, err := packet.MarshalBinary()
+		assert.NoError(t, err)
+		recorder := pingRelayBackendUpdate(t, "application/octet-stream", buff, updateMetrics, redisClient, geoClient, nil, nil)
+		relayUpdateErrorAssertions(t, recorder, http.StatusNotFound, metric)
+	}
+
+	// JSON version
+	{
+		buff, err := packet.MarshalJSON()
+		assert.NoError(t, err)
+		recorder := pingRelayBackendUpdate(t, "application/json", buff, updateMetrics, redisClient, geoClient, nil, nil)
+		relayUpdateErrorAssertions(t, recorder, http.StatusNotFound, metric)
+	}
+}


### PR DESCRIPTION
Added a simple test for the 404 return for ghost relays. I stuck with the `Metrics.ErrorMetrics.RelayNotFound` type.