### PR TITLE
Set Linux Process Limit

### DIFF
--- a/deploy/vm-update-app.sh
+++ b/deploy/vm-update-app.sh
@@ -38,3 +38,6 @@ cp app.service /etc/systemd/system/app.service
 # Start the service
 systemctl daemon-reload
 systemctl start app.service
+
+# Ensure the file descriptor limit for the process is set
+prlimit --nofile=200000:200000 --pid $(pidof app)


### PR DESCRIPTION
This sets the process limit on the VMs every deplpyment. When the PR is merged the following still needs to happen since this file only gets copied to VMs when they are created. 

1. Copy this file to GCP buckets
  - Dev: `gs://artifacts.network-next-v3-dev.appspot.com/vm-update-app.sh`
  - Prod: `gs://us.artifacts.network-next-v3-prod.appspot.com/vm-update-app.sh`
2. Copy this file to dev/prod VMs currently running to `/app/vm-update-app.sh`