### PR TITLE
Adjust pubsub parameters to batch messages

### DIFF
--- a/cmd/server_backend/server_backend.go
+++ b/cmd/server_backend/server_backend.go
@@ -599,50 +599,50 @@ func main() {
 
 	// Setup the stats print routine
 	{
-		// memoryUsed := func() float64 {
-		// 	var m runtime.MemStats
-		// 	runtime.ReadMemStats(&m)
-		// 	return float64(m.Alloc) / (1000.0 * 1000.0)
-		// }
+		memoryUsed := func() float64 {
+			var m runtime.MemStats
+			runtime.ReadMemStats(&m)
+			return float64(m.Alloc) / (1000.0 * 1000.0)
+		}
 
-		// go func() {
-		// 	for {
-		// 		// todo: ryan. I would like to see all of the variables below, put into stackdriver metrics
-		// 		// so we can track them over time. right here in place, update the values in stackdriver once
-		// 		// every second
+		go func() {
+			for {
+				// todo: ryan. I would like to see all of the variables below, put into stackdriver metrics
+				// so we can track them over time. right here in place, update the values in stackdriver once
+				// every second
 
-		// 		fmt.Printf("-----------------------------\n")
-		// 		fmt.Printf("%d vetoes\n", vetoMap.NumVetoes())
-		// 		fmt.Printf("%d servers\n", serverMap.NumServers())
-		// 		fmt.Printf("%d sessions\n", sessionMap.NumSessions())
-		// 		fmt.Printf("%d goroutines\n", runtime.NumGoroutine())
-		// 		fmt.Printf("%.2f mb allocated\n", memoryUsed())
-		// 		fmt.Printf("%d billing entries submitted\n", biller.NumSubmitted())
-		// 		fmt.Printf("%d billing entries queued\n", biller.NumQueued())
-		// 		fmt.Printf("%d billing entries flushed\n", biller.NumFlushed())
-		// 		fmt.Printf("%d server init packets processed\n", atomic.LoadUint64(&serverInitCounters.Packets))
-		// 		fmt.Printf("%d server update packets processed\n", atomic.LoadUint64(&serverUpdateCounters.Packets))
-		// 		fmt.Printf("%d session update packets processed\n", atomic.LoadUint64(&sessionUpdateCounters.Packets))
-		// 		fmt.Printf("%d long server inits\n", atomic.LoadUint64(&serverInitCounters.LongDuration))
-		// 		fmt.Printf("%d long server updates\n", atomic.LoadUint64(&serverUpdateCounters.LongDuration))
-		// 		fmt.Printf("%d long session updates\n", atomic.LoadUint64(&sessionUpdateCounters.LongDuration))
-		// 		fmt.Printf("%d long route matrix updates\n", atomic.LoadUint64(&longRouteMatrixUpdates))
+				fmt.Printf("-----------------------------\n")
+				fmt.Printf("%d vetoes\n", vetoMap.NumVetoes())
+				fmt.Printf("%d servers\n", serverMap.NumServers())
+				fmt.Printf("%d sessions\n", sessionMap.NumSessions())
+				fmt.Printf("%d goroutines\n", runtime.NumGoroutine())
+				fmt.Printf("%.2f mb allocated\n", memoryUsed())
+				fmt.Printf("%d billing entries submitted\n", biller.NumSubmitted())
+				fmt.Printf("%d billing entries queued\n", biller.NumQueued())
+				fmt.Printf("%d billing entries flushed\n", biller.NumFlushed())
+				fmt.Printf("%d server init packets processed\n", atomic.LoadUint64(&serverInitCounters.Packets))
+				fmt.Printf("%d server update packets processed\n", atomic.LoadUint64(&serverUpdateCounters.Packets))
+				fmt.Printf("%d session update packets processed\n", atomic.LoadUint64(&sessionUpdateCounters.Packets))
+				fmt.Printf("%d long server inits\n", atomic.LoadUint64(&serverInitCounters.LongDuration))
+				fmt.Printf("%d long server updates\n", atomic.LoadUint64(&serverUpdateCounters.LongDuration))
+				fmt.Printf("%d long session updates\n", atomic.LoadUint64(&sessionUpdateCounters.LongDuration))
+				fmt.Printf("%d long route matrix updates\n", atomic.LoadUint64(&longRouteMatrixUpdates))
 
-		// 		unknownDatacentersLength := datacenterTracker.UnknownDatacenterLength()
-		// 		if unknownDatacentersLength > 0 {
-		// 			fmt.Printf("%d unknown datacenters: %v\n", unknownDatacentersLength, datacenterTracker.GetUnknownDatacenters())
-		// 		}
+				unknownDatacentersLength := datacenterTracker.UnknownDatacenterLength()
+				if unknownDatacentersLength > 0 {
+					fmt.Printf("%d unknown datacenters: %v\n", unknownDatacentersLength, datacenterTracker.GetUnknownDatacenters())
+				}
 
-		// 		emptyDatacentersLength := datacenterTracker.EmptyDatacenterLength()
-		// 		if emptyDatacentersLength > 0 {
-		// 			fmt.Printf("%d empty datacenters: %v\n", emptyDatacentersLength, datacenterTracker.GetEmptyDatacenters())
-		// 		}
+				emptyDatacentersLength := datacenterTracker.EmptyDatacenterLength()
+				if emptyDatacentersLength > 0 {
+					fmt.Printf("%d empty datacenters: %v\n", emptyDatacentersLength, datacenterTracker.GetEmptyDatacenters())
+				}
 
-		// 		fmt.Printf("-----------------------------\n")
+				fmt.Printf("-----------------------------\n")
 
-		// 		time.Sleep(time.Second)
-		// 	}
-		// }()
+				time.Sleep(time.Second)
+			}
+		}()
 	}
 
 	// Start UDP server


### PR DESCRIPTION
This PR closes #1121. Thankfully the pusub Go library already has batching built in, we just had some of the parameters for it set wrong. My guess is that the `DelayThreshold` was always triggering the publish since it was only at 10 seconds. We were also using an unbuffered channel. Unfortunately the maximum allowed `CountThreshold` is 1000 so this can't go any higher. The size of a direct route is 62 bytes while the maximum is 189 bytes (once I remove `NumNextRelaysPrice`). So if our `ByteThreshold` is `60*1024`, then we can hold 990 messages before publishing all direct route entries, and 321 messages before publishing entries of all maximum size. So this means that we shouldn't ever be hitting the `CountThreshold` of 1000, rather always hitting the `ByteThreshold` of 60KB.