### PR TITLE
Nullable Next Stats

### DIFF
--- a/billing/googlebigquery.go
+++ b/billing/googlebigquery.go
@@ -84,9 +84,13 @@ func (entry *BillingEntry) Save() (map[string]bigquery.Value, string, error) {
 	e["directJitter"] = entry.DirectJitter
 	e["directPacketLoss"] = entry.DirectPacketLoss
 	e["next"] = entry.Next
-	e["nextRTT"] = entry.NextRTT
-	e["nextJitter"] = entry.NextJitter
-	e["nextPacketLoss"] = entry.NextPacketLoss
+
+	if entry.Next {
+		e["nextRTT"] = entry.NextRTT
+		e["nextJitter"] = entry.NextJitter
+		e["nextPacketLoss"] = entry.NextPacketLoss
+	}
+
 	e["totalPrice"] = int(entry.TotalPrice)
 
 	if entry.ClientToServerPacketsLost > 0 {


### PR DESCRIPTION
Closes #1176. Changed the code to only publish next stats if on a network next route. I've already changed the billing schema in BigQuery for `nextRTT`, `nextJitter`, and `nextPacketLoss` from `REQUIRED` to `NULLABLE`, so this PR can be merged in whenever.