### PR TITLE
Transpose the output of <next shader> and search by buyer name

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -1157,11 +1157,11 @@ func main() {
 				ShortHelp:  "Retrieve route shader settings for the specified buyer",
 				Exec: func(_ context.Context, args []string) error {
 					if len(args) == 0 {
-						log.Fatal("No buyer ID provided.\nUsage:\nnext shader <buyer ID>\nbuyer ID: the buyer's ID\nFor a list of buyers, use next buyers")
+						log.Fatal("No buyer name or substring provided.\nUsage:\nnext shader <buyer name or substring>\n")
 					}
 
 					// Get the buyer's route shader
-					// routingRulesSettings(rpcClient, env, args[0])
+					routingRulesSettings(rpcClient, env, args[0])
 					return nil
 				},
 				Subcommands: []*ffcli.Command{
@@ -1214,7 +1214,7 @@ func main() {
 							}
 
 							// Get the buyer's route shader
-							routingRulesSettingsById(rpcClient, env, args[0])
+							routingRulesSettingsByID(rpcClient, env, args[0])
 							return nil
 						},
 					},


### PR DESCRIPTION
Case-insensitive search by buyer name is now the default:

```
14:36 $ ./next shader liquid

 Routing rules for Liquid Bit:

┌──────────────────────────────┬───────┐
│ RoutingRuleSetting           │ Value │
├──────────────────────────────┼───────┤
│ EnvelopeKbpsUp               │ 320   │
│ EnvelopeKbpsDown             │ 500   │
│ Mode                         │ 0     │
│ MaxCentsPerGB                │ 25    │
│ RTTEpsilon                   │ 5     │
│ RTTThreshold                 │ 0     │
│ RTTHysteresis                │ -1    │
│ RTTVeto                      │ -1    │
│ EnableYouOnlyLiveOnce        │ true  │
│ EnablePacketLossSafety       │ true  │
│ EnableMultipathForPacketLoss │ false │
│ EnableMultipathForJitter     │ false │
│ EnableMultipathForRTT        │ false │
│ EnableABTest                 │ false │
│ EnableTryBeforeYouBuy        │ true  │
│ TryBeforeYouBuyMaxSlices     │ 3     │
│ SelectionPercentage          │ 100   │
└──────────────────────────────┴───────┘
```

I added an `id` subcommand to search by id:

```
10:31 $ ./next shader id f0d3cc73dca0bc89

 Routing rules for Liquid Bit:

┌──────────────────────────────┬───────┐
│ RoutingRuleSetting           │ Value │
├──────────────────────────────┼───────┤
│ EnvelopeKbpsUp               │ 320   │
│ EnvelopeKbpsDown             │ 500   │
│ Mode                         │ 0     │
│ MaxCentsPerGB                │ 25    │
│ RTTEpsilon                   │ 5     │
│ RTTThreshold                 │ 0     │
│ RTTHysteresis                │ -1    │
│ RTTVeto                      │ -1    │
│ EnableYouOnlyLiveOnce        │ true  │
│ EnablePacketLossSafety       │ true  │
│ EnableMultipathForPacketLoss │ false │
│ EnableMultipathForJitter     │ false │
│ EnableMultipathForRTT        │ false │
│ EnableABTest                 │ false │
│ EnableTryBeforeYouBuy        │ true  │
│ TryBeforeYouBuyMaxSlices     │ 3     │
│ SelectionPercentage          │ 100   │
└──────────────────────────────┴───────┘
```


Closes #513 .
Closes #514 .