### PR TITLE
Optimize Resolve Relay

### DIFF
--- a/routing/cost_matrix.go
+++ b/routing/cost_matrix.go
@@ -403,6 +403,10 @@ func (m *CostMatrix) Optimize(routes *RouteMatrix, thresholdRTT int32) error {
 	routes.RelaySessionCounts = m.RelaySessionCounts
 	routes.RelayMaxSessionCounts = m.RelayMaxSessionCounts
 
+	if err := routes.UpdateRelayAddressCache(); err != nil {
+		return err
+	}
+
 	type Indirect struct {
 		relay uint64
 		rtt   int32
@@ -660,7 +664,7 @@ func (m *CostMatrix) Size() uint64 {
 	length += numRelays*uint64(MaxRelayAddressLength+crypto.KeySize) + 4
 
 	// allocation for relay lat and longs
-	length += numRelays*8*2
+	length += numRelays * 8 * 2
 
 	for _, v := range m.DatacenterRelays {
 		// datacenter id + number of relays for that datacenter + allocation for all of those relay ids


### PR DESCRIPTION
Took out the relay address parsing from ResolveRelay() since updating the relay address cache already does this. That way the function can just use the relay address cache which makes it faster.