### PR TITLE
Customer name in session tool always set to private

### DIFF
--- a/cmd/portal/public/index.html
+++ b/cmd/portal/public/index.html
@@ -667,7 +667,7 @@
                                                         </dt>
                                                         <dd v-if="!handlers.userHandler.isAnonymous()">
                                                             {{
-                                                                Array.from(allBuyers.length) > 0 ? Aray.from(allBuyers).find((buyer) => {
+                                                                Array.from(allBuyers.length) && handlers.userHandler.isAdmin() > 0 ? Array.from(allBuyers).find((buyer) => {
                                                                     return buyer.id == pages.sessionTool.meta.customer_id
                                                                 }).name || "Private" : "Private"
                                                             }}


### PR DESCRIPTION
Typo made case fail always to "Private". Luckily this was there though because I also forgot the isAdmin protection as well

Closes #995 