### PR TITLE
Potential fix for video race condition

### DIFF
--- a/cmd/portal/public/index.html
+++ b/cmd/portal/public/index.html
@@ -1205,7 +1205,7 @@
                                     </button>
                                 </div>
                                 <iframe id="video-player"
-                                        src="https://www.youtube.com/embed/WJnrMNCahxc?autoplay=1&amp;autohide=1&amp;modestbranding=1&amp;showinfo=0&amp;controls=0&amp;vq=hd1080"
+                                        src="https://www.youtube.com/embed/G1IbRujko-A?autoplay=1&amp;autohide=1&amp;modestbranding=1&amp;showinfo=0&amp;controls=0&amp;vq=hd1080"
                                         style="width: 100%; height: 360px;"
                                         frameborder="0">
                                 </iframe>


### PR DESCRIPTION
Sometimes after an unknown combination of reloads and page navigations, the welcome video will play with out the popup containing the video. I think this will fix the issue but it is hard to reproduce.

Removes pan functionality from session tool map