### PR TITLE
Fixed copy/paste error

### DIFF
--- a/cmd/next/relay.go
+++ b/cmd/next/relay.go
@@ -392,9 +392,9 @@ func enableRelays(env Environment, rpcClient jsonrpc.RPCClient, regexes []string
 	fmt.Println("Waiting for portal to sync changes...")
 	time.Sleep(11 * time.Second)
 
-	str := "Reverts"
+	str := "Enabling"
 	if enabledRelays == 1 {
-		str = "Revert"
+		str = "Enable"
 	}
 	fmt.Printf("%s complete\n", str)
 }


### PR DESCRIPTION
Closes #795 

Fixed the copy/paste error. Also converted ID output in `./next relay ...` to 16 byte zero padded hex.