### PR TITLE
Need a customer column in top sessions table

### DIFF
--- a/cmd/portal/public/index.html
+++ b/cmd/portal/public/index.html
@@ -544,7 +544,7 @@
                                                 {{ session.location.isp != "" ? session.location.isp : "Unknown" }}
                                             </td>
                                             <td v-if="handlers.userHandler.isAdmin()">
-                                                {{ handlers.userHandler.getCustomerName(pages.sessionTool.meta.customer_id) }}
+                                                {{ handlers.userHandler.getCustomerName(session.customer_id) }}
                                             </td>
                                             <td>
                                                 <span class="text-dark">


### PR DESCRIPTION
Addresses issue and first bonus points. For triple bonus points the question is how should we let the user know that the session tool is filtering on the buyer selected within the map or top sessions page. Adding a dropdown to the session tool search may look funky and adding any other indication that they are searching with a set buyerID may look weird as well. 

Closes #1397 