### PR TITLE
update seller and datacenter every relay_update

### DIFF
--- a/transport/relay_handlers.go
+++ b/transport/relay_handlers.go
@@ -748,6 +748,9 @@ func RelayUpdateHandlerFunc(logger log.Logger, relayslogger log.Logger, params *
 
 		relayCacheEntry.Version = relayUpdateRequest.RelayVersion
 
+		// Update these fields in case they change in Firestore
+		relayCacheEntry.Seller = relay.Seller
+		relayCacheEntry.Datacenter = relay.Datacenter
 		relayCacheEntry.MaxSessions = relay.MaxSessions
 
 		// Regular set for expiry


### PR DESCRIPTION
Need to do this just for like for max sessions so that if the relay seller or datacenter's data changes in firestore (or our representation of the data changes, as is the case here), then that change will propagate to the rest of the system.