### PR TITLE
Disable tilt and rotate

### DIFF
--- a/cmd/portal/public/js/portal.js
+++ b/cmd/portal/public/js/portal.js
@@ -714,7 +714,8 @@ WorkspaceHandler = {
 								container: 'session-tool-map',
 								controller: {
 									dragPan: false,
-									dragRotate: false
+									dragRotate: false,
+									dragTilt: false
 								},
 								layers: [sessionLocationLayer],
 							});


### PR DESCRIPTION
Didn't even realize this was a feature but I disabled dragTilt and dragRotate in the map controller objects for the session map and session tool map.

Closes #1231 