### PR TITLE
Add history buffer to total session counts

### DIFF
--- a/cmd/portal/public/js/portal.js
+++ b/cmd/portal/public/js/portal.js
@@ -234,18 +234,27 @@ MapHandler = {
 				let direct = response.direct
 				let next = response.next
 
-				this.totalDirectSessions[this.totalSessionCountCalls % 32] = direct
-				this.totalNextSessions[this.totalSessionCountCalls % 32] = next
+				const isDev = window.location.hostname == 'portal-dev.networknext.com';
+				if (!isDev) {
+					this.totalDirectSessions[this.totalSessionCountCalls % 32] = direct
+					this.totalNextSessions[this.totalSessionCountCalls % 32] = next
 
-				let maxDirectTotal = Math.max(...this.totalDirectSessions)
-				let maxNextTotal = Math.max(...this.totalNextSessions)
+					let maxDirectTotal = Math.max(...this.totalDirectSessions)
+					let maxNextTotal = Math.max(...this.totalNextSessions)
 
+					Object.assign(rootComponent.$data, {
+						direct: maxDirectTotal,
+						mapSessions: maxDirectTotal + maxNextTotal,
+						onNN: maxNextTotal,
+					});
+					this.totalSessionCountCalls++
+					return
+				}
 				Object.assign(rootComponent.$data, {
-					direct: maxDirectTotal,
-					mapSessions: maxDirectTotal + maxNextTotal,
-					onNN: maxNextTotal,
+					direct: direct,
+					mapSessions: direct + next,
+					onNN: next,
 				});
-				this.totalSessionCountCalls++
 			})
 			.catch((error) => {
 				console.log("Something went wrong fetching map point totals");


### PR DESCRIPTION
The session counts update every second so they fluctuate a lot. Added a history buffer to store 32 different counts and then take the max of those 32 to get a more consistent number. This will only affect prod and not dev.

Closes #1153 