### PR TITLE
Packet Loss Safety Flexibility

### DIFF
--- a/routing/route_decision.go
+++ b/routing/route_decision.go
@@ -153,7 +153,7 @@ func DecideDowngradeRTT(rttHysteresis float64, yolo bool) DecisionFunc {
 // RTT by more than the RTT veto value, or increases packet loss if packet loss safety is enabled.
 // This decision only downgrades network next routes, so direct routes aren't considered.
 // Multipath sessions aren't considered.
-func DecideVeto(rttVeto float64, packetLossSafety bool, yolo bool) DecisionFunc {
+func DecideVeto(onNNSliceCounter uint64, rttVeto float64, packetLossSafety bool, yolo bool) DecisionFunc {
 	return func(prevDecision Decision, predictedNextStats Stats, lastNextStats Stats, directStats Stats) Decision {
 		// If we've already decided on multipath, then don't change the reason
 		if IsMultipath(prevDecision) {
@@ -172,7 +172,7 @@ func DecideVeto(rttVeto float64, packetLossSafety bool, yolo bool) DecisionFunc 
 			}
 
 			// Whether or not the network next route made the packet loss worse, if the buyer has packet loss safety enabled
-			if packetLossSafety && lastNextStats.PacketLoss > directStats.PacketLoss {
+			if onNNSliceCounter > 2 && packetLossSafety && lastNextStats.PacketLoss > directStats.PacketLoss {
 				// If the buyer has YouOnlyLiveOnce safety setting enabled, add that reason to the DecisionReason
 				if yolo {
 					return Decision{false, DecisionVetoPacketLoss | DecisionVetoYOLO}

--- a/routing/route_decision_test.go
+++ b/routing/route_decision_test.go
@@ -106,8 +106,10 @@ func TestDecideVeto(t *testing.T) {
 		PacketLoss: 0,
 	}
 
+	onNNSliceCounter := uint64(0)
+
 	rttVeto := float64(routing.DefaultRoutingRulesSettings.RTTVeto)
-	routeDecisionFunc := routing.DecideVeto(rttVeto, false, false)
+	routeDecisionFunc := routing.DecideVeto(onNNSliceCounter, rttVeto, false, false)
 
 	// Test if multipath is enabled
 	decision := routing.Decision{true, routing.DecisionRTTReductionMultipath}
@@ -121,23 +123,30 @@ func TestDecideVeto(t *testing.T) {
 
 	// Now test for yolo reason
 	decision.OnNetworkNext = true
-	routeDecisionFunc = routing.DecideVeto(rttVeto, false, true)
+	routeDecisionFunc = routing.DecideVeto(onNNSliceCounter, rttVeto, false, true)
 
 	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoRTT | routing.DecisionVetoYOLO}, decision)
 
-	// Now test if the route is vetoed for packet loss increases
+	// Now test that the route won't be vetoed yet for packet loss increases since it's withing the first 3 slices
 	lastNextStats.RTT = directStats.RTT
 	lastNextStats.PacketLoss = directStats.PacketLoss + 1
-	decision.OnNetworkNext = true
-	routeDecisionFunc = routing.DecideVeto(rttVeto, true, false)
+	decision = routing.Decision{OnNetworkNext: true, Reason: routing.DecisionRTTReduction}
+	routeDecisionFunc = routing.DecideVeto(onNNSliceCounter, rttVeto, true, false)
+
+	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
+	assert.Equal(t, routing.Decision{true, routing.DecisionRTTReduction}, decision)
+
+	// Now test if the route is vetoed for packet loss increases
+	onNNSliceCounter = 3
+	routeDecisionFunc = routing.DecideVeto(onNNSliceCounter, rttVeto, true, false)
 
 	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoPacketLoss}, decision)
 
 	// Now test for yolo reason
 	decision.OnNetworkNext = true
-	routeDecisionFunc = routing.DecideVeto(rttVeto, true, true)
+	routeDecisionFunc = routing.DecideVeto(onNNSliceCounter, rttVeto, true, true)
 
 	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoPacketLoss | routing.DecisionVetoYOLO}, decision)
@@ -145,7 +154,7 @@ func TestDecideVeto(t *testing.T) {
 	// Test if route isn't vetoed
 	lastNextStats.PacketLoss = directStats.PacketLoss
 	decision = routing.Decision{true, routing.DecisionNoReason}
-	routeDecisionFunc = routing.DecideVeto(rttVeto, true, true)
+	routeDecisionFunc = routing.DecideVeto(onNNSliceCounter, rttVeto, true, true)
 
 	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
 	assert.Equal(t, routing.Decision{true, routing.DecisionNoReason}, decision)
@@ -153,14 +162,14 @@ func TestDecideVeto(t *testing.T) {
 	// Test if route was changed to direct from another function, but the RTT increase was so severe that it should be vetoed
 	lastNextStats.RTT = 60
 	decision = routing.Decision{OnNetworkNext: false, Reason: routing.DecisionRTTHysteresis}
-	routeDecisionFunc = routing.DecideVeto(rttVeto, true, false)
+	routeDecisionFunc = routing.DecideVeto(onNNSliceCounter, rttVeto, true, false)
 
 	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoRTT}, decision)
 
 	// Now with yolo
 	decision = routing.Decision{OnNetworkNext: false, Reason: routing.DecisionRTTHysteresis}
-	routeDecisionFunc = routing.DecideVeto(rttVeto, true, true)
+	routeDecisionFunc = routing.DecideVeto(onNNSliceCounter, rttVeto, true, true)
 
 	decision = routeDecisionFunc(decision, routing.Stats{}, lastNextStats, directStats)
 	assert.Equal(t, routing.Decision{false, routing.DecisionVetoRTT | routing.DecisionVetoYOLO}, decision)

--- a/transport/session_update_handler_test.go
+++ b/transport/session_update_handler_test.go
@@ -2632,6 +2632,130 @@ func TestVetoYOLONoReturn(t *testing.T) {
 	validateDirectResponsePacket(t, resbuf, sessionMetrics.DirectSessions, sessionMetrics.DecisionMetrics.VetoRTTYOLO)
 }
 
+func TestEarlySlice(t *testing.T) {
+	redisServer, err := miniredis.Run()
+	assert.NoError(t, err)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+
+	sessionMetrics := metrics.EmptySessionMetrics
+	localMetrics := metrics.LocalHandler{}
+
+	decisionMetric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "decision metric"})
+	assert.NoError(t, err)
+	nextMetric, err := localMetrics.NewCounter(context.Background(), &metrics.Descriptor{ID: "route metric"})
+	assert.NoError(t, err)
+
+	sessionMetrics.DecisionMetrics.RTTReduction = decisionMetric
+	sessionMetrics.NextSessions = nextMetric
+
+	routeRuleSettings := routing.LocalRoutingRulesSettings
+	routeRuleSettings.SelectionPercentage = 100
+	db := storage.InMemory{}
+	db.AddBuyer(context.Background(), routing.Buyer{
+		PublicKey:            TestBuyersServerPublicKey,
+		RoutingRulesSettings: routeRuleSettings,
+	})
+
+	iploc := routing.LocateIPFunc(func(ip net.IP) (routing.Location, error) {
+		return routing.Location{
+			Continent: "NA",
+			Country:   "US",
+			Region:    "NY",
+			City:      "Troy",
+			Latitude:  0,
+			Longitude: 0,
+		}, nil
+	})
+
+	geoClient := routing.GeoClient{
+		RedisClient: redisClient,
+		Namespace:   "GEO_TEST",
+	}
+
+	err = geoClient.Add(1, 0, 0)
+	assert.NoError(t, err)
+
+	rp := mockRouteProvider{
+		datacenterRelays: []routing.Relay{{}},
+		routes: []routing.Route{
+			{
+				Relays: []routing.Relay{
+					{ID: 1, Addr: net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 123}, PublicKey: TestRelayPublicKey[:], MaxSessions: 3000},
+					{ID: 2, Addr: net.UDPAddr{IP: net.ParseIP("127.0.0.2"), Port: 123}, PublicKey: TestRelayPublicKey[:], MaxSessions: 3000},
+					{ID: 3, Addr: net.UDPAddr{IP: net.ParseIP("127.0.0.3"), Port: 123}, PublicKey: TestRelayPublicKey[:], MaxSessions: 3000},
+				},
+			},
+		},
+	}
+
+	addr, err := net.ResolveUDPAddr("udp", "0.0.0.0:13")
+	assert.NoError(t, err)
+
+	serverCacheEntry := transport.ServerCacheEntry{
+		Sequence: 13,
+		Server: routing.Server{
+			Addr:      *addr,
+			PublicKey: TestBuyersServerPublicKey[:],
+		},
+		Datacenter: routing.Datacenter{
+			Enabled: true,
+		},
+	}
+	serverCacheEntryData, err := serverCacheEntry.MarshalBinary()
+	assert.NoError(t, err)
+
+	err = redisServer.Set("SERVER-0-0.0.0.0:13", string(serverCacheEntryData))
+	assert.NoError(t, err)
+
+	sessionCacheEntry := transport.SessionCacheEntry{
+		SessionID:        9999,
+		Sequence:         13,
+		OnNNSliceCounter: 2,
+	}
+	sessionCacheEntryData, err := sessionCacheEntry.MarshalBinary()
+	assert.NoError(t, err)
+
+	err = redisServer.Set("SESSION-0-9999", string(sessionCacheEntryData))
+	assert.NoError(t, err)
+
+	packet := transport.SessionUpdatePacket{
+		SessionID:     9999,
+		Sequence:      14,
+		ServerAddress: net.UDPAddr{IP: net.IPv4zero, Port: 13},
+
+		NumNearRelays:       1,
+		NearRelayIDs:        []uint64{1},
+		NearRelayMinRTT:     []float32{1},
+		NearRelayMaxRTT:     []float32{1},
+		NearRelayMeanRTT:    []float32{1},
+		NearRelayJitter:     []float32{1},
+		NearRelayPacketLoss: []float32{1},
+
+		ClientAddress: net.UDPAddr{
+			IP:   net.ParseIP("0.0.0.0"),
+			Port: 1234,
+		},
+		ClientRoutePublicKey: TestBuyersClientPublicKey[:],
+
+		OnNetworkNext: true,
+		DirectMinRTT:  40,
+		NextMinRTT:    30,
+
+		NextPacketLoss: 1.0, // Should server a NN route even though we have high packet loss
+	}
+	packet.Signature = crypto.Sign(TestBuyersServerPrivateKey, packet.GetSignData())
+
+	data, err := packet.MarshalBinary()
+	assert.NoError(t, err)
+
+	var resbuf bytes.Buffer
+
+	handler := transport.SessionUpdateHandlerFunc(log.NewNopLogger(), redisClient, redisClient, 10*time.Second, &db, &rp, &iploc, &geoClient, &sessionMetrics, &billing.NoOpBiller{}, TestServerBackendPrivateKey[:], TestRouterPrivateKey[:])
+	handler(&resbuf, &transport.UDPPacket{SourceAddr: addr, Data: data})
+
+	validateNextResponsePacket(t, resbuf, packet.SessionID, packet.Sequence, 5, routing.RouteTypeNew, sessionMetrics.NextSessions, sessionMetrics.DecisionMetrics.RTTReduction)
+}
+
 func TestForceDirect(t *testing.T) {
 	t.Run("by selection percentage", func(t *testing.T) {
 		redisServer, err := miniredis.Run()


### PR DESCRIPTION
It may be the case that Rocket League players are experiencing packet loss for the first few slices on NN due to loading screen or thread contention - something beyond our control. Since Psyonix has packet loss safety on, we're vetoing any session that has packet loss. This PR will only apply the packet loss safety after the first 3 NN slices after going from direct to next.