### PR TITLE
Update VM Startup Script

### DIFF
--- a/deploy/vm-startup.sh
+++ b/deploy/vm-startup.sh
@@ -4,7 +4,6 @@ apt-get install libsodium23
 
 mkdir -p /app
 cd /app
-gsutil cp gs://artifacts.network-next-v3-dev.appspot.com/GeoLite2-City.mmdb .
-gsutil cp gs://artifacts.network-next-v3-dev.appspot.com/vm-update-app.sh .
+gsutil cp gs://prod_artifacts/vm-update-app.sh .
 chmod +x vm-update-app.sh
-./vm-update-app.sh -a gs://artifacts.network-next-v3-dev.appspot.com/ARTIFACT.tar.gz
+./vm-update-app.sh -a gs://prod_artifacts/ARTIFACT.tar.gz


### PR DESCRIPTION
This script is manually set on an instance template for VMs, but this is meant to be a reference copy to be used in prod and dev.

When the original bucket was renamed and cleaned up this current script would fail because it could not pull the old Maxmind file from Storage so prod deploys would fail. Dev was fine since these buckets and files we left untouched.