### PR TITLE
Buy specific total-* keys are growing without bound

### DIFF
--- a/transport/jsonrpc/buyer.go
+++ b/transport/jsonrpc/buyer.go
@@ -547,9 +547,9 @@ func (s *BuyersService) GenerateMapPointsPerBuyer() error {
 					sremtx.SRem("map-points-global", keyparts[1])
 					sremtx.SRem(fmt.Sprintf("map-points-%016x-buyer", buyer.ID), keyparts[1])
 					sremtx.ZRem("total-next", keyparts[1])
-					sremtx.SRem(fmt.Sprintf("total-next-buyer-%016x", buyer.ID), keyparts[1])
+					sremtx.ZRem(fmt.Sprintf("total-next-buyer-%016x", buyer.ID), keyparts[1])
 					sremtx.ZRem("total-direct", keyparts[1])
-					sremtx.SRem(fmt.Sprintf("total-direct-buyer-%016x", buyer.ID), keyparts[1])
+					sremtx.ZRem(fmt.Sprintf("total-direct-buyer-%016x", buyer.ID), keyparts[1])
 					continue
 				}
 


### PR DESCRIPTION
Not sure why this isn't showing up as an issue in the redis dashboards but buyer specific keys are growing without bound for psyonix and are elevated for the Raspberry buyer in dev. I believe this is because psyonix is at a scale where the issue is amplified by the shear number of sessions. With the Raspberry customer there is a relatively constant number of sessions so the bug doesn't effect it in the same way. The total-*-buyer-* keys are the ones that are growing out of control so somewhere in the code they are not being deleted properly.

I believe this fix will work because it adds in the removal of the total-*-buyer-* key when a point isn't found for the map. So it will keep the map points entries for both global and buyer specific synced up with the keys in the total* sets. When looking at the portal and the numbers that come in when filtering shows that something is funky here as well because the numbers are some what all over the place and don't make sense when added up to == the global totals.

Unfortunately this bug isn't reproducible locally as far as I have been able to tell so we will have to test in dev.

Please let me know if there is anything I am missing or if my logic is off somewhere because this is basically an educated guess at this point.

Closes #1407 