### PR TITLE
Cleanup Firestore Happy Path

### DIFF
--- a/cmd/relay_backend/relay_backend.go
+++ b/cmd/relay_backend/relay_backend.go
@@ -201,10 +201,18 @@ func main() {
 	// Create a local metrics handler
 	var metricsHandler metrics.Handler = &metrics.LocalHandler{}
 
+	gcpProjectID, gcpOK := os.LookupEnv("GOOGLE_PROJECT_ID")
+	_, emulatorOK := os.LookupEnv("FIRESTORE_EMULATOR_HOST")
+	if emulatorOK {
+		gcpProjectID = "local"
+
+		level.Info(logger).Log("msg", "Detected firestore emulator")
+	}
+
 	// Configure all GCP related services if the GOOGLE_PROJECT_ID is set
 	// GCP VMs actually get populated with the GOOGLE_APPLICATION_CREDENTIALS
 	// on creation so we can use that for the default then
-	if gcpProjectID, ok := os.LookupEnv("GOOGLE_PROJECT_ID"); ok {
+	if gcpOK || emulatorOK {
 
 		// Firestore
 		{
@@ -230,7 +238,9 @@ func main() {
 			// Set the Firestore Storer to give to handlers
 			db = fs
 		}
+	}
 
+	if gcpOK {
 		// Stackdriver Metrics
 		{
 			var enableSDMetrics bool

--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -1685,43 +1685,6 @@ func (fs *Firestore) syncCustomers(ctx context.Context) error {
 	return nil
 }
 
-func (fs *Firestore) createRouteRulesSettingsForBuyerID(ctx context.Context, ID string, name string, rrs routing.RoutingRulesSettings) error {
-	// Comment below taken from old backend, at least attempting to explain why we need to append _0 (no existing entries have suffixes other than _0)
-	// "Must be of the form '<buyer key>_<tag id>'. The buyer key can be found by looking at the ID under Buyer; it should be something like 763IMDH693HLsr2LGTJY. The tag ID should be 0 (for default) or the fnv64a hash of the tag the customer is using. Therefore this value should look something like: 763IMDH693HLsr2LGTJY_0. This value can not be changed after the entity is created."
-	routeShaderID := ID + "_0"
-
-	// Convert RoutingRulesSettings struct to firestore version
-	rrsFirestore := routingRulesSettings{
-		DisplayName:                  name,
-		EnvelopeKbpsUp:               rrs.EnvelopeKbpsUp,
-		EnvelopeKbpsDown:             rrs.EnvelopeKbpsDown,
-		Mode:                         rrs.Mode,
-		MaxPricePerGBNibblins:        int64(rrs.MaxNibblinsPerGB),
-		AcceptableLatency:            rrs.AcceptableLatency,
-		RTTEpsilon:                   rrs.RTTEpsilon,
-		RTTThreshold:                 rrs.RTTThreshold,
-		RTTHysteresis:                rrs.RTTHysteresis,
-		RTTVeto:                      rrs.RTTVeto,
-		EnableYouOnlyLiveOnce:        rrs.EnableYouOnlyLiveOnce,
-		EnablePacketLossSafety:       rrs.EnablePacketLossSafety,
-		EnableMultipathForPacketLoss: rrs.EnableMultipathForPacketLoss,
-		MultipathPacketLossThreshold: rrs.MultipathPacketLossThreshold,
-		EnableMultipathForJitter:     rrs.EnableMultipathForJitter,
-		EnableMultipathForRTT:        rrs.EnableMultipathForRTT,
-		EnableABTest:                 rrs.EnableABTest,
-		EnableTryBeforeYouBuy:        rrs.EnableTryBeforeYouBuy,
-		TryBeforeYouBuyMaxSlices:     rrs.TryBeforeYouBuyMaxSlices,
-		SelectionPercentage:          rrs.SelectionPercentage,
-	}
-
-	// Attempt to create route shader for buyer
-	rsDocRef := fs.Client.Collection("RouteShader").NewDoc()
-	rsDocRef.ID = routeShaderID
-
-	_, err := rsDocRef.Create(ctx, rrsFirestore)
-	return err
-}
-
 func (fs *Firestore) deleteRouteRulesSettingsForBuyerID(ctx context.Context, ID string) error {
 	// Comment below taken from old backend, at least attempting to explain why we need to append _0 (no existing entries have suffixes other than _0)
 	// "Must be of the form '<buyer key>_<tag id>'. The buyer key can be found by looking at the ID under Buyer; it should be something like 763IMDH693HLsr2LGTJY. The tag ID should be 0 (for default) or the fnv64a hash of the tag the customer is using. Therefore this value should look something like: 763IMDH693HLsr2LGTJY_0. This value can not be changed after the entity is created."


### PR DESCRIPTION
Didn't get to review #1476, was going to comment that you can check for the emulator and GCP project ID at the same time and then only have the firestore initialization once rather than copy+pasting. Also added support for firestore emulator on relay and server backends. The happy path will run but there's no data in the firestore emulator yet so servers won't initialize, relays won't connect, etc. I can make that change after, just wanted to get this in for code quality purposes. 