### PR TITLE
Fix Flush Buffer

### DIFF
--- a/billing/googlebigquery.go
+++ b/billing/googlebigquery.go
@@ -38,6 +38,7 @@ func (bq *GoogleBigQueryClient) WriteLoop(ctx context.Context) error {
 
 	for entry := range bq.entries {
 		if len(bq.buffer) >= bq.BatchSize {
+			if err := bq.TableInserter.Put(ctx, bq.buffer); err != nil {
 				level.Error(bq.Logger).Log("msg", "failed to write to BigQuery", "err", err)
 			}
 			level.Info(bq.Logger).Log("msg", "flushed entries to BigQuery", "size", bq.BatchSize, "total", len(bq.buffer))


### PR DESCRIPTION
When the buffer filled it wrote just the entry that completed filling it, not the actual buffer.

I was running a `SELECT COUNT(*)` in BigQuery and watched the count grow a lot faster when I was running 20 local client sessions. When I stopped that it would only grow by 1 since dev had older code.