### PR TITLE
next relay update for local dev

### DIFF
--- a/cmd/next/relay.go
+++ b/cmd/next/relay.go
@@ -264,16 +264,23 @@ func updateRelays(env Environment, rpcClient jsonrpc.RPCClient, regexes []string
 				continue
 			}
 
+			var publicKeyB64 string
+			var privateKeyB64 string
+
 			// Create the public and private keys for the relay
-			publicKey, privateKey, err := box.GenerateKey(rand.Reader)
-
-			if err != nil {
-				fmt.Println("could not generate public private keypair")
-				continue
+			if env.Name == "local" {
+				// if local, just reuse the ones from the environment
+				publicKeyB64 = os.Getenv("RELAY_PUBLIC_KEY")
+				privateKeyB64 = os.Getenv("RELAY_PRIVATE_KEY")
+			} else {
+				publicKey, privateKey, err := box.GenerateKey(rand.Reader)
+				if err != nil {
+					fmt.Println("could not generate public private keypair")
+					continue
+				}
+				publicKeyB64 = base64.StdEncoding.EncodeToString(publicKey[:])
+				privateKeyB64 = base64.StdEncoding.EncodeToString(privateKey[:])
 			}
-
-			publicKeyB64 := base64.StdEncoding.EncodeToString(publicKey[:])
-			privateKeyB64 := base64.StdEncoding.EncodeToString(privateKey[:])
 
 			// Create the environment
 			{


### PR DESCRIPTION
While researching ebpf I needed to spin up a virtualbox VM and turn that into a relay. I was using next relay update to do it and realized that because we rotate the public/private keys at that point, and because everything is in memory for relays, the relay will fail the crytpo check because the relay backend's in memory relay is out of sync with the portals version. 

All that I did was check if the env is local, and if so reuse the public/private keys from the env vars so that the desync doesn't occur