### PR TITLE
Hex IDs

### DIFF
--- a/cmd/tools/next/customers.go
+++ b/cmd/tools/next/customers.go
@@ -17,14 +17,14 @@ func customers(rpcClient jsonrpc.RPCClient, env Environment) {
 
 	customers := []struct {
 		Name     string
-		BuyerID  uint64
+		BuyerID  string
 		SellerID string
 	}{}
 
 	for _, customer := range reply.Customers {
 		customers = append(customers, struct {
 			Name     string
-			BuyerID  uint64
+			BuyerID  string
 			SellerID string
 		}{
 			Name:     customer.Name,

--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -130,7 +130,7 @@ func (fs *Firestore) Buyer(id uint64) (routing.Buyer, error) {
 
 	b, found := fs.buyers[id]
 	if !found {
-		return routing.Buyer{}, &DoesNotExistError{resourceType: "buyer", resourceRef: id}
+		return routing.Buyer{}, &DoesNotExistError{resourceType: "buyer", resourceRef: fmt.Sprintf("%x", id)}
 	}
 
 	return b, nil
@@ -248,7 +248,7 @@ func (fs *Firestore) RemoveBuyer(ctx context.Context, id uint64) error {
 	fs.buyerMutex.RUnlock()
 
 	if !ok {
-		return &DoesNotExistError{resourceType: "buyer", resourceRef: id}
+		return &DoesNotExistError{resourceType: "buyer", resourceRef: fmt.Sprintf("%x", id)}
 	}
 
 	bdocs := fs.Client.Collection("Buyer").Documents(ctx)
@@ -330,7 +330,7 @@ func (fs *Firestore) RemoveBuyer(ctx context.Context, id uint64) error {
 		}
 	}
 
-	return &DoesNotExistError{resourceType: "buyer", resourceRef: id}
+	return &DoesNotExistError{resourceType: "buyer", resourceRef: fmt.Sprintf("%x", id)}
 }
 
 func (fs *Firestore) SetBuyer(ctx context.Context, b routing.Buyer) error {
@@ -340,7 +340,7 @@ func (fs *Firestore) SetBuyer(ctx context.Context, b routing.Buyer) error {
 	fs.buyerMutex.RUnlock()
 
 	if !ok {
-		return &DoesNotExistError{resourceType: "buyer", resourceRef: b.ID}
+		return &DoesNotExistError{resourceType: "buyer", resourceRef: fmt.Sprintf("%x", b.ID)}
 	}
 
 	// Loop through all buyers in firestore
@@ -393,7 +393,7 @@ func (fs *Firestore) SetBuyer(ctx context.Context, b routing.Buyer) error {
 		}
 	}
 
-	return &DoesNotExistError{resourceType: "buyer", resourceRef: b.ID}
+	return &DoesNotExistError{resourceType: "buyer", resourceRef: fmt.Sprintf("%x", b.ID)}
 }
 
 func (fs *Firestore) Seller(id string) (routing.Seller, error) {
@@ -603,7 +603,7 @@ func (fs *Firestore) Relay(id uint64) (routing.Relay, error) {
 
 	relay, found := fs.relays[id]
 	if !found {
-		return routing.Relay{}, &DoesNotExistError{resourceType: "relay", resourceRef: id}
+		return routing.Relay{}, &DoesNotExistError{resourceType: "relay", resourceRef: fmt.Sprintf("%x", id)}
 	}
 
 	return relay, nil
@@ -678,7 +678,7 @@ func (fs *Firestore) AddRelay(ctx context.Context, r routing.Relay) error {
 	}
 
 	if datacenterRef == nil {
-		return &DoesNotExistError{resourceType: "datacenter", resourceRef: r.Datacenter.ID}
+		return &DoesNotExistError{resourceType: "datacenter", resourceRef: fmt.Sprintf("%x", r.Datacenter.ID)}
 	}
 
 	newRelayData := relay{
@@ -717,7 +717,7 @@ func (fs *Firestore) RemoveRelay(ctx context.Context, id uint64) error {
 	fs.relayMutex.RUnlock()
 
 	if !ok {
-		return &DoesNotExistError{resourceType: "relay", resourceRef: id}
+		return &DoesNotExistError{resourceType: "relay", resourceRef: fmt.Sprintf("%x", id)}
 	}
 
 	rdocs := fs.Client.Collection("Relay").Documents(ctx)
@@ -754,7 +754,7 @@ func (fs *Firestore) RemoveRelay(ctx context.Context, id uint64) error {
 		}
 	}
 
-	return &DoesNotExistError{resourceType: "relay", resourceRef: id}
+	return &DoesNotExistError{resourceType: "relay", resourceRef: fmt.Sprintf("%x", id)}
 }
 
 // Only relay state, public key, and NIC speed are updated in firestore for now
@@ -765,7 +765,7 @@ func (fs *Firestore) SetRelay(ctx context.Context, r routing.Relay) error {
 	fs.relayMutex.RUnlock()
 
 	if !ok {
-		return &DoesNotExistError{resourceType: "relay", resourceRef: r.ID}
+		return &DoesNotExistError{resourceType: "relay", resourceRef: fmt.Sprintf("%x", r.ID)}
 	}
 
 	// Loop through all relays in firestore
@@ -817,7 +817,7 @@ func (fs *Firestore) SetRelay(ctx context.Context, r routing.Relay) error {
 		}
 	}
 
-	return &DoesNotExistError{resourceType: "relay", resourceRef: r.ID}
+	return &DoesNotExistError{resourceType: "relay", resourceRef: fmt.Sprintf("%x", r.ID)}
 }
 
 func (fs *Firestore) Datacenter(id uint64) (routing.Datacenter, error) {
@@ -826,7 +826,7 @@ func (fs *Firestore) Datacenter(id uint64) (routing.Datacenter, error) {
 
 	d, found := fs.datacenters[id]
 	if !found {
-		return routing.Datacenter{}, &DoesNotExistError{resourceType: "datacenter", resourceRef: id}
+		return routing.Datacenter{}, &DoesNotExistError{resourceType: "datacenter", resourceRef: fmt.Sprintf("%x", id)}
 	}
 
 	return d, nil
@@ -874,7 +874,7 @@ func (fs *Firestore) RemoveDatacenter(ctx context.Context, id uint64) error {
 	fs.datacenterMutex.RUnlock()
 
 	if !ok {
-		return &DoesNotExistError{resourceType: "datacenter", resourceRef: id}
+		return &DoesNotExistError{resourceType: "datacenter", resourceRef: fmt.Sprintf("%x", id)}
 	}
 
 	ddocs := fs.Client.Collection("Datacenter").Documents(ctx)
@@ -910,7 +910,7 @@ func (fs *Firestore) RemoveDatacenter(ctx context.Context, id uint64) error {
 		}
 	}
 
-	return &DoesNotExistError{resourceType: "datacenter", resourceRef: id}
+	return &DoesNotExistError{resourceType: "datacenter", resourceRef: fmt.Sprintf("%x", id)}
 }
 
 func (fs *Firestore) SetDatacenter(ctx context.Context, d routing.Datacenter) error {
@@ -920,7 +920,7 @@ func (fs *Firestore) SetDatacenter(ctx context.Context, d routing.Datacenter) er
 	fs.datacenterMutex.RUnlock()
 
 	if !ok {
-		return &DoesNotExistError{resourceType: "datacenter", resourceRef: d.ID}
+		return &DoesNotExistError{resourceType: "datacenter", resourceRef: fmt.Sprintf("%x", d.ID)}
 	}
 
 	// Loop through all datacenters in firestore
@@ -969,7 +969,7 @@ func (fs *Firestore) SetDatacenter(ctx context.Context, d routing.Datacenter) er
 		}
 	}
 
-	return &DoesNotExistError{resourceType: "datacenter", resourceRef: d.ID}
+	return &DoesNotExistError{resourceType: "datacenter", resourceRef: fmt.Sprintf("%x", d.ID)}
 }
 
 // SyncLoop is a helper method that calls Sync

--- a/transport/jsonrpc/ops.go
+++ b/transport/jsonrpc/ops.go
@@ -233,7 +233,7 @@ type CustomersReply struct {
 }
 
 type customer struct {
-	BuyerID  uint64 `json:"buyer_id"`
+	BuyerID  string `json:"buyer_id"`
 	SellerID string `json:"seller_id"`
 	Name     string `json:"name"`
 }
@@ -244,7 +244,7 @@ func (s *OpsService) Customers(r *http.Request, args *CustomersArgs, reply *Cust
 
 	for _, b := range s.Storage.Buyers() {
 		customers[b.Name] = customer{
-			BuyerID: b.ID,
+			BuyerID: fmt.Sprintf("%x", b.ID),
 			Name:    b.Name,
 		}
 	}
@@ -541,8 +541,8 @@ type DatacentersReply struct {
 }
 
 type datacenter struct {
-	ID        uint64  `json:"id"`
 	Name      string  `json:"name"`
+	ID        string  `json:"id"`
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
 	Enabled   bool    `json:"enabled"`
@@ -551,8 +551,8 @@ type datacenter struct {
 func (s *OpsService) Datacenters(r *http.Request, args *DatacentersArgs, reply *DatacentersReply) error {
 	for _, d := range s.Storage.Datacenters() {
 		reply.Datacenters = append(reply.Datacenters, datacenter{
-			ID:        d.ID,
 			Name:      d.Name,
+			ID:        fmt.Sprintf("%x", d.ID),
 			Enabled:   d.Enabled,
 			Latitude:  d.Location.Latitude,
 			Longitude: d.Location.Longitude,

--- a/transport/jsonrpc/ops_test.go
+++ b/transport/jsonrpc/ops_test.go
@@ -56,7 +56,7 @@ func TestCustomersSingle(t *testing.T) {
 		err := svc.Customers(nil, &jsonrpc.CustomersArgs{}, &reply)
 		assert.NoError(t, err)
 
-		assert.Equal(t, uint64(1), reply.Customers[0].BuyerID)
+		assert.Equal(t, "1", reply.Customers[0].BuyerID)
 		assert.Equal(t, "some seller", reply.Customers[0].SellerID)
 		assert.Equal(t, "Fred Scuttle", reply.Customers[0].Name)
 	})
@@ -80,11 +80,11 @@ func TestCustomersMultiple(t *testing.T) {
 		assert.NoError(t, err)
 
 		// sorted alphabetically by name
-		assert.Equal(t, uint64(0), reply.Customers[0].BuyerID)
+		assert.Equal(t, "", reply.Customers[0].BuyerID)
 		assert.Equal(t, "some seller", reply.Customers[0].SellerID)
 		assert.Equal(t, "Bull Winkle", reply.Customers[0].Name)
 
-		assert.Equal(t, uint64(1), reply.Customers[1].BuyerID)
+		assert.Equal(t, "1", reply.Customers[1].BuyerID)
 		assert.Equal(t, "", reply.Customers[1].SellerID)
 		assert.Equal(t, "Fred Scuttle", reply.Customers[1].Name)
 	})


### PR DESCRIPTION
This PR closes #686.

Changed all display of entity IDs to hex minus the seller IDs, since right now those are firestore IDs which are strings. I also changed the display of IDs in the firestore errors so that we can see them as hex in the backend logs.

In addition, I swapped the Name and ID columns in `next datacenters`