### PR TITLE
Fix for next relay disable

### DIFF
--- a/cmd/next/relay.go
+++ b/cmd/next/relay.go
@@ -25,8 +25,9 @@ const (
 
 	// DisableRelayScript is the bash script used to disable relays
 	DisableRelayScript = `
-	if ! systemctl is-active --quiet relay; then
-		echo 'Relay service has already been stopped'
+	service="$(sudo systemctl list-unit-files --state=enabled | grep 'relay.service')"
+	if [ -z "$service" ]; then
+		echo 'Relay service has already been disabled'
 		exit
 	fi
 
@@ -44,9 +45,10 @@ const (
 	`
 
 	// EnableRelayScript is the bash script used to enable relays
-	// If the relay is already running, it will clean shut down before re-enabling.
+	// If the relay service is already enabled, it will clean shut down before re-enabling.
 	EnableRelayScript = `
-	if systemctl is-active --quiet relay; then
+	service="$(sudo systemctl list-unit-files --state=enabled | grep 'relay.service')"
+	if [ ! -z "$service" ]; then
 		echo 'Relay service is already running, cleanly shutting down...'
 
 		echo "Waiting for the relay service to clean shutdown"


### PR DESCRIPTION
Closes #770 and #750.

The reason this was happening was because the tool would only check if the service was running. The relays have a 10 second restart delay after shutting down so when updating quarantined relays sometimes they would be within that window, which would cause the check to pass at first and then by the time you get to updating them the script would check again but systemd would have restarted the service causing it to fail.

To solve that I changed the script to check if the service is in the enabled state which doesn't care about whether the relay is running or not.