### PR TITLE
SSHing with the next tool no longer prompts for 'yes/no' with unknown hosts

### DIFF
--- a/cmd/tools/next/ssh.go
+++ b/cmd/tools/next/ssh.go
@@ -41,11 +41,13 @@ func NewSSHConn(user, address string, port string, authKeyFilename string) SSHCo
 }
 
 func (con SSHConn) commonSSHCommands() []string {
-	args := make([]string, 4)
+	args := make([]string, 6)
 	args[0] = "-i"
 	args[1] = con.keyfile
 	args[2] = "-p"
 	args[3] = con.port
+	args[4] = "-o"
+	args[5] = "StrictHostKeyChecking=no"
 	return args
 }
 


### PR DESCRIPTION
Just had to add a flag to the ssh commands. Tested this worked by deleting my `~/.ssh/known_hosts` file and performing `next relays check` on the dev environment. No prompts were given to me