### PR TITLE
Prod Fix In Master

### DIFF
--- a/billing/googlebigquery.go
+++ b/billing/googlebigquery.go
@@ -103,11 +103,11 @@ func (entry *BillingEntry) Save() (map[string]bigquery.Value, string, error) {
 	e["totalPrice"] = int(entry.TotalPrice)
 
 	if entry.ClientToServerPacketsLost > 0 {
-		e["clientToServerPacketsLost"] = entry.ClientToServerPacketsLost
+		e["clientToServerPacketsLost"] = int(entry.ClientToServerPacketsLost)
 	}
 
 	if entry.ServerToClientPacketsLost > 0 {
-		e["serverToClientPacketsLost"] = entry.ServerToClientPacketsLost
+		e["serverToClientPacketsLost"] = int(entry.ServerToClientPacketsLost)
 	}
 
 	e["committed"] = entry.Committed
@@ -116,11 +116,11 @@ func (entry *BillingEntry) Save() (map[string]bigquery.Value, string, error) {
 
 	if entry.Next {
 		e["initial"] = entry.Initial
-		e["nextBytesUp"] = entry.NextBytesUp
-		e["nextBytesDown"] = entry.NextBytesDown
+		e["nextBytesUp"] = int(entry.NextBytesUp)
+		e["nextBytesDown"] = int(entry.NextBytesDown)
 	}
 
-	e["datacenterID"] = entry.DatacenterID
+	e["datacenterID"] = int(entry.DatacenterID)
 
 	if entry.Next {
 		e["rttReduction"] = entry.RTTReduction


### PR DESCRIPTION
This PR just gets the prod hotfix in master.

The root cause of the billing write failure was not casting the uint64 to an int type. Other uint64 values weren't being casted but still being sent up so it took me a while to find this. I guess if the number is just too large then BQ can't write it.

This would have been caught if we had some way to test BQ locally...I can brainstorm some solutions for that. Once we have that, then #1390 would be fully addressed, as we have the pubsub emulator on the happy path to test the data getting through pubsub.