### PR TITLE
next relay update --hard

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -365,6 +365,11 @@ func main() {
 	var loglines uint
 	relaylogfs.UintVar(&loglines, "n", 10, "the number of log lines to display")
 
+	relaydisablefs := flag.NewFlagSet("relay disable", flag.ExitOnError)
+
+	var hardDisable bool
+	relaydisablefs.BoolVar(&hardDisable, "hard", false, "hard disable the relay(s), killing the process immediately")
+
 	relayupdatefs := flag.NewFlagSet("relay update", flag.ExitOnError)
 
 	var updateOpts updateOptions
@@ -800,13 +805,14 @@ func main() {
 						Name:       "disable",
 						ShortUsage: "next relay disable [regex...]",
 						ShortHelp:  "Disable the specified relay(s)",
+						FlagSet:    relaydisablefs,
 						Exec: func(_ context.Context, args []string) error {
 							regexes := []string{".*"}
 							if len(args) > 0 {
 								regexes = args
 							}
 
-							disableRelays(env, rpcClient, regexes, false)
+							disableRelays(env, rpcClient, regexes, hardDisable)
 
 							return nil
 						},

--- a/cmd/next/relay.go
+++ b/cmd/next/relay.go
@@ -35,13 +35,13 @@ const (
 
 	echo "Waiting for the relay service to clean shutdown"
 
+	sudo systemctl disable relay || exit 1
+
 	sudo systemctl stop relay || exit 1
 
 	while systemctl is-active --quiet relay; do
 		sleep 1
 	done
-
-	sudo systemctl disable relay || exit 1
 
 	echo 'Relay service shutdown'
 	`
@@ -53,8 +53,9 @@ const (
 		exit
 	fi
 
-	sudo systemctl kill -s SIGKILL relay || exit 1
 	sudo systemctl disable relay || exit 1
+	sudo systemctl kill -s SIGKILL relay || exit 1
+	sudo systemctl stop relay || exit 1
 
 	echo 'Relay service shutdown hard'
 	`


### PR DESCRIPTION
Closes #811 

When the --hard flag is passed to update, systemctl sends SIGKILL to the relay to instantly terminate it in case it is stuck for whatever reason. I also found it has to still use `systemctl stop` afterwards otherwise the relay will try restarting.

Because update reused the disable function, I added the functionality through disable, so now `next relay disable` also has the --hard flag.

Lastly, I added the `next relay logs` command because I needed to check them frequently in this branch to see how the relay was shutting down. Basically grabs the output of journalctl for the specified relays. Just made it function for my needs so it's nothing special