### PR TITLE
Added datacenter found and 'neither found' tests

### DIFF
--- a/transport/server_init_handler_test.go
+++ b/transport/server_init_handler_test.go
@@ -85,10 +85,9 @@ func TestServerInitDatacenterMaps(t *testing.T) {
 		}
 
 		handler := transport.ServerInitHandlerFunc(&serverInitParams)
-		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
+		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: *addr, Data: data})
 
 		assert.Equal(t, 0.0, initMetrics.ErrorMetrics.DatacenterNotFound.Value())
-
 
 	})
 
@@ -155,7 +154,7 @@ func TestServerInitDatacenterMaps(t *testing.T) {
 		}
 
 		handler := transport.ServerInitHandlerFunc(&serverInitParams)
-		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
+		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: *addr, Data: data})
 
 		assert.Equal(t, 0.0, initMetrics.ErrorMetrics.DatacenterNotFound.Value())
 	})
@@ -254,7 +253,7 @@ func TestServerInitHandlerFunc(t *testing.T) {
 		}
 
 		handler := transport.ServerInitHandlerFunc(&serverInitParms)
-		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: []byte("this is not a proper packet")})
+		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: *addr, Data: []byte("this is not a proper packet")})
 
 		assert.Equal(t, 1.0, initMetrics.ErrorMetrics.ReadPacketFailure.Value())
 	})
@@ -300,7 +299,7 @@ func TestServerInitHandlerFunc(t *testing.T) {
 		}
 
 		handler := transport.ServerInitHandlerFunc(&serverInitParms)
-		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
+		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: *addr, Data: data})
 
 		assert.Equal(t, 1.0, initMetrics.ErrorMetrics.DatacenterNotFound.Value())
 	})

--- a/transport/server_update_handler_test.go
+++ b/transport/server_update_handler_test.go
@@ -172,7 +172,7 @@ func TestServerUpdateDatacenterMaps(t *testing.T) {
 		}
 
 		handler := transport.ServerUpdateHandlerFunc(&serverUpdateParams)
-		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
+		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: *addr, Data: data})
 
 		assert.Equal(t, 0.0, updateMetrics.ErrorMetrics.DatacenterNotFound.Value())
 
@@ -236,7 +236,7 @@ func TestServerUpdateDatacenterMaps(t *testing.T) {
 
 		serverMap := transport.NewServerMap()
 
-    serverUpdateParams := transport.ServerUpdateParams{
+		serverUpdateParams := transport.ServerUpdateParams{
 			Logger:    log.NewNopLogger(),
 			Storer:    &db,
 			Metrics:   &updateMetrics,
@@ -245,7 +245,7 @@ func TestServerUpdateDatacenterMaps(t *testing.T) {
 		}
 
 		handler := transport.ServerUpdateHandlerFunc(&serverUpdateParams)
-		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
+		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: *addr, Data: data})
 
 		assert.Equal(t, 0.0, updateMetrics.ErrorMetrics.DatacenterNotFound.Value())
 	})
@@ -317,7 +317,7 @@ func TestServerUpdateDatacenterMaps(t *testing.T) {
 		}
 
 		handler := transport.ServerUpdateHandlerFunc(&serverUpdateParams)
-		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: addr, Data: data})
+		handler(&bytes.Buffer{}, &transport.UDPPacket{SourceAddr: *addr, Data: data})
 
 		assert.Equal(t, 1.0, updateMetrics.ErrorMetrics.DatacenterNotFound.Value())
 	})


### PR DESCRIPTION
There are 3 possible outcomes during datacenter checks in _ServerUpdateHandlerFunc()_ and _ServerInitHandlerFunc()_:

* datacenter found, alias not checked
* datacenter not found, alias found
* datacenter not found, alias not found

This PR adds tests for the 1<sup>st</sup> and 3<sup>rd</sup> bullets. All 3 are now covered.