### PR TITLE
Truncate next sessions ISP to 32 characters

### DIFF
--- a/cmd/next/sessions.go
+++ b/cmd/next/sessions.go
@@ -295,7 +295,7 @@ func sessions(rpcClient jsonrpc.RPCClient, env Environment, sessionID string, se
 		}{
 			ID:          session.ID,
 			UserHash:    session.UserHash,
-			ISP:         session.Location.ISP,
+			ISP:         fmt.Sprintf("%.32s", session.Location.ISP),
 			Datacenter:  session.Datacenter,
 			DirectRTT:   fmt.Sprintf("%.02f", session.DirectRTT),
 			NextRTT:     fmt.Sprintf("%.02f", session.NextRTT),


### PR DESCRIPTION
Truncate all ISP names to 32 characters when printed with ./next sessions.

Closes #1058 