### PR TITLE
Fix for 3.3.2 Sign Data

### DIFF
--- a/transport/packet_server.go
+++ b/transport/packet_server.go
@@ -183,6 +183,8 @@ type ServerInitResponsePacket struct {
 	RequestID uint64
 	Response  uint32
 	Signature []byte
+
+	Version SDKVersion
 }
 
 func (packet *ServerInitResponsePacket) Serialize(stream encoding.Stream) error {

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -136,6 +136,7 @@ func ServerInitHandlerFunc(logger log.Logger, redisClient redis.Cmdable, storer 
 		response := ServerInitResponsePacket{
 			RequestID: packet.RequestID,
 			Response:  InitResponseOK,
+			Version:   packet.Version,
 		}
 		defer func() {
 			if err := writeInitResponse(w, response, serverPrivateKey); err != nil {
@@ -485,6 +486,7 @@ func SessionUpdateHandlerFunc(logger log.Logger, redisClientCache redis.Cmdable,
 		// Deserialize the Session packet now that we have the version
 		var packet SessionUpdatePacket
 		packet.Version = serverCacheEntry.SDKVersion
+		response.Version = serverCacheEntry.SDKVersion
 		if err := packet.UnmarshalBinary(incoming.Data); err != nil {
 			sentry.CaptureException(err)
 			level.Error(logger).Log("msg", "could not read packet", "err", err)


### PR DESCRIPTION
Fixes sign data for SDK version 3.3.2 and sets the version correctly when serializing response packets