### PR TITLE
Add datacenterID, rttReduction, and packetLossReduction to billing schema

### DIFF
--- a/billing/billing_test.go
+++ b/billing/billing_test.go
@@ -8,6 +8,7 @@ import (
 	"cloud.google.com/go/pubsub"
 	"github.com/go-kit/kit/log"
 	"github.com/networknext/backend/billing"
+	"github.com/networknext/backend/metrics"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,12 +23,12 @@ func TestNewGooglePubSubBiller(t *testing.T) {
 	checkGooglePubsubEmulator(t)
 
 	t.Run("no publish settings", func(t *testing.T) {
-		_, err := billing.NewGooglePubSubBiller(context.Background(), log.NewNopLogger(), "", "", 0, 0, nil)
+		_, err := billing.NewGooglePubSubBiller(context.Background(), &metrics.EmptyBillingMetrics, log.NewNopLogger(), "", "", 0, 0, nil)
 		assert.EqualError(t, err, "nil google pubsub publish settings")
 	})
 
 	t.Run("success", func(t *testing.T) {
-		_, err := billing.NewGooglePubSubBiller(context.Background(), log.NewNopLogger(), "default", "billing", 1, 0, &pubsub.DefaultPublishSettings)
+		_, err := billing.NewGooglePubSubBiller(context.Background(), &metrics.EmptyBillingMetrics, log.NewNopLogger(), "default", "billing", 1, 0, &pubsub.DefaultPublishSettings)
 		assert.NoError(t, err)
 	})
 }
@@ -43,7 +44,7 @@ func TestGooglePubSubBill(t *testing.T) {
 	})
 
 	t.Run("success", func(t *testing.T) {
-		biller, err := billing.NewGooglePubSubBiller(context.Background(), log.NewNopLogger(), "default", "billing", 1, 0, &pubsub.DefaultPublishSettings)
+		biller, err := billing.NewGooglePubSubBiller(context.Background(), &metrics.EmptyBillingMetrics, log.NewNopLogger(), "default", "billing", 1, 0, &pubsub.DefaultPublishSettings)
 		assert.NoError(t, err)
 
 		biller.Bill(ctx, &billing.BillingEntry{})

--- a/cmd/server_backend/server_backend.go
+++ b/cmd/server_backend/server_backend.go
@@ -304,6 +304,36 @@ func main() {
 		}
 	}
 
+	// Create server init metrics
+	serverInitMetrics, err := metrics.NewServerInitMetrics(ctx, metricsHandler)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to create server init metrics", "err", err)
+	}
+
+	// Create server update metrics
+	serverUpdateMetrics, err := metrics.NewServerUpdateMetrics(ctx, metricsHandler)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to create server update metrics", "err", err)
+	}
+
+	// Create session update metrics
+	sessionUpdateMetrics, err := metrics.NewSessionMetrics(ctx, metricsHandler)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to create session metrics", "err", err)
+	}
+
+	// Create maxmindb sync metrics
+	maxmindSyncMetrics, err := metrics.NewMaxmindSyncMetrics(ctx, metricsHandler)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to create session metrics", "err", err)
+	}
+
+	// Create billing metrics
+	billingMetrics, err := metrics.NewBillingMetrics(ctx, metricsHandler)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to create billing metrics", "err", err)
+	}
+
 	_, emulatorOK := os.LookupEnv("PUBSUB_EMULATOR_HOST")
 	if gcpOK || emulatorOK {
 
@@ -328,7 +358,7 @@ func main() {
 				Timeout:        time.Minute,
 			}
 
-			pubsub, err := billing.NewGooglePubSubBiller(pubsubCtx, logger, gcpProjectID, "billing", 1, 0, &settings)
+			pubsub, err := billing.NewGooglePubSubBiller(pubsubCtx, billingMetrics, logger, gcpProjectID, "billing", 1, 0, &settings)
 			if err != nil {
 				level.Error(logger).Log("msg", "could not create pubsub biller", "err", err)
 				os.Exit(1)
@@ -336,30 +366,6 @@ func main() {
 
 			biller = pubsub
 		}
-	}
-
-	// Create server init metrics
-	serverInitMetrics, err := metrics.NewServerInitMetrics(ctx, metricsHandler)
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to create server init metrics", "err", err)
-	}
-
-	// Create server update metrics
-	serverUpdateMetrics, err := metrics.NewServerUpdateMetrics(ctx, metricsHandler)
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to create server update metrics", "err", err)
-	}
-
-	// Create session update metrics
-	sessionUpdateMetrics, err := metrics.NewSessionMetrics(ctx, metricsHandler)
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to create session metrics", "err", err)
-	}
-
-	// Create maxmindb sync metrics
-	maxmindSyncMetrics, err := metrics.NewMaxmindSyncMetrics(ctx, metricsHandler)
-	if err != nil {
-		level.Error(logger).Log("msg", "failed to create session metrics", "err", err)
 	}
 
 	getIPLocatorFunc := func() routing.IPLocator {

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -721,9 +721,9 @@ func SessionUpdateHandlerFunc(params *SessionUpdateParams) UDPHandlerFunc {
 			}
 		}
 
-		// IMPORTANT: Immediately after ip2location we *must* anonymize the IP address so there is no chance 
-		// we accidentally use or store the non-anonymized IP address past this point. This is an important 
-		// business requirement because IP addresses are considered private identifiable information according 
+		// IMPORTANT: Immediately after ip2location we *must* anonymize the IP address so there is no chance
+		// we accidentally use or store the non-anonymized IP address past this point. This is an important
+		// business requirement because IP addresses are considered private identifiable information according
 		// to the GDRP and CCPA. We must *never* collect or store non-anonymized IP addresses!
 
 		// todo: anonymize address should work in place instead, and not have a failure case.
@@ -1057,13 +1057,13 @@ func CalculateTotalPriceNibblins(chosenRoute *routing.Route, envelopeBytesUp uin
 	envelopeUpGB := float64(envelopeBytesUp) / 1000000000.0
 	envelopeDownGB := float64(envelopeBytesDown) / 1000000000.0
 
-	totalPriceNibblins := nibblinsPerGB * ( envelopeUpGB + envelopeDownGB )
+	totalPriceNibblins := nibblinsPerGB * (envelopeUpGB + envelopeDownGB)
 
 	return uint64(totalPriceNibblins)
 }
 
 func PostSessionUpdate(params *SessionUpdateParams, packet *SessionUpdatePacket, response *SessionResponsePacket, serverDataReadOnly *ServerData,
-	routeRelays []routing.Relay, lastNextStats *routing.Stats, lastDirectStats *routing.Stats, isMultipath bool, location *routing.Location, nearRelays []routing.Relay,
+	routeRelays []routing.Relay, lastNextStats *routing.Stats, lastDirectStats *routing.Stats, prevRouteDecision routing.Decision, location *routing.Location, nearRelays []routing.Relay,
 	routeDecision routing.Decision, timeNow time.Time, totalPriceNibblins uint64, nextBytesUp uint64, nextBytesDown uint64, prevInitial bool) {
 
 	// IMPORTANT: we actually need to display the true datacenter name in the demo and demo plus views,
@@ -1076,6 +1076,8 @@ func PostSessionUpdate(params *SessionUpdateParams, packet *SessionUpdatePacket,
 	// Send a massive amount of data to the portal via redis.
 	// This drives all the stuff you see in the portal, including the map and top sessions list.
 	// We send it via redis because google pubsub is not able to deliver data quickly enough.
+
+	isMultipath := routing.IsMultipath(prevRouteDecision)
 
 	if err := updatePortalData(params.RedisClientPortal, params.RedisClientPortalExp, packet, lastNextStats, lastDirectStats, routeRelays,
 		packet.OnNetworkNext, datacenterName, location, nearRelays, timeNow, isMultipath, datacenterAlias); err != nil {
@@ -1116,6 +1118,9 @@ func PostSessionUpdate(params *SessionUpdateParams, packet *SessionUpdatePacket,
 		Initial:                   prevInitial,
 		NextBytesUp:               nextBytesUp,
 		NextBytesDown:             nextBytesDown,
+		DatacenterID:              serverDataReadOnly.datacenter.ID,
+		RTTReduction:              prevRouteDecision.Reason&routing.DecisionRTTReduction != 0 || prevRouteDecision.Reason&routing.DecisionRTTReductionMultipath != 0,
+		PacketLossReduction:       prevRouteDecision.Reason&routing.DecisionHighPacketLossMultipath != 0,
 	}
 
 	if err := params.Biller.Bill(context.Background(), &billingEntry); err != nil {
@@ -1444,10 +1449,8 @@ func sendRouteResponse(w io.Writer, chosenRoute *routing.Route, params *SessionU
 	// Calculate the total price for the billing entry
 	totalPriceNibblins := CalculateTotalPriceNibblins(chosenRoute, envelopeBytesUp, envelopeBytesDown)
 
-	isMultipath := routing.IsMultipath(prevRouteDecision)
-
 	// IMPORTANT: run post in parallel so it doesn't block the response
-	go PostSessionUpdate(params, packet, response, serverDataReadOnly, chosenRoute.Relays, lastNextStats, lastDirectStats, isMultipath, location, nearRelays, routeDecision, timeNow, totalPriceNibblins, usageBytesUp, usageBytesDown, prevInitial)
+	go PostSessionUpdate(params, packet, response, serverDataReadOnly, chosenRoute.Relays, lastNextStats, lastDirectStats, prevRouteDecision, location, nearRelays, routeDecision, timeNow, totalPriceNibblins, usageBytesUp, usageBytesDown, prevInitial)
 
 	// Send the Session Response back to the server
 	if _, err := w.Write(responseData); err != nil {


### PR DESCRIPTION
Also added some better visibility with metrics in the billing process. Added a metric for # of entries written to BQ (should be equal to # of entries read from pubsub), and added a metric for # of pubsub publish errors.

Also noticed what I believe to be a bug where `nextBytesUp` and `nextBytesDown` were only getting written to bigquery if `initial=true` instead of `next=true` (was fixed from pubsub, but I guess not to bigquery). Hopefully @alexander-pan can confirm this was happening and was a bug.