### PR TITLE
Track unknown datacenters

### DIFF
--- a/cmd/server_backend/server_backend.go
+++ b/cmd/server_backend/server_backend.go
@@ -583,6 +583,15 @@ func main() {
 	serverUpdateCounters := &transport.ServerUpdateCounters{}
 	sessionUpdateCounters := &transport.SessionUpdateCounters{}
 
+	// Initialize the unknown datacenter map
+	unknownDatacenters := transport.NewUnknownDatacenters()
+	go func() {
+		timeout := time.Minute
+		frequency := time.Millisecond * 10
+		ticker := time.NewTicker(frequency)
+		unknownDatacenters.TimeoutLoop(ctx, timeout, ticker.C)
+	}()
+
 	// Setup the stats print routine
 	{
 		memoryUsed := func() float64 {
@@ -613,6 +622,13 @@ func main() {
 				fmt.Printf("%d long server updates\n", atomic.LoadUint64(&serverUpdateCounters.LongDuration))
 				fmt.Printf("%d long session updates\n", atomic.LoadUint64(&sessionUpdateCounters.LongDuration))
 				fmt.Printf("%d long route matrix updates\n", atomic.LoadUint64(&longRouteMatrixUpdates))
+
+				unknownDatacentersLength := unknownDatacenters.Length()
+				fmt.Printf("%d unknown datacenters\n", unknownDatacentersLength)
+				if unknownDatacentersLength > 0 {
+					fmt.Printf("unknown datacenters: %v\n", unknownDatacenters.GetUnknownDatacenters())
+				}
+
 				fmt.Printf("-----------------------------\n")
 
 				time.Sleep(time.Second)
@@ -623,19 +639,21 @@ func main() {
 	// Start UDP server
 	{
 		serverInitConfig := &transport.ServerInitParams{
-			ServerPrivateKey: serverPrivateKey,
-			Storer:           db,
-			Metrics:          serverInitMetrics,
-			Logger:           logger,
-			Counters:         serverInitCounters,
+			ServerPrivateKey:   serverPrivateKey,
+			Storer:             db,
+			Metrics:            serverInitMetrics,
+			Logger:             logger,
+			Counters:           serverInitCounters,
+			UnknownDatacenters: unknownDatacenters,
 		}
 
 		serverUpdateConfig := &transport.ServerUpdateParams{
-			Storer:    db,
-			Metrics:   serverUpdateMetrics,
-			Logger:    logger,
-			ServerMap: serverMap,
-			Counters:  serverUpdateCounters,
+			Storer:             db,
+			Metrics:            serverUpdateMetrics,
+			Logger:             logger,
+			ServerMap:          serverMap,
+			Counters:           serverUpdateCounters,
+			UnknownDatacenters: unknownDatacenters,
 		}
 
 		sessionUpdateConfig := &transport.SessionUpdateParams{

--- a/transport/server_init_handler_test.go
+++ b/transport/server_init_handler_test.go
@@ -292,10 +292,11 @@ func TestServerInitHandlerFunc(t *testing.T) {
 		assert.NoError(t, err)
 
 		serverInitParms := transport.ServerInitParams{
-			Logger:   log.NewNopLogger(),
-			Storer:   &db,
-			Metrics:  &initMetrics,
-			Counters: &serverInitCounters,
+			Logger:             log.NewNopLogger(),
+			Storer:             &db,
+			Metrics:            &initMetrics,
+			Counters:           &serverInitCounters,
+			UnknownDatacenters: transport.NewUnknownDatacenters(),
 		}
 
 		handler := transport.ServerInitHandlerFunc(&serverInitParms)

--- a/transport/server_update_handler_test.go
+++ b/transport/server_update_handler_test.go
@@ -309,11 +309,12 @@ func TestServerUpdateDatacenterMaps(t *testing.T) {
 		serverMap := transport.NewServerMap()
 
 		serverUpdateParams := transport.ServerUpdateParams{
-			Logger:    log.NewNopLogger(),
-			Storer:    &db,
-			Metrics:   &updateMetrics,
-			Counters:  &serverUpdateCounters,
-			ServerMap: serverMap,
+			Logger:             log.NewNopLogger(),
+			Storer:             &db,
+			Metrics:            &updateMetrics,
+			Counters:           &serverUpdateCounters,
+			ServerMap:          serverMap,
+			UnknownDatacenters: transport.NewUnknownDatacenters(),
 		}
 
 		handler := transport.ServerUpdateHandlerFunc(&serverUpdateParams)

--- a/transport/unknown_datacenters.go
+++ b/transport/unknown_datacenters.go
@@ -1,0 +1,80 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+type UnknownDatacenters struct {
+	unknownDatacentersMap map[uint64]time.Time
+	mutex                 sync.Mutex
+}
+
+func NewUnknownDatacenters() *UnknownDatacenters {
+	return &UnknownDatacenters{
+		unknownDatacentersMap: make(map[uint64]time.Time),
+	}
+}
+
+func (ud *UnknownDatacenters) Add(datacenterID uint64) {
+	ud.mutex.Lock()
+	defer ud.mutex.Unlock()
+
+	ud.unknownDatacentersMap[datacenterID] = time.Now()
+}
+
+func (ud *UnknownDatacenters) Length() int {
+	ud.mutex.Lock()
+	defer ud.mutex.Unlock()
+
+	return len(ud.unknownDatacentersMap)
+}
+
+func (ud *UnknownDatacenters) GetUnknownDatacenters() []string {
+	ud.mutex.Lock()
+
+	unknownDatacenters := make([]string, len(ud.unknownDatacentersMap))
+
+	var i int
+	for key := range ud.unknownDatacentersMap {
+		unknownDatacenters[i] = fmt.Sprintf("%016x", key)
+		i++
+	}
+
+	ud.mutex.Unlock()
+
+	sort.Slice(unknownDatacenters, func(i, j int) bool {
+		return unknownDatacenters[i] < unknownDatacenters[j]
+	})
+
+	return unknownDatacenters
+}
+
+func (ud *UnknownDatacenters) TimeoutLoop(ctx context.Context, timeout time.Duration, c <-chan time.Time) {
+	for {
+		select {
+		case <-c:
+			ud.mutex.Lock()
+
+			numIterations := 0
+			for datacenterID, expireTime := range ud.unknownDatacentersMap {
+				if numIterations > 3 {
+					break
+				}
+
+				if time.Since(expireTime) >= timeout {
+					delete(ud.unknownDatacentersMap, datacenterID)
+				}
+
+				numIterations++
+			}
+
+			ud.mutex.Unlock()
+		case <-ctx.Done():
+			return
+		}
+	}
+}


### PR DESCRIPTION
Extended the server backend to keep a map of unknown datacenters so that we can see their hash in the server backend terminal output. We can then use these to try and figure out which datacenters we don't have mapped in the database and add them.