### PR TITLE
Session Update Packet Header Unmarshaling

### DIFF
--- a/transport/packet_server.go
+++ b/transport/packet_server.go
@@ -310,6 +310,32 @@ func (packet *ServerUpdatePacket) MarshalBinary() ([]byte, error) {
 	return ws.GetData()[:ws.GetBytesProcessed()], nil
 }
 
+type SessionUpdatePacketHeader struct {
+	Sequence      uint64
+	CustomerID    uint64
+	ServerAddress net.UDPAddr
+	SessionID     uint64
+}
+
+func (header *SessionUpdatePacketHeader) Serialize(stream encoding.Stream) error {
+	packetType := uint32(PacketTypeSessionUpdate)
+	stream.SerializeBits(&packetType, 8)
+
+	stream.SerializeUint64(&header.Sequence)
+	stream.SerializeUint64(&header.CustomerID)
+	stream.SerializeAddress(&header.ServerAddress)
+	stream.SerializeUint64(&header.SessionID)
+
+	return nil
+}
+
+func (header *SessionUpdatePacketHeader) UnmarshalBinary(data []byte) error {
+	if err := header.Serialize(encoding.CreateReadStream(data)); err != nil {
+		return err
+	}
+	return nil
+}
+
 type SessionUpdatePacket struct {
 	Sequence                  uint64
 	CustomerID                uint64


### PR DESCRIPTION
This PR closes #585.

When a session update packer from an older SDK version (3.3.2/3.3.3) came in to the handler, we were checking the version for deserialization, but not actually assigning that version beforehand, so it was trying to deserialize as version 0.0.0 (aka shorthand for the latest version). This PR corrects this issue by only deserializing the first few fields that are guaranteed not to change between SDK versions, and use this data to get the SDK version from the server cache entry. Then once we have the SDK version, we can correctly deserialize the rest of the packet.