### PR TITLE
Cleanup PlantUML Diagrams

### DIFF
--- a/.diagrams/infra-prod.plantuml
+++ b/.diagrams/infra-prod.plantuml
@@ -1,4 +1,4 @@
-@startuml
+@startuml Infrastructure
 cloud Relays
 
 cloud Cloudflare {

--- a/.diagrams/overview.plantuml
+++ b/.diagrams/overview.plantuml
@@ -1,14 +1,17 @@
-@startuml
+@startuml Overview
 node NetworkNext {
-    database BigTable
     database BigQuery
     database Firestore
     database RedisRelays
-    database RedisSessionCache
     database RedisPortal
-    queue PubSub
-    queue Dataflow
+    database RedisCache
 
+    node Portal [
+        Portal
+
+        - RPC API
+        - Web UI
+    ]
     node RelayBackend [
         RelayBackend
 
@@ -22,12 +25,6 @@ node NetworkNext {
         - Instance2
         - InstanceN
     ]
-    node Portal [
-        Portal
-
-        - RPC API
-        - Web UI
-    ]
 }
 
 cloud Internet {
@@ -40,27 +37,26 @@ cloud Internet {
 }
 
 RelayBackend <..> Relays : Ping Stats (1s)
-RelayBackend <..> RedisRelays
-RelayBackend <..> Firestore
+RelayBackend <..> RedisRelays : Read/Write active\nRelay data
+RelayBackend <.. Firestore : Sync Relays (1s)
+RelayBackend ..> Firestore : Set Relay State
 
 GameServer <..> GameClient : Direct Route
 GameClient <..> Relays : Next Route\nHop 0
 GameServer <..> Relays : Next Route\nHop (3..5)
 ServerBackend <..> GameServer : Session Updates (10s)
-ServerBackend <.. Firestore : Syncs Buyers\n&\nDatacenters (10s)
-ServerBackend <.. RelayBackend : Syncs Route Matrix (10s)
+ServerBackend <..> GameServer : Server Updates (10s)
+ServerBackend <.. Firestore : Syncs Buyers\n&\nDatacenters (1s)
+ServerBackend <.. RelayBackend : Syncs Route Matrix (1s)
 ServerBackend <.. RedisRelays : Relays Near\nClient IP
-ServerBackend <..> RedisSessionCache
-ServerBackend ..> RedisPortal
-ServerBackend ..> PubSub : Billing Slice Entries
+ServerBackend <..> RedisCache : Read/Write active\nServer and Session\ndata
+ServerBackend ..> RedisPortal : Write Map, Session,\nand User data
 
-PubSub ..> Dataflow
-Dataflow ..> BigTable
-BigTable ..> BigQuery
+ServerBackend ..> BigQuery : Billing Slice Entries
 
-Portal <.. Firestore : Syncs Buyers\n&\nDatacenters (10s)
-Portal <.. BigQuery : Session Details\n&\nUser Sessions
-Portal <.. RedisPortal : Session Map\n&\nTop Sessions
+Portal <.. Firestore : Syncs Buyers\n&\nDatacenters (1s)
+Portal <.. RedisPortal : Read Map, Session,\nand User data
+Portal <.. RedisRelays : Relay data for\nOps Service
 Portal <..> Auth0 : User Accounts
 @enduml
 

--- a/.diagrams/relay-state.plantuml
+++ b/.diagrams/relay-state.plantuml
@@ -1,24 +1,24 @@
-@startuml
+@startuml Relay States
 Enabled : Relay is online and\ncommunicating with\nthe backend
-    Offline : Relay is operating\nbut isn't communicating\nwith the backend yet
-    Quarantined : Relay has disconnected\nfor some reason and is\nawaiting operator\napproval before going\nback online
-    Maintenance : Relay has cleanly\nshut down
-    Disabled : Relay has been\nmanually shut down
-    Decommissioned : Final state before\npermanent shutdown
+Offline : Relay is operating\nbut isn't communicating\nwith the backend yet
+Quarantined : Relay has disconnected\nfor some reason and is\nawaiting operator\napproval before going\nback online
+Maintenance : Relay has cleanly\nshut down
+Disabled : Relay has been\nmanually shut down
+Decommissioned : Final state before\npermanent shutdown
 
-    [*] --> Offline : startup
-    Offline --> Enabled : connected
-    Offline --> Disabled : `next relay disable`
-    Enabled --> Quarantined : disconnected
-    Enabled --> Maintenance : clean shutdown
-    Enabled --> Disabled : `next relay disable`
-    Maintenance --> Enabled : automatic restart
-    Maintenance --> Offline : `next relay enable`
-    Quarantined --> Offline : `next relay enable`
-    Quarantined --> Disabled : `next relay disable`
-    Maintenance --> Disabled : `next relay disable`
-    Disabled --> Offline : `next relay enable`
-    Disabled --> Decommissioned : manual only
-    Decommissioned --> [*]
+[*] --> Offline : startup
+Offline --> Enabled : connected
+Offline --> Disabled : `next relay disable`
+Enabled --> Quarantined : disconnected
+Enabled --> Maintenance : clean shutdown
+Enabled --> Disabled : `next relay disable`
+Maintenance --> Enabled : automatic restart
+Maintenance --> Offline : `next relay enable`
+Quarantined --> Offline : `next relay enable`
+Quarantined --> Disabled : `next relay disable`
+Maintenance --> Disabled : `next relay disable`
+Disabled --> Offline : `next relay enable`
+Disabled --> Decommissioned : `next relay remove`
+Decommissioned --> [*]
 @enduml
 

--- a/.diagrams/relays.plantuml
+++ b/.diagrams/relays.plantuml
@@ -1,4 +1,4 @@
-@startuml
+@startuml Relays
 node NetworkNext {
     node ServerBackend
 }

--- a/.diagrams/storage_entities.plantuml
+++ b/.diagrams/storage_entities.plantuml
@@ -1,0 +1,70 @@
+@startuml Entities
+package Entities {
+    node Customer {
+        object Buyer
+        object Seller
+    }
+
+    object Relay
+    object Datacenter
+    object RouteShader
+}
+
+
+Buyer *-- RouteShader
+
+Buyer : - ID
+Buyer : - Name
+Buyer : - Domain
+Buyer : - Active
+Buyer : - Live
+Buyer : - PublicKey
+Buyer : - RouteShader (RoutingRulesSettings)
+
+Seller : - ID
+Seller : - Name
+Seller : - IngressPriceCents
+Seller : - EgressPriceCents
+
+Relay : - ID
+Relay : - Name
+Relay : - Addr
+Relay : - PublicKey
+Relay : - Seller
+Relay : - Datacenter
+Relay : - NICSpeedMbps
+Relay : - IncludedBandwidthGB
+Relay : - State
+Relay : - ManagementAddr
+Relay : - SSHUser
+Relay : - SSHPort
+Relay : - MaxSessions
+Relay : - UpdateKey
+Relay : - FirestoreID
+
+Datacenter : - ID
+Datacenter : - Name
+Datacenter : - AliasName
+Datacenter : - Enabled
+Datacenter : - Location
+
+RouteShader : - EnvelopeKbpsUp
+RouteShader : - EnvelopeKbpsDown
+RouteShader : - Mode
+RouteShader : - MaxCentsPerGB
+RouteShader : - AcceptableLatency
+RouteShader : - RTTEpsilon (rttRouteSwtich)
+RouteShader : - RTTThreshold
+RouteShader : - RTTHysteresis
+RouteShader : - RTTVeto
+RouteShader : - EnableYouOnlyLiveOnce
+RouteShader : - EnablePacketLossSafety
+RouteShader : - EnableMultipathForPacketLoss
+RouteShader : - EnableMultipathForJitter
+RouteShader : - EnableMultipathForRTT
+RouteShader : - EnableABTest
+RouteShader : - EnableTryBeforeYouBuy
+RouteShader : - TryBeforeYouBuyMaxSlices
+RouteShader : - SelectionPercentage
+@enduml
+


### PR DESCRIPTION
In preparation for my talks tomorrow, I cleaned up some of the PlantUML diagrams and added one for firestore entities so that we can go over them. I left the infrastructure diagram as is even though it's slightly out of date (VMs have been changed, dataflow is no longer used, etc.) so that if someone wants to familiarize themselves more with the PlantUML diagrams they can go in and update it (maybe Andrew since he'll be working with Glenn to get dev to match prod?).