### PR TITLE
Add relay ids to output

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -435,6 +435,10 @@ func main() {
 	var relaysCount int64
 	relaysfs.Int64Var(&relaysCount, "n", 0, "number of relays to display (default: all)")
 
+	// Display relay IDs as signed ints instead of the default hex
+	var relayIDSigned bool
+	relaysfs.BoolVar(&relayIDSigned, "signed", false, "display relay IDs as signed integers")
+
 	var authCommand = &ffcli.Command{
 		Name:       "auth",
 		ShortUsage: "next auth",
@@ -599,6 +603,7 @@ func main() {
 					csvOutputFlag,
 					relayVersionFilter,
 					relaysCount,
+					relayIDSigned,
 				)
 				return nil
 			}
@@ -613,6 +618,7 @@ func main() {
 				csvOutputFlag,
 				relayVersionFilter,
 				relaysCount,
+				relayIDSigned,
 			)
 			return nil
 		},

--- a/cmd/next/relays.go
+++ b/cmd/next/relays.go
@@ -27,6 +27,7 @@ func relays(
 	csvOutputFlag bool,
 	relayVersionFilter string,
 	relaysCount int64,
+	relayIDSigned bool,
 ) {
 	args := localjsonrpc.RelaysArgs{
 		Regex: regex,
@@ -121,9 +122,15 @@ func relays(
 					relay.Name,
 				})
 			} else if relayVersionFilter == "all" || relay.Version == relayVersionFilter {
+				var relayID string
+				if relayIDSigned {
+					relayID = fmt.Sprintf("%d", int64(relay.ID))
+				} else {
+					relayID = fmt.Sprintf("%016x", relay.ID)
+				}
 				relaysCSV = append(relaysCSV, []string{
 					relay.Name,
-					fmt.Sprintf("%016x", relay.ID),
+					relayID,
 					address,
 					relay.State,
 					fmt.Sprintf("%d", relay.SessionCount),
@@ -135,6 +142,12 @@ func relays(
 			}
 
 		} else if relayVersionFilter == "all" || relay.Version == relayVersionFilter {
+			var relayID string
+			if relayIDSigned {
+				relayID = fmt.Sprintf("%d", int64(relay.ID))
+			} else {
+				relayID = fmt.Sprintf("%016x", relay.ID)
+			}
 			relays = append(relays, struct {
 				Name        string
 				ID          string
@@ -147,7 +160,7 @@ func relays(
 				LastUpdated string
 			}{
 				Name:        relay.Name,
-				ID:          fmt.Sprintf("%016x", relay.ID),
+				ID:          relayID,
 				Address:     address,
 				State:       relay.State,
 				Sessions:    fmt.Sprintf("%d", relay.SessionCount),


### PR DESCRIPTION
Relay IDs are now visible in the output of `next relays`. Hex by default. Adding the -signed switch (`next relays -signed`) displays the IDs as signed ints.