### PR TITLE
Artifact Version Metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,12 +381,14 @@ build-portal-prod-artifact: build-portal ## builds the portal with the right env
 publish-portal-artifact: ## publishes the portal artifact to GCP Storage with gsutil
 	@printf "Publishing portal artifact... \n\n"
 	@gsutil cp $(DIST_DIR)/portal.dev.tar.gz $(ARTIFACT_BUCKET)/portal.dev.tar.gz
+	@gsutil setmeta -h "BuildTime:$(TIMESTAMP)" -h "SHA:$(SHA)" -h "Release:$(RELEASE)" $(ARTIFACT_BUCKET)/portal.dev.tar.gz
 	@printf "done\n"
 
 .PHONY: publish-portal-prod-artifact
 publish-portal-prod-artifact: ## publishes the portal artifact to GCP Storage with gsutil
 	@printf "Publishing portal artifact... \n\n"
 	@gsutil cp $(DIST_DIR)/portal.prod.tar.gz $(ARTIFACT_BUCKET_PROD)/portal.prod.tar.gz
+	@gsutil setmeta -h "BuildTime:$(TIMESTAMP)" -h "SHA:$(SHA)" -h "Release:$(RELEASE)" $(ARTIFACT_BUCKET_PROD)/portal.dev.tar.gz
 	@printf "done\n"
 
 .PHONY: deploy-portal
@@ -424,12 +426,14 @@ build-relay-backend-prod-artifact: build-relay-backend ## builds the relay backe
 publish-relay-backend-artifact: ## publishes the relay backend artifact to GCP Storage with gsutil
 	@printf "Publishing relay backend artifact... \n\n"
 	@gsutil cp $(DIST_DIR)/relay_backend.dev.tar.gz $(ARTIFACT_BUCKET)/relay_backend.dev.tar.gz
+	@gsutil setmeta -h "BuildTime:$(TIMESTAMP)" -h "SHA:$(SHA)" -h "Release:$(RELEASE)" $(ARTIFACT_BUCKET)/relay_backend.dev.tar.gz
 	@printf "done\n"
 
 .PHONY: publish-relay-backend-artifact
 publish-relay-backend-prod-artifact: ## publishes the relay backend artifact to GCP Storage with gsutil
 	@printf "Publishing relay backend artifact... \n\n"
 	@gsutil cp $(DIST_DIR)/relay_backend.prod.tar.gz $(ARTIFACT_BUCKET_PROD)/relay_backend.prod.tar.gz
+	@gsutil setmeta -h "BuildTime:$(TIMESTAMP)" -h "SHA:$(SHA)" -h "Release:$(RELEASE)" $(ARTIFACT_BUCKET_PROD)/relay_backend.dev.tar.gz
 	@printf "done\n"
 
 .PHONY: deploy-relay-backend
@@ -467,12 +471,14 @@ build-server-backend-prod-artifact: build-server-backend ## builds the server ba
 publish-server-backend-artifact: ## publishes the server backend artifact to GCP Storage with gsutil
 	@printf "Publishing server backend artifact... \n\n"
 	@gsutil cp $(DIST_DIR)/server_backend.dev.tar.gz $(ARTIFACT_BUCKET)/server_backend.dev.tar.gz
+	@gsutil setmeta -h "BuildTime:$(TIMESTAMP)" -h "SHA:$(SHA)" -h "Release:$(RELEASE)" $(ARTIFACT_BUCKET)/server_backend.dev.tar.gz
 	@printf "done\n"
 
 .PHONY: publish-server-backend-artifact
 publish-server-backend-prod-artifact: ## publishes the server backend artifact to GCP Storage with gsutil
 	@printf "Publishing server backend artifact... \n\n"
 	@gsutil cp $(DIST_DIR)/server_backend.prod.tar.gz $(ARTIFACT_BUCKET_PROD)/server_backend.prod.tar.gz
+	@gsutil setmeta -h "BuildTime:$(TIMESTAMP)" -h "SHA:$(SHA)" -h "Release:$(RELEASE)" $(ARTIFACT_BUCKET_PROD)/server_backend.dev.tar.gz
 	@printf "done\n"
 
 .PHONY: deploy-server-backend


### PR DESCRIPTION
Closes #1080

Rather than make a new file just leverage the existing tech for adding metadata to Storage files. You can't click and open text files in GCP anyway without completely downloading them. Using metadata lets you stay in the Storage GUI and see these values.