### PR TITLE
Temporary way to turn off Vue devtools on production

### DIFF
--- a/cmd/portal/public/index.html
+++ b/cmd/portal/public/index.html
@@ -1325,9 +1325,10 @@
         <script src="./js/choices/scripts/choices.js"></script>
         <script src="./js/portal.js"></script>
         <script>
-            /* Vue.config.devtools = false
-            Vue.config.debug = false
-            Vue.config.silent = true */
+            const isProd = window.location.hostname == 'portal.networknext.com';
+            Vue.config.devtools = !isProd
+            Vue.config.debug = !isProd
+            Vue.config.silent = isProd
             Sentry.init({ dsn: 'https://e24b8397eac44e1eb7ac090b5492d29e@o382503.ingest.sentry.io/5211452' });
             window.onload = async () => {
                 AuthHandler.init();


### PR DESCRIPTION
This a rough way of turning off the vue dev tools for production. This will be removed and updated in the Vue rewrite when we switch to an actual build system.