### PR TITLE
Prod bucket name change

### DIFF
--- a/.diagrams/infra-prod.plantuml
+++ b/.diagrams/infra-prod.plantuml
@@ -78,7 +78,7 @@ node Firestore {
 }
 
 node Storage {
-    component "us.artifacts.network-next-v3-prod.appspot.com" {
+    component "prod_artifacts" {
         artifact "portal.prod.tar.gz"
         artifact "relay_backend.prod.tar.gz"
         artifact "server_backend.prod.tar.gz"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CURRENT_DIR = $(shell pwd -P)
 DEPLOY_DIR = ./deploy
 DIST_DIR = ./dist
 ARTIFACT_BUCKET = gs://artifacts.network-next-v3-dev.appspot.com
-ARTIFACT_BUCKET_PROD = gs://us.artifacts.network-next-v3-prod.appspot.com
+ARTIFACT_BUCKET_PROD = gs://prod_artifacts
 SYSTEMD_SERVICE_FILE = app.service
 
 COST_FILE = $(DIST_DIR)/cost.bin

--- a/cmd/next/env.go
+++ b/cmd/next/env.go
@@ -20,7 +20,7 @@ const (
 	RouterPublicKeyProd  = "SS55dEl9nTSnVVDrqwPeqRv/YcYOZZLXCWTpNBIyX0Y="
 
 	RelayArtifactURLDev  = "https://storage.googleapis.com/artifacts.network-next-v3-dev.appspot.com/relay.dev.tar.gz"
-	RelayArtifactURLProd = "https://storage.googleapis.com/us.artifacts.network-next-v3-prod.appspot.com/relay.prod.tar.gz"
+	RelayArtifactURLProd = "https://storage.googleapis.com/prod_artifacts/relay.prod.tar.gz"
 
 	RelayBackendHostnameLocal = "localhost"
 	RelayBackendHostnameDev   = "relay_backend.dev.networknext.com"

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -64,10 +64,10 @@ GCP Project: `network-next-v3-prod`
 
 ### GCP Artifacts
 
-- portal: `gs://us.artifacts.network-next-v3-prod.appspot.com/portal.dev.tar.gz`
-- relay backend: `gs://us.artifacts.network-next-v3-prod.appspot.com/relay_backend.dev.tar.gz`
-- server backend: `gs://us.artifacts.network-next-v3-prod.appspot.com/server_backend.dev.tar.gz`
-- relay: `gs://us.artifacts.network-next-v3-prod.appspot.com/relay.prod.tar.gz`
+- portal: `gs://prod_artifacts/portal.dev.tar.gz`
+- relay backend: `gs://prod_artifacts/relay_backend.dev.tar.gz`
+- server backend: `gs://prod_artifacts/server_backend.dev.tar.gz`
+- relay: `gs://prod_artifacts/relay.prod.tar.gz`
 
 ### Domains
 


### PR DESCRIPTION
changes the references of `us.artifacts.network-next-v3-prod.appspot.com` to the new bucket `prod_artifacts`