### PR TITLE
Map and Slice Bounds Checks

### DIFF
--- a/routing/geo.go
+++ b/routing/geo.go
@@ -162,11 +162,30 @@ func (mmdb *MaxmindDB) LocateIP(ip net.IP) (Location, error) {
 		return Location{}, fmt.Errorf("no location found for '%s'", ip.String())
 	}
 
+	continent := "unknown"
+	if val, ok := res.Continent.Names["en"]; ok {
+		continent = val
+	}
+	country := "unknown"
+	if val, ok := res.Country.Names["en"]; ok {
+		country = val
+	}
+	region := "unknown"
+	if len(res.Subdivisions) > 0 {
+		if val, ok := res.Subdivisions[0].Names["en"]; ok {
+			region = val
+		}
+	}
+	city := "unknown"
+	if val, ok := res.City.Names["en"]; ok {
+		city = val
+	}
+
 	return Location{
-		Continent: res.Continent.Names["en"],
-		Country:   res.Country.Names["en"],
-		Region:    res.Subdivisions[0].Names["en"],
-		City:      res.City.Names["en"],
+		Continent: continent,
+		Country:   country,
+		Region:    region,
+		City:      city,
 		Latitude:  res.Location.Latitude,
 		Longitude: res.Location.Longitude,
 		ISP:       "unknown",


### PR DESCRIPTION
The server instances were throwing panic messages in `journald` causing service restarts which threw the health checks off since it panicked so often.

I SSHed into one of the VMs and ran `sudo journalctl -u app` to get the history of the local logs.

```
Jun 16 23:10:34 server-backend-mig-jsmc app[1735]: panic: runtime error: index 
out of range [0] with length 0
Jun 16 23:10:34 server-backend-mig-jsmc app[1735]: goroutine 575 [running]:
Jun 16 23:10:34 server-backend-mig-jsmc app[1735]: github.com/networknext/backend/routing.(*MaxmindDB).LocateIP(0xc000346028, 0xc01753b860, 0x10, 0x10, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
Jun 16 23:10:34 server-backend-mig-jsmc app[1735]:         /home/semaphore/backend/routing/geo.go:168 +0x4a3
Jun 16 23:10:34 server-backend-mig-jsmc app[1735]: github.com/networknext/backend/transport.SessionUpdateHandlerFunc.func1(0xf14400,0xc014d38a50, 0xc013a5fe60)
Jun 16 23:10:34 server-backend-mig-jsmc app[1735]:        /home/semaphore/backend/transport/server_handlers.go:642 +0xb4cf
Jun 16 23:10:34 server-backend-mig-jsmc app[1735]: github.com/networknext/backend/transport(*UDPServerMux).handler(0xc00ce3b4a0, 0xf2c700,0xc0000c6000, 0xf)
Jun 16 23:10:34 server-backend-mig-jsmc app[1735]:         /home/semaphore/backend/transport/server_handlers.go:93 +0x307
Jun 16 23:10:34 server-backend-mig-jsmc app[1735]: created by github.com/networknext/backend/transport.(*UDPServerMux).Start
Jun 16 23:10:34 server-backend-mig-jsmc app[1735]:         /home/semaphore/backend/transport/server_handlers.go:54 +0x6f
Jun 16 23:10:34 server-backend-mig-jsmc systemd[1]: app.service: Main p
```

This was when we switched to Maxmind and some IPs did not return complete results so I added bounds checks. We could add a test case for this, but we'd have to track down the IP that caused the panic so we can account for that one in the Maxmind DB file.