### PR TITLE
Packet Loss Multipath Threshold

### DIFF
--- a/routing/route_decision.go
+++ b/routing/route_decision.go
@@ -311,7 +311,7 @@ func DecideCommitted(onNNLastSlice bool, maxObservedSlices uint8, yolo bool, com
 // DecideMultipath will decide if we should serve a network next route to be used for multipath
 // If the decision function can't find a good enough reason to send a network next route, then it decides to go direct
 // If multipath isn't enabled then the decision isn't affected
-func DecideMultipath(rttMultipath bool, jitterMultipath bool, packetLossMultipath bool, rttThreshold float64) DecisionFunc {
+func DecideMultipath(rttMultipath bool, jitterMultipath bool, packetLossMultipath bool, rttThreshold float64, packetLossThreshold float64) DecisionFunc {
 	return func(prevDecision Decision, predictedNextStats, lastNextStats, lastDirectStats *Stats) Decision {
 		// If we've already decided on multipath, then don't change the reason
 		// This is to make sure that the session can't go back to direct, since multipath always needs a next route
@@ -340,7 +340,7 @@ func DecideMultipath(rttMultipath bool, jitterMultipath bool, packetLossMultipat
 		}
 
 		// If the direct packet loss is more than 1%, then use multipath for packet loss
-		if packetLossMultipath && lastDirectStats.PacketLoss >= 1.0 {
+		if packetLossMultipath && lastDirectStats.PacketLoss >= packetLossThreshold {
 			decision.OnNetworkNext = true
 			decision.Reason |= DecisionHighPacketLossMultipath
 		}

--- a/routing/route_decision_test.go
+++ b/routing/route_decision_test.go
@@ -265,9 +265,10 @@ func TestDecideCommitted(t *testing.T) {
 
 func TestDecideMultipath(t *testing.T) {
 	rttThreshold := float64(routing.LocalRoutingRulesSettings.RTTThreshold)
+	packetLossThreshold := float64(routing.LocalRoutingRulesSettings.MultipathPacketLossThreshold)
 
 	// Test if multipath isn't enabled
-	routeDecisionFunc := routing.DecideMultipath(false, false, false, rttThreshold)
+	routeDecisionFunc := routing.DecideMultipath(false, false, false, rttThreshold, packetLossThreshold)
 	predictedNNStats := &routing.Stats{RTT: 30}
 	directStats := &routing.Stats{RTT: 60}
 	decision := routing.Decision{}
@@ -275,7 +276,7 @@ func TestDecideMultipath(t *testing.T) {
 	assert.Equal(t, routing.Decision{}, decision)
 
 	// Test if multipath is already active
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold)
 	decision = routing.Decision{true, routing.DecisionRTTReductionMultipath}
 	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
 	assert.Equal(t, routing.Decision{true, routing.DecisionRTTReductionMultipath}, decision)
@@ -288,7 +289,7 @@ func TestDecideMultipath(t *testing.T) {
 	// Test when multipath reason is high jitter
 	// directStats.RTT set to -6.0 as it must be less than LocalROutingRulesSettings.RTTTHreshold
 	// if predictedNNStats.RTT = 0 (default) for happy path to run and force NN.
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold)
 	decision = routing.Decision{}
 	predictedNNStats = &routing.Stats{}
 	directStats = &routing.Stats{Jitter: 50, RTT: -6.0}
@@ -298,7 +299,7 @@ func TestDecideMultipath(t *testing.T) {
 	// Test when multipath reason is high packet loss
 	// directStats.RTT set to -5 as it must be less than LocalROutingRulesSettings.RTTTHreshold
 	// if predictedNNStats.RTT = 0 (default) for happy path to run and force NN.
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold)
 	decision = routing.Decision{}
 	predictedNNStats = &routing.Stats{}
 	directStats = &routing.Stats{PacketLoss: 1, RTT: -6.0}

--- a/routing/route_test.go
+++ b/routing/route_test.go
@@ -17,7 +17,7 @@ func TestDecideUpgradeRoute(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -67,7 +67,7 @@ func TestDecideDowngradeRTTHysteresis(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -121,7 +121,7 @@ func TestDecideDowngradeRTTHysteresisYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -179,7 +179,7 @@ func TestDecideRTTVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -238,7 +238,7 @@ func TestDecideRTTVetoYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -297,7 +297,7 @@ func TestDecidePacketLossVetoEarlySlice(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -356,7 +356,7 @@ func TestDecidePacketLossVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -416,7 +416,7 @@ func TestDecidePacketLossVetoYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -474,7 +474,7 @@ func TestDecideStayOnDirectRoute(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -525,7 +525,7 @@ func TestDecideStayOnNNRoute(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -582,7 +582,7 @@ func TestValidateInitialSlice(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -639,7 +639,7 @@ func TestDecideCommitVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 		routing.DecideCommitted(true, uint8(rrs.TryBeforeYouBuyMaxSlices), rrs.EnableYouOnlyLiveOnce, committedData),
 	}
 
@@ -708,7 +708,7 @@ func TestValidateCommitted(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 		routing.DecideCommitted(true, uint8(rrs.TryBeforeYouBuyMaxSlices), rrs.EnableYouOnlyLiveOnce, committedData),
 	}
 
@@ -777,7 +777,7 @@ func TestDecideMultipathDirect(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -831,7 +831,7 @@ func TestDecideMultipathStayActive(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -883,7 +883,7 @@ func TestValidateMultipathRTT(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -939,7 +939,7 @@ func TestValidateMultipathJitter(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -995,7 +995,7 @@ func TestValidateMultipathPacketLoss(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold)),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold)),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -1007,7 +1007,7 @@ func TestValidateMultipathPacketLoss(t *testing.T) {
 	lastDirectStats := &routing.Stats{
 		RTT:        0,
 		Jitter:     0,
-		PacketLoss: 1,
+		PacketLoss: 2,
 	}
 
 	route := routing.Route{

--- a/routing/routing_rules_settings.go
+++ b/routing/routing_rules_settings.go
@@ -55,8 +55,12 @@ type RoutingRulesSettings struct {
 	// Multipath means network traffic is sent over multiple network routes (any combination of direct and multiple network next routes)
 	// Once a session has multipath enabled, it will stay on multipath until the session ends. As of such vetos are disabled
 
-	// If true, enables multipath when there is 1% or more packet loss on the direct route
+	// If true, enables multipath when there is MultipathPacketLossThreshold% or more packet loss on the direct route
 	EnableMultipathForPacketLoss bool
+
+	// The amount of allowed packet loss on the direct route before a multipath route will be sent.
+	// This is only used if EnableMultipathForPacketLoss is true.
+	MultipathPacketLossThreshold float32
 
 	// If true, enables multipath when there is 50ms or more jitter on the direct route
 	EnableMultipathForJitter bool
@@ -81,16 +85,17 @@ type RoutingRulesSettings struct {
 }
 
 var DefaultRoutingRulesSettings = RoutingRulesSettings{
-	MaxCentsPerGB:            25.0,
-	EnvelopeKbpsUp:           256,
-	EnvelopeKbpsDown:         256,
-	AcceptableLatency:        -1.0,
-	RTTThreshold:             5.0,
-	RTTEpsilon:               2.0,
-	RTTHysteresis:            -5.0,
-	RTTVeto:                  -20.0,
-	TryBeforeYouBuyMaxSlices: 3,
-	SelectionPercentage:      0,
+	MaxCentsPerGB:                25.0,
+	EnvelopeKbpsUp:               256,
+	EnvelopeKbpsDown:             256,
+	AcceptableLatency:            -1.0,
+	RTTThreshold:                 5.0,
+	RTTEpsilon:                   2.0,
+	RTTHysteresis:                -5.0,
+	RTTVeto:                      -20.0,
+	TryBeforeYouBuyMaxSlices:     3,
+	SelectionPercentage:          0,
+	MultipathPacketLossThreshold: 2.0,
 }
 
 // LocalRoutingRulesSettings sets the rules for localhost:20000 Happy Path
@@ -98,13 +103,14 @@ var DefaultRoutingRulesSettings = RoutingRulesSettings{
 // slower than direct. Ditto for hysterisis and veto (more "real" than
 // forcing with 'Mode: ModeForceNext`).
 var LocalRoutingRulesSettings = RoutingRulesSettings{
-	MaxCentsPerGB:       25.0,
-	EnvelopeKbpsUp:      256,
-	EnvelopeKbpsDown:    256,
-	AcceptableLatency:   -1.0,
-	RTTThreshold:        -5,
-	RTTEpsilon:          0.1,
-	RTTHysteresis:       -10,
-	RTTVeto:             -20,
-	SelectionPercentage: 100,
+	MaxCentsPerGB:                25.0,
+	EnvelopeKbpsUp:               256,
+	EnvelopeKbpsDown:             256,
+	AcceptableLatency:            -1.0,
+	RTTThreshold:                 -5,
+	RTTEpsilon:                   0.1,
+	RTTHysteresis:                -10,
+	RTTVeto:                      -20,
+	SelectionPercentage:          100,
+	MultipathPacketLossThreshold: 1.0,
 }

--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -101,6 +101,7 @@ type routingRulesSettings struct {
 	EnableYouOnlyLiveOnce        bool    `firestore:"youOnlyLiveOnce"`
 	EnablePacketLossSafety       bool    `firestore:"packetLossSafety"`
 	EnableMultipathForPacketLoss bool    `firestore:"packetLossMultipath"`
+	MultipathPacketLossThreshold float32 `firestore:"multipathPacketLossThreshold"`
 	EnableMultipathForJitter     bool    `firestore:"jitterMultipath"`
 	EnableMultipathForRTT        bool    `firestore:"rttMultipath"`
 	EnableABTest                 bool    `firestore:"abTest"`
@@ -1645,6 +1646,7 @@ func (fs *Firestore) createRouteRulesSettingsForBuyerID(ctx context.Context, ID 
 		EnableYouOnlyLiveOnce:        rrs.EnableYouOnlyLiveOnce,
 		EnablePacketLossSafety:       rrs.EnablePacketLossSafety,
 		EnableMultipathForPacketLoss: rrs.EnableMultipathForPacketLoss,
+		MultipathPacketLossThreshold: rrs.MultipathPacketLossThreshold,
 		EnableMultipathForJitter:     rrs.EnableMultipathForJitter,
 		EnableMultipathForRTT:        rrs.EnableMultipathForRTT,
 		EnableABTest:                 rrs.EnableABTest,
@@ -1705,6 +1707,7 @@ func (fs *Firestore) getRoutingRulesSettingsForBuyerID(ctx context.Context, ID s
 	rrs.EnableYouOnlyLiveOnce = tempRRS.EnableYouOnlyLiveOnce
 	rrs.EnablePacketLossSafety = tempRRS.EnablePacketLossSafety
 	rrs.EnableMultipathForPacketLoss = tempRRS.EnableMultipathForPacketLoss
+	rrs.MultipathPacketLossThreshold = tempRRS.MultipathPacketLossThreshold
 	rrs.EnableMultipathForJitter = tempRRS.EnableMultipathForJitter
 	rrs.EnableMultipathForRTT = tempRRS.EnableMultipathForRTT
 	rrs.EnableABTest = tempRRS.EnableABTest
@@ -1722,25 +1725,26 @@ func (fs *Firestore) setRoutingRulesSettingsForBuyerID(ctx context.Context, ID s
 
 	// Convert RoutingRulesSettings struct to firestore map
 	rrsFirestore := map[string]interface{}{
-		"displayName":              name,
-		"envelopeKbpsUp":           rrs.EnvelopeKbpsUp,
-		"envelopeKbpsDown":         rrs.EnvelopeKbpsDown,
-		"mode":                     rrs.Mode,
-		"maxPricePerGBNibblins":    int64(billing.CentsToNibblins(rrs.MaxCentsPerGB)),
-		"acceptableLatency":        rrs.AcceptableLatency,
-		"rttRouteSwitch":           rrs.RTTEpsilon,
-		"rttThreshold":             rrs.RTTThreshold,
-		"rttHysteresis":            rrs.RTTHysteresis,
-		"rttVeto":                  rrs.RTTVeto,
-		"youOnlyLiveOnce":          rrs.EnableYouOnlyLiveOnce,
-		"packetLossSafety":         rrs.EnablePacketLossSafety,
-		"packetLossMultipath":      rrs.EnableMultipathForPacketLoss,
-		"jitterMultipath":          rrs.EnableMultipathForJitter,
-		"rttMultipath":             rrs.EnableMultipathForRTT,
-		"abTest":                   rrs.EnableABTest,
-		"tryBeforeYouBuy":          rrs.EnableTryBeforeYouBuy,
-		"tryBeforeYouBuyMaxSlices": rrs.TryBeforeYouBuyMaxSlices,
-		"selectionPercentage":      rrs.SelectionPercentage,
+		"displayName":                  name,
+		"envelopeKbpsUp":               rrs.EnvelopeKbpsUp,
+		"envelopeKbpsDown":             rrs.EnvelopeKbpsDown,
+		"mode":                         rrs.Mode,
+		"maxPricePerGBNibblins":        int64(billing.CentsToNibblins(rrs.MaxCentsPerGB)),
+		"acceptableLatency":            rrs.AcceptableLatency,
+		"rttRouteSwitch":               rrs.RTTEpsilon,
+		"rttThreshold":                 rrs.RTTThreshold,
+		"rttHysteresis":                rrs.RTTHysteresis,
+		"rttVeto":                      rrs.RTTVeto,
+		"youOnlyLiveOnce":              rrs.EnableYouOnlyLiveOnce,
+		"packetLossSafety":             rrs.EnablePacketLossSafety,
+		"packetLossMultipath":          rrs.EnableMultipathForPacketLoss,
+		"multipathPacketLossThreshold": rrs.MultipathPacketLossThreshold,
+		"jitterMultipath":              rrs.EnableMultipathForJitter,
+		"rttMultipath":                 rrs.EnableMultipathForRTT,
+		"abTest":                       rrs.EnableABTest,
+		"tryBeforeYouBuy":              rrs.EnableTryBeforeYouBuy,
+		"tryBeforeYouBuyMaxSlices":     rrs.TryBeforeYouBuyMaxSlices,
+		"selectionPercentage":          rrs.SelectionPercentage,
 	}
 
 	// Attempt to set route shader for buyer

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -979,7 +979,7 @@ func GetBestRoute(routeMatrix RouteProvider, nearRelays []routing.Relay, datacen
 		routing.DecideUpgradeRTT(float64(buyer.RoutingRulesSettings.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(buyer.RoutingRulesSettings.RTTHysteresis), buyer.RoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(buyer.RoutingRulesSettings.RTTVeto), buyer.RoutingRulesSettings.EnablePacketLossSafety, buyer.RoutingRulesSettings.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(buyer.RoutingRulesSettings.EnableMultipathForRTT, buyer.RoutingRulesSettings.EnableMultipathForJitter, buyer.RoutingRulesSettings.EnableMultipathForPacketLoss, float64(buyer.RoutingRulesSettings.RTTThreshold)),
+		routing.DecideMultipath(buyer.RoutingRulesSettings.EnableMultipathForRTT, buyer.RoutingRulesSettings.EnableMultipathForJitter, buyer.RoutingRulesSettings.EnableMultipathForPacketLoss, float64(buyer.RoutingRulesSettings.RTTThreshold), float64(buyer.RoutingRulesSettings.MultipathPacketLossThreshold)),
 	}
 
 	if buyer.RoutingRulesSettings.EnableTryBeforeYouBuy {


### PR DESCRIPTION
Adds a packet loss threshold setting in the route shader. This value will determine how much packet loss to allow on the direct route before serving a next route (only when multipath is enabled). Before this was hardcoded to 1%. Now the default is 2%.