### PR TITLE
Actually use the ssh port when updating relays

### DIFF
--- a/cmd/next/relay.go
+++ b/cmd/next/relay.go
@@ -323,7 +323,7 @@ func updateRelays(env Environment, rpcClient jsonrpc.RPCClient, regexes []string
 			time.Sleep(11 * time.Second)
 
 			// Run the relay update script
-			if !runCommandEnv("deploy/relay-update.sh", []string{env.SSHKeyFilePath, relay.user + "@" + relay.sshAddr}, nil) {
+			if !runCommandEnv("deploy/relay-update.sh", []string{env.SSHKeyFilePath, relay.sshPort, relay.user + "@" + relay.sshAddr}, nil) {
 				fmt.Println("could not execute the relay-update.sh script")
 				continue
 			}

--- a/deploy/relay-update.sh
+++ b/deploy/relay-update.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # $1 = ssh key file
-# $2 = username@address
+# $2 = port
+# $3 = username@address
 
 proj_root="$(pwd)"
 
@@ -9,6 +10,6 @@ tarfile="relay.tar.gz"
 
 cd 'dist'
 
-tar -zcf "$proj_root/dist/$tarfile" 'relay' 'relay.env' 'relay.service' 'install.sh'
-scp -i "$1" "$proj_root/dist/$tarfile" "$2:~/$tarfile"
-ssh -i "$1" "$2" -- "tar -xvf $tarfile && chmod 755 ./install.sh && sudo ./install.sh -i"
+tar -zcf "$proj_root/dist/$tarfile" 'relay' 'relay.env' 'relay.service' 'install.sh' || exit 1
+scp -i "$1" -P "$2" "$proj_root/dist/$tarfile" "$3:~/$tarfile" || exit 1
+ssh -i "$1" -p "$2" "$3" -- "tar -xvf $tarfile && chmod 755 ./install.sh && sudo ./install.sh -i" || exit 1


### PR DESCRIPTION
Closes #745. 

The hostdime relays weren't able to update because the update script didn't specify the port numbers when ssh-ing or scp-ing. So far those seem to be the only ones that don't ssh over port 22.