### PR TITLE
Remove "DirectStats" from routing.Route

### DIFF
--- a/cmd/next/routes.go
+++ b/cmd/next/routes.go
@@ -27,8 +27,7 @@ func routes(rpcClient jsonrpc.RPCClient, env Environment, srcrelays []string, de
 	}
 
 	for _, route := range reply.Routes {
-		fmt.Printf("Next RTT(%v) ", route.Stats.RTT)
-		fmt.Printf("Direct RTT(%v) ", route.DirectStats.RTT)
+		fmt.Printf("RTT(%v) ", route.Stats.RTT)
 		for _, relay := range route.Relays {
 			fmt.Print(relay.Name, " ")
 		}

--- a/routing/route.go
+++ b/routing/route.go
@@ -8,19 +8,14 @@ import (
 )
 
 type Route struct {
-	Relays      []Relay `json:"relays"`
-	Stats       Stats   `json:"stats"`
-	DirectStats Stats   `json:"direct_stats"`
+	Relays []Relay `json:"relays"`
+	Stats  Stats   `json:"stats"`
 }
 
 func (r Route) String() string {
 	var sb strings.Builder
-	sb.WriteString("next_stats=")
+	sb.WriteString("stats=")
 	sb.WriteString(r.Stats.String())
-	sb.WriteString(" ")
-
-	sb.WriteString("direct_stats=")
-	sb.WriteString(r.DirectStats.String())
 	sb.WriteString(" ")
 
 	sb.WriteString("hash=")

--- a/routing/route_matrix.go
+++ b/routing/route_matrix.go
@@ -288,9 +288,6 @@ func (m *RouteMatrix) FillRoutes(routes []Route, routeIndex *int, fromCost int, 
 			Stats: Stats{
 				RTT: float64(fromCost + int(m.Entries[entryIndex].RouteRTT[i])),
 			},
-			DirectStats: Stats{
-				RTT: float64(fromCost + int(m.Entries[entryIndex].DirectRTT)),
-			},
 		}
 
 		if *routeIndex >= len(routes) {


### PR DESCRIPTION
It's a confusing field that we don't need. On multiple occasions it's been confused with the direct stats for client <-> server, but in reality it's the stats for the direct route between two relays. We don't use these stats for anything in the backend so it's better to just remove it and prevent the confusion.