### PR TITLE
Forgot minZoom value reintroducing one of the dreaded zoom bugs

### DIFF
--- a/cmd/portal/public/js/portal.js
+++ b/cmd/portal/public/js/portal.js
@@ -179,8 +179,9 @@ MapHandler = {
     longitude: 0,
     zoom: 2,
     pitch: 0,
-    bearing: 0
-  },
+    bearing: 0,
+		minZoom: 2,
+	},
 	mapCountLoop: null,
 	mapInstance: null,
 	deckGlInstance: null,
@@ -316,7 +317,8 @@ MapHandler = {
 								center: [viewState.longitude, viewState.latitude],
 								zoom: viewState.zoom,
 								bearing: viewState.bearing,
-								pitch: viewState.pitch
+								pitch: viewState.pitch,
+								minZoom: 2,
 							});
 						},
 						layers: layers
@@ -684,7 +686,8 @@ WorkspaceHandler = {
 									latitude: meta.location.latitude,
 									minZoom: 2,
 									bearing: 0,
-									pitch: 0
+									pitch: 0,
+									minZoom: 2,
 								},
 								container: 'session-tool-map',
 								controller: {


### PR DESCRIPTION
If minZoom isn't set, the map can zoom out beyond the size of the map layer which causes it to scroll instead of zoom any further. Adding in the minZoom property fixes this.

This could potentially be caught going forward in the Vue rewrite because we will have to play by the rules of third party libs enforced by the compiler where here these things will just happen and we will only know when it breaks something because there is nothing keeping us in check.