### PR TITLE
Initial relay ping always set to InvalidRouteValue

### DIFF
--- a/cmd/server_backend/server_backend.go
+++ b/cmd/server_backend/server_backend.go
@@ -186,6 +186,7 @@ func main() {
 		if err := db.AddBuyer(ctx, routing.Buyer{
 			ID:                   13672574147039585173,
 			Name:                 "local",
+			Live:                 true,
 			PublicKey:            customerPublicKey,
 			RoutingRulesSettings: routing.LocalRoutingRulesSettings,
 		}); err != nil {

--- a/routing/stats_database_test.go
+++ b/routing/stats_database_test.go
@@ -128,19 +128,19 @@ func TestStatsDatabase(t *testing.T) {
 			}
 		})
 
-		t.Run("source and destination both don't exist but entries are updated properly", func(t *testing.T) {
+		t.Run("source and destination both don't exist but entries are set to invalid value", func(t *testing.T) {
 			statsdb := routing.NewStatsDatabase()
 			statsdb.ProcessStats(&update)
 			entry, _ := statsdb.Entries[update.ID]
 			assert.Equal(t, len(entry.Relays), len(update.PingStats))
 			for _, stats := range update.PingStats {
 				destRelay, _ := entry.Relays[stats.RelayID]
-				assert.Equal(t, stats.RTT, destRelay.RTT)
-				assert.Equal(t, stats.Jitter, destRelay.Jitter)
-				assert.Equal(t, stats.PacketLoss, destRelay.PacketLoss)
-				assert.Equal(t, stats.RTT, destRelay.RTTHistory[0])
-				assert.Equal(t, stats.Jitter, destRelay.JitterHistory[0])
-				assert.Equal(t, stats.PacketLoss, destRelay.PacketLossHistory[0])
+				assert.Equal(t, float32(routing.InvalidRouteValue), destRelay.RTT)
+				assert.Equal(t, float32(routing.InvalidRouteValue), destRelay.Jitter)
+				assert.Equal(t, float32(routing.InvalidRouteValue), destRelay.PacketLoss)
+				assert.Equal(t, float32(routing.InvalidRouteValue), destRelay.RTTHistory[0])
+				assert.Equal(t, float32(routing.InvalidRouteValue), destRelay.JitterHistory[0])
+				assert.Equal(t, float32(routing.InvalidRouteValue), destRelay.PacketLossHistory[0])
 			}
 		})
 


### PR DESCRIPTION
This PR closes #1378. Tested locally, fixed confirmed. The only side effect of this is now it takes 5 minutes for a client to get a next route on the happy path. When we are testing next routes in the future we can just temporarily set the local route shader to force next though, so no big deal.