### PR TITLE
Sort top sessions before responding to portal

### DIFF
--- a/transport/jsonrpc/buyer.go
+++ b/transport/jsonrpc/buyer.go
@@ -428,7 +428,7 @@ func (s *BuyersService) TopSessions(r *http.Request, args *TopSessionsArgs, repl
 		reply.Sessions = reply.Sessions[:TopSessionsSize]
 	}
 
-	sort.Slice(reply.Sessions, func(i int, j int) bool {
+	sort.SliceStable(reply.Sessions, func(i int, j int) bool {
 		firstSession := reply.Sessions[i]
 		secondSession := reply.Sessions[j]
 		if firstSession.OnNetworkNext && secondSession.OnNetworkNext {


### PR DESCRIPTION
if both sessions are on network next, sort them by highest deltaRTT
if the first session is on and the second is off, return true to sort the onNN session first
if the second session is on and the first is off, return false to sort the onNN session first
if both sessions are !onNN, sort them by lowest deltaRTT

Closes #954 