### PR TITLE
Mount /healthz for Portal Uptime Checks

### DIFF
--- a/cmd/portal/portal.go
+++ b/cmd/portal/portal.go
@@ -319,6 +319,7 @@ func main() {
 		}, "")
 
 		http.Handle("/rpc", jsonrpc.AuthMiddleware(os.Getenv("JWT_AUDIENCE"), s))
+		http.HandleFunc("/healthz", transport.HealthzHandlerFunc())
 
 		http.Handle("/", http.FileServer(http.Dir(uiDir)))
 


### PR DESCRIPTION
Since GCP sucks and won't just check `https://portal.networknext.com` and I don't want to spend all day debugging this I am mounting a `/healthz` endpoint on Portal like Relay and Server does and configure uptime checks and alerts to Slack.