### PR TITLE
if a near relay has 100% packet loss set its stats to invalid values

### DIFF
--- a/routing/stats_database.go
+++ b/routing/stats_database.go
@@ -162,9 +162,17 @@ func (database *StatsDatabase) ProcessStats(statsUpdate *RelayStatsUpdate) {
 			relay.PacketLossHistory[relay.Index] = InvalidRouteValue
 
 		} else {
-			relay.RTTHistory[relay.Index] = stats.RTT
-			relay.JitterHistory[relay.Index] = stats.Jitter
-			relay.PacketLossHistory[relay.Index] = stats.PacketLoss
+			// Make sure that relays with 100% packet loss do not have 0 RTT
+			// and will definitely be excluded during route optimzation
+			if stats.PacketLoss > 99 {
+				relay.RTTHistory[relay.Index] = InvalidRouteValue
+				relay.JitterHistory[relay.Index] = InvalidRouteValue
+				relay.PacketLossHistory[relay.Index] = InvalidRouteValue
+			} else {
+				relay.RTTHistory[relay.Index] = stats.RTT
+				relay.JitterHistory[relay.Index] = stats.Jitter
+				relay.PacketLossHistory[relay.Index] = stats.PacketLoss
+			}
 		}
 
 		relay.Index = (relay.Index + 1) % HistorySize

--- a/transport/relay_handlers.go
+++ b/transport/relay_handlers.go
@@ -614,6 +614,7 @@ func RelayUpdateHandlerFunc(logger log.Logger, relayslogger log.Logger, params *
 			err = errors.New("unsupported content type")
 		}
 		if err != nil {
+			level.Error(locallogger).Log("msg", "error unmarshaling relay update request", "err", err)
 			http.Error(writer, err.Error(), http.StatusBadRequest)
 			params.Metrics.ErrorMetrics.UnmarshalFailure.Add(1)
 			return


### PR DESCRIPTION
This PR should close #1454 and close #1451.

Added an extra check to make sure that if we are seeing near 100% packet loss from a relay that we set all its ping stats to the invalid route value. 

I tested this by emulating a local ghost relay that pinged the backend (`127.0.0.1:10010`) but didn't respond to any relay pings, so packet loss would always be 100% to that relay. Before the check it seemed like almost all relays would set their ping stats for that relay to the invalid route value, except one, `127.0.0.1:10000`. After the check, all relays did every time.