### PR TITLE
handle rpc errors better not just dump them to terminal

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -672,7 +672,7 @@ func main() {
 						ShortUsage: "next relay keys <relay name>",
 						ShortHelp:  "Show the public keys for the relay",
 						Exec: func(ctx context.Context, args []string) error {
-							relays := getRelayInfo(rpcClient, args[0])
+							relays := getRelayInfo(rpcClient, env, args[0])
 
 							if len(relays) == 0 {
 								log.Fatalf("no relays matched the name '%s'\n", args[0])
@@ -765,7 +765,7 @@ func main() {
 								log.Fatalf("Unable to parse %s as uint64", args[1])
 							}
 
-							setRelayNIC(rpcClient, args[0], nicSpeed)
+							setRelayNIC(rpcClient, env, args[0], nicSpeed)
 
 							return nil
 						},
@@ -784,7 +784,7 @@ func main() {
 								log.Fatal("You need to supply at least one relay name regex")
 							}
 
-							setRelayState(rpcClient, args[0], args[1:])
+							setRelayState(rpcClient, env, args[0], args[1:])
 							return nil
 						},
 					},

--- a/cmd/next/relays.go
+++ b/cmd/next/relays.go
@@ -128,7 +128,7 @@ func addRelay(rpcClient jsonrpc.RPCClient, env Environment, relay routing.Relay)
 }
 
 func removeRelay(rpcClient jsonrpc.RPCClient, env Environment, name string) {
-	relays := getRelayInfo(rpcClient, name)
+	relays := getRelayInfo(rpcClient, env, name)
 
 	if len(relays) == 0 {
 		log.Fatalf("no relays matched the name '%s'\n", name)

--- a/cmd/next/ssh.go
+++ b/cmd/next/ssh.go
@@ -19,7 +19,7 @@ func testForSSHKey(env Environment) {
 }
 
 func SSHInto(env Environment, rpcClient jsonrpc.RPCClient, relayName string) {
-	relays := getRelayInfo(rpcClient, relayName)
+	relays := getRelayInfo(rpcClient, env, relayName)
 	if len(relays) == 0 {
 		log.Fatalf("no relays matches the regex '%s'", relayName)
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/go-redis/redis/v7 v7.0.0-beta.5
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gogo/protobuf v1.3.1
-	github.com/golang/protobuf v1.3.3
-	github.com/gorilla/handlers v1.4.2 // indirect
+	github.com/golang/protobuf v1.4.2
+	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/rpc v1.2.0
 	github.com/json-iterator/go v1.1.9


### PR DESCRIPTION
Fixes #775

Anyone working on the CLI tool remember to use `func handleJSONRPCError(env Environment, err error)` when catching RCP errors since this will print a nicer message when auth fails rather than dumping it with `log.Fatal(err)`.