### PR TITLE
Fix RTT Hysteresis and RTT Veto

### DIFF
--- a/routing/route_decision_test.go
+++ b/routing/route_decision_test.go
@@ -76,7 +76,7 @@ func TestDecideDowngradeRTT(t *testing.T) {
 	assert.Equal(t, routing.Decision{true, routing.DecisionNoReason}, decision)
 
 	// Now test to see if the route gets downgraded to a direct route due to RTT
-	predictedStats.RTT = directStats.RTT + rttHyteresis + 1.0
+	predictedStats.RTT = directStats.RTT - rttHyteresis + 1.0
 
 	decision = routeDecisionFunc(decision, predictedStats, routing.Stats{}, directStats)
 	assert.Equal(t, routing.Decision{false, routing.DecisionRTTHysteresis}, decision)

--- a/routing/routing_rules_settings.go
+++ b/routing/routing_rules_settings.go
@@ -87,8 +87,8 @@ var DefaultRoutingRulesSettings = RoutingRulesSettings{
 	AcceptableLatency:        -1.0,
 	RTTThreshold:             5.0,
 	RTTEpsilon:               2.0,
-	RTTHysteresis:            5.0,
-	RTTVeto:                  20.0,
+	RTTHysteresis:            -5.0,
+	RTTVeto:                  -20.0,
 	TryBeforeYouBuyMaxSlices: 3,
 	SelectionPercentage:      0,
 }
@@ -100,8 +100,8 @@ var LocalRoutingRulesSettings = RoutingRulesSettings{
 	AcceptableLatency:        -1.0,
 	RTTThreshold:             0.05,
 	RTTEpsilon:               0.1,
-	RTTHysteresis:            0.05,
-	RTTVeto:                  1.0,
+	RTTHysteresis:            -0.05,
+	RTTVeto:                  -1.0,
 	TryBeforeYouBuyMaxSlices: 3,
 	SelectionPercentage:      100,
 }


### PR DESCRIPTION
Hopped on a call with Glenn and I noticed I had my signs backwards to his expectation. This PR should address the backwards signs by always calculating improvement as direct - next and then using that value in route decisions. Should make it easier to reason about what is wrong (if anything) with the route decision logic.