### PR TITLE
Relay version

### DIFF
--- a/cmd/relay_new/src/config.hpp
+++ b/cmd/relay_new/src/config.hpp
@@ -1,6 +1,8 @@
 #ifndef CONFIG_HPP
 #define CONFIG_HPP
 
+#define RELAY_VERSION "1.0.0"
+
 // Legacy, use bools instead, eventually delete and replace these
 #define RELAY_OK 0
 #define RELAY_ERROR -1

--- a/cmd/relay_new/src/core/backend.hpp
+++ b/cmd/relay_new/src/core/backend.hpp
@@ -388,6 +388,7 @@ namespace core
     doc.set(UpdateRequestVersion, "version");
     doc.set(mAddressStr, "relay_address");
     doc.set(mBase64RelayPublicKey, "Metadata", "PublicKey");
+    doc.set(RELAY_VERSION, "relay_version");
 
     // traffic stats
     {

--- a/cmd/tools/next/relays.go
+++ b/cmd/tools/next/relays.go
@@ -33,6 +33,7 @@ func relays(rpcClient jsonrpc.RPCClient, env Environment, filter string) {
 		Sessions    string
 		Tx          string
 		Rx          string
+		Version     string
 		LastUpdated string
 	}{}
 
@@ -59,6 +60,7 @@ func relays(rpcClient jsonrpc.RPCClient, env Environment, filter string) {
 			Sessions    string
 			Tx          string
 			Rx          string
+			Version     string
 			LastUpdated string
 		}{
 			Name:        relay.Name,
@@ -67,6 +69,7 @@ func relays(rpcClient jsonrpc.RPCClient, env Environment, filter string) {
 			Sessions:    fmt.Sprintf("%d", relay.SessionCount),
 			Tx:          tx,
 			Rx:          rx,
+			Version:     relay.Version,
 			LastUpdated: lastUpdated,
 		})
 	}

--- a/routing/relay.go
+++ b/routing/relay.go
@@ -295,6 +295,7 @@ type RelayCacheEntry struct {
 	LastUpdateTime time.Time
 	TrafficStats   RelayTrafficStats
 	MaxSessions    uint32
+	Version        string
 }
 
 func (e *RelayCacheEntry) UnmarshalBinary(data []byte) error {

--- a/transport/jsonrpc/ops.go
+++ b/transport/jsonrpc/ops.go
@@ -299,6 +299,7 @@ type relay struct {
 	PublicKey           string    `json:"public_key"`
 	UpdateKey           string    `json:"update_key"`
 	FirestoreID         string    `json:"firestore_id"`
+	Version             string    `json:"relay_version"`
 }
 
 func (s *OpsService) Relays(r *http.Request, args *RelaysArgs, reply *RelaysReply) error {
@@ -341,6 +342,7 @@ func (s *OpsService) Relays(r *http.Request, args *RelaysArgs, reply *RelaysRepl
 				relay.BytesReceived = relayCacheEntry.TrafficStats.BytesReceived
 
 				relay.LastUpdateTime = relayCacheEntry.LastUpdateTime
+				relay.Version = relayCacheEntry.Version
 			}
 		}
 

--- a/transport/packet_relay.go
+++ b/transport/packet_relay.go
@@ -308,9 +308,10 @@ func (r *RelayInitResponse) UnmarshalBinary(buf []byte) error {
 }
 
 type RelayUpdateRequest struct {
-	Version uint32
-	Address net.UDPAddr
-	Token   []byte
+	Version      uint32
+	RelayVersion string
+	Address      net.UDPAddr
+	Token        []byte
 
 	PingStats    []routing.RelayStatsPing
 	TrafficStats routing.RelayTrafficStats
@@ -324,6 +325,7 @@ func (r *RelayUpdateRequest) UnmarshalJSON(buff []byte) error {
 	doc := gjson.ParseBytes(buff)
 
 	r.Version = uint32(doc.Get("version").Int())
+	r.RelayVersion = doc.Get("relay_version").String()
 
 	addr := doc.Get("relay_address").String()
 	host, port, err := net.SplitHostPort(addr)

--- a/transport/relay_handlers.go
+++ b/transport/relay_handlers.go
@@ -759,6 +759,8 @@ func RelayUpdateHandlerFunc(logger log.Logger, relayslogger log.Logger, params *
 
 		relayCacheEntry.TrafficStats = relayUpdateRequest.TrafficStats
 
+		relayCacheEntry.Version = relayUpdateRequest.RelayVersion
+
 		// Regular set for expiry
 		if res := params.RedisClient.Set(relayCacheEntry.Key(), 0, routing.RelayTimeout); res.Err() != nil {
 			level.Error(locallogger).Log("msg", "failed to store relay update expiry", "err", res.Err())


### PR DESCRIPTION
Saw issue #648 and figured I should let this get out so that's not held up assuming version means the same thing there. Originated from issue #592. 

Got the version number to the backend through the update handler. Thought about doing it in the init handler but the issue mentioned update so I stuck with that.

![image](https://user-images.githubusercontent.com/22827169/84196068-a2efc080-aa6d-11ea-80c9-fb28de8302d5.png)