### PR TITLE
Remove SellerID Requirement

### DIFF
--- a/cmd/tools/next/README.md
+++ b/cmd/tools/next/README.md
@@ -4,10 +4,17 @@
 
 Run `./next` in the root of the repo for available commands.
 
+## Select
+
+To set the current environment for the next tool: `next select <local|dev|prod>`
+
+Only valid values are `local`, `dev`, or `prod`.
+
 ## Env
 
-To set the current environment for the next tool: `next env <local|dev|prod>`
+To display information about the current environment: `next env`
 
+The environment can also be changed with `next env [local|dev|prod]` in the same way as `next select <local|dev|prod>`
 Only valid values are `local`, `dev`, or `prod`.
 
 ## Auth

--- a/cmd/tools/next/next.go
+++ b/cmd/tools/next/next.go
@@ -277,6 +277,12 @@ type buyer struct {
 	PublicKey string
 }
 
+type seller struct {
+	Name              string
+	IngressPriceCents uint64
+	EgressPriceCents  uint64
+}
+
 type relay struct {
 	Name                string
 	Addr                string
@@ -378,9 +384,17 @@ func main() {
 			},
 			{
 				Name:       "select",
-				ShortUsage: "next select <local|dev|prod|other_portal_hostname>",
+				ShortUsage: "next select <local|dev|prod>",
 				ShortHelp:  "Select environment to use (local|dev|prod)",
 				Exec: func(_ context.Context, args []string) error {
+					if len(args) == 0 {
+						log.Fatal("Provide an environment to switch to (local|dev|prod)")
+					}
+
+					if args[0] != "local" && args[0] != "dev" && args[0] != "prod" {
+						log.Fatalf("Invalid environment %s: use (local|dev|prod)", args[0])
+					}
+
 					env.Name = args[0]
 					env.Write()
 
@@ -394,8 +408,14 @@ func main() {
 				ShortHelp:  "Display environment",
 				Exec: func(_ context.Context, args []string) error {
 					if len(args) > 0 {
+						if args[0] != "local" && args[0] != "dev" && args[0] != "prod" {
+							log.Fatalf("Invalid environment %s: use (local|dev|prod)", args[0])
+						}
+
 						env.Name = args[0]
 						env.Write()
+
+						fmt.Printf("Selected %s environment\n", env.Name)
 					}
 
 					env.RemoteRelease = "Unknown"
@@ -929,13 +949,18 @@ func main() {
 							jsonData := readJSONData("sellers", args)
 
 							// Unmarshal the JSON and create the Seller struct
-							var seller routing.Seller
-							if err := json.Unmarshal(jsonData, &seller); err != nil {
+							var s seller
+							if err := json.Unmarshal(jsonData, &s); err != nil {
 								log.Fatalf("Could not unmarshal seller: %v", err)
 							}
 
 							// Add the Seller to storage
-							addSeller(rpcClient, env, seller)
+							addSeller(rpcClient, env, routing.Seller{
+								ID:                s.Name,
+								Name:              s.Name,
+								IngressPriceCents: s.IngressPriceCents,
+								EgressPriceCents:  s.EgressPriceCents,
+							})
 							return nil
 						},
 						Subcommands: []*ffcli.Command{
@@ -944,8 +969,7 @@ func main() {
 								ShortUsage: "next seller add example",
 								ShortHelp:  "Displays an example seller for the correct JSON schema",
 								Exec: func(_ context.Context, args []string) error {
-									example := routing.Seller{
-										ID:   "5tCm7KjOw3EBYojLe6PC",
+									example := seller{
 										Name: "amazon",
 									}
 

--- a/cmd/tools/next/sellers.go
+++ b/cmd/tools/next/sellers.go
@@ -19,17 +19,17 @@ func sellers(rpcClient jsonrpc.RPCClient, env Environment) {
 	}
 
 	sellers := []struct {
-		Name      string
-		ID        string
+		Name string
+		ID   string
 	}{}
 
 	for _, seller := range reply.Sellers {
 		sellers = append(sellers, struct {
-			Name       string
-			ID         string
+			Name string
+			ID   string
 		}{
-			Name:        seller.Name,
-			ID:          seller.ID,
+			Name: seller.Name,
+			ID:   seller.ID,
 		})
 	}
 


### PR DESCRIPTION
This PR closes #693.

Changed up `next seller add` so that the ID isn't required and doesn't show in the example schema. Because I couldn't actually remove the ID requirement when creating the seller at the firestore level (due to the way we've structured our storage package), I've opted to just make the seller ID the same as the seller name. Since the firestore ID is just a randomly generated string and can be set to anything, as long as we don't have multiple sellers with the same name this will work fine. I'm keeping both the seller name and seller ID columns in `next sellers` since even though future sellers added will have the same value, existing sellers don't.