### PR TITLE
Reversed sorting when all sessions are direct

### DIFF
--- a/transport/jsonrpc/buyer.go
+++ b/transport/jsonrpc/buyer.go
@@ -373,9 +373,14 @@ func (s *BuyersService) TopSessions(r *http.Request, args *TopSessionsArgs, repl
 		reply.Sessions = reply.Sessions[:TopSessionsSize]
 	}
 
+	allDirectSessions := len(nextSessions) == 0
+
 	sort.SliceStable(reply.Sessions, func(i int, j int) bool {
 		firstSession := reply.Sessions[i]
 		secondSession := reply.Sessions[j]
+		if allDirectSessions {
+			return firstSession.DirectRTT > secondSession.DirectRTT
+		}
 		if firstSession.OnNetworkNext && secondSession.OnNetworkNext {
 			return firstSession.DeltaRTT > secondSession.DeltaRTT
 		}


### PR DESCRIPTION
When all sessions are direct in the top sessions, reverse the sort order.

Closes #1109 