### PR TITLE
Compact Map Points JSON

### DIFF
--- a/transport/jsonrpc/buyer.go
+++ b/transport/jsonrpc/buyer.go
@@ -487,6 +487,7 @@ func (s *BuyersService) GenerateMapPoints() error {
 
 			// if there was no error then add the SessionMapPoint to the slice
 			mappoints = append(mappoints, point)
+
 			var onNN uint
 			if point.OnNetworkNext {
 				onNN = 1
@@ -524,6 +525,16 @@ func (s *BuyersService) SessionMapPoints(r *http.Request, args *MapPointsArgs, r
 
 	// pull the local cache and reply with it
 	reply.Points = s.mapPointsCache
+
+	return nil
+}
+
+func (s *BuyersService) SessionMap(r *http.Request, args *MapPointsArgs, reply *MapPointsReply) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// pull the local cache and reply with it
+	reply.Points = s.mapPointsCompactCache
 
 	return nil
 }


### PR DESCRIPTION
Address #718 to reduce JSON response size.  The `"map_points"` key is now an array tuple in the form of `[long, lat, on_nn]` where `on_nn` is either `0` or `1` since `true` or `false` consume 4-5 bytes as opposed to just 1 byte for a digit.

This is separate RPC call as to not break the contact of the current one and we can swap over gradually and deprecate the old one if we want.