### PR TITLE
Max Sessions Updates in relay_update

### DIFF
--- a/transport/relay_handlers.go
+++ b/transport/relay_handlers.go
@@ -748,6 +748,8 @@ func RelayUpdateHandlerFunc(logger log.Logger, relayslogger log.Logger, params *
 
 		relayCacheEntry.Version = relayUpdateRequest.RelayVersion
 
+		relayCacheEntry.MaxSessions = relay.MaxSessions
+
 		// Regular set for expiry
 		if res := params.RedisClient.Set(relayCacheEntry.Key(), 0, routing.RelayTimeout); res.Err() != nil {
 			level.Error(locallogger).Log("msg", "failed to store relay update expiry", "err", res.Err())


### PR DESCRIPTION
This PR closes #1478 by updating the max sessions variable in the relay update handler. This way if we change the max sessions in Firestore the relays will take that change.