### PR TITLE
Shut Down Relay If It's Already Running With next relay enable

### DIFF
--- a/cmd/tools/next/relay.go
+++ b/cmd/tools/next/relay.go
@@ -38,10 +38,23 @@ const (
 	echo 'Relay service shutdown'
 	`
 
+	// EnableRelayScript is the bash script used to enable relays
+	// If the relay is already running, it will clean shut down before re-enabling.
 	EnableRelayScript = `
 	if systemctl is-active --quiet relay; then
-		echo 'Relay service is already running'
-		exit
+		echo 'Relay service is already running, cleanly shutting down...'
+
+		echo "Waiting for the relay service to clean shutdown"
+
+		sudo systemctl stop relay || exit 1
+
+		while systemctl is-active --quiet relay; do
+			sleep 1
+		done
+
+		sudo systemctl disable relay
+
+		echo 'Relay service shutdown'
 	fi
 
 	sudo systemctl enable relay || exit 1
@@ -254,13 +267,19 @@ func updateRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []str
 			log.Fatal("could not execute the relay-update.sh script")
 		}
 
-		// Give the portal enough time to pull down the new state so that
-		// the relay doesn't appear disabled/offline
-		fmt.Println("Waiting for portal to sync changes...")
-		time.Sleep(11 * time.Second)
-
-		fmt.Printf("Update complete for %s!\n", relayName)
+		fmt.Printf("%s finished updating\n", relayName)
 	}
+
+	// Give the portal enough time to pull down the new state so that
+	// the relay state doesn't appear incorrectly
+	fmt.Println("Waiting for portal to sync changes...")
+	time.Sleep(11 * time.Second)
+
+	str := "Updates"
+	if len(relayNames) == 1 {
+		str = "Update"
+	}
+	fmt.Printf("%s complete\n", str)
 }
 
 func revertRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []string) {
@@ -283,6 +302,17 @@ func revertRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []str
 			con.ConnectAndIssueCmd("./install.sh -r")
 		}
 	}
+
+	// Give the portal enough time to pull down the new state so that
+	// the relay state doesn't appear incorrectly
+	fmt.Println("Waiting for portal to sync changes...")
+	time.Sleep(11 * time.Second)
+
+	str := "Reverts"
+	if len(relayNames) == 1 {
+		str = "Revert"
+	}
+	fmt.Printf("%s complete\n", str)
 }
 
 func enableRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []string) {
@@ -294,6 +324,17 @@ func enableRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []str
 		con := NewSSHConn(info.user, info.sshAddr, info.sshPort, env.SSHKeyFilePath)
 		con.ConnectAndIssueCmd(EnableRelayScript)
 	}
+
+	// Give the portal enough time to pull down the new state so that
+	// the relay state doesn't appear incorrectly
+	fmt.Println("Waiting for portal to sync changes...")
+	time.Sleep(11 * time.Second)
+
+	str := "Relays"
+	if len(relayNames) == 1 {
+		str = "Relay"
+	}
+	fmt.Printf("%s enabled\n", str)
 }
 
 func disableRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []string) {
@@ -305,6 +346,17 @@ func disableRelays(env Environment, rpcClient jsonrpc.RPCClient, relayNames []st
 		con.ConnectAndIssueCmd(DisableRelayScript)
 		updateRelayState(rpcClient, info, routing.RelayStateDisabled)
 	}
+
+	// Give the portal enough time to pull down the new state so that
+	// the relay state doesn't appear incorrectly
+	fmt.Println("Waiting for portal to sync changes...")
+	time.Sleep(11 * time.Second)
+
+	str := "Relays"
+	if len(relayNames) == 1 {
+		str = "Relay"
+	}
+	fmt.Printf("%s disabled\n", str)
 }
 
 func setRelayNIC(rpcClient jsonrpc.RPCClient, relayName string, nicSpeed uint64) {
@@ -319,4 +371,11 @@ func setRelayNIC(rpcClient jsonrpc.RPCClient, relayName string, nicSpeed uint64)
 	if err := rpcClient.CallFor(&reply, "OpsService.RelayNICSpeedUpdate", args); err != nil {
 		log.Fatal(err)
 	}
+
+	// Give the portal enough time to pull down the new state so that
+	// the relay state doesn't appear incorrectly
+	fmt.Println("Waiting for portal to sync changes...")
+	time.Sleep(11 * time.Second)
+
+	fmt.Printf("NIC speed set for %s\n", info.name)
 }


### PR DESCRIPTION
This PR closes #684.

There was a need for `next relay enable` to always bring the state of the relay to `enabled`, especially after a relay is quarantined but is still running. For this to happen, `next relay enable` will now cleanly shut down the relay if it is already running before doing the normal enable process.

One could argue that all that was really needed was to set the state to enabled and not touch the running relay, but since we already have a command for that with `next relay state` I figured it would be better to take it through the whole process rather than setting the state directly, since restarting the relay may help resolve issues with it anyway.