### PR TITLE
Added number of relays to relay dashboard

### DIFF
--- a/transport/relay_handlers.go
+++ b/transport/relay_handlers.go
@@ -940,7 +940,7 @@ func RelayDashboardHandlerFunc(redisClient redis.Cmdable, routeMatrix *routing.R
 				<h2>Route Matrix Analysis</h2>
 				<pre>{{ .Analysis }}</pre>
 
-				<h2>Relays</h2>
+				<h2>{{ len .Relays }} Relays</h2>
 				<table>
 					<tr>
 						<th>Name</th>


### PR DESCRIPTION
Relay dashboard will now have the number of relays next to the "Relays" header

Closes #828 