### PR TITLE
Fix ZeroMQ Socket Contention

### DIFF
--- a/transport/pubsub/portal_cruncher_publisher.go
+++ b/transport/pubsub/portal_cruncher_publisher.go
@@ -1,6 +1,8 @@
 package pubsub
 
 import (
+	"sync"
+
 	"github.com/pebbe/zmq4"
 )
 
@@ -10,6 +12,7 @@ const (
 
 type PortalCruncherPublisher struct {
 	socket *zmq4.Socket
+	mutex  sync.Mutex
 }
 
 func NewPortalCruncherPublisher(host string) (*PortalCruncherPublisher, error) {
@@ -28,5 +31,7 @@ func NewPortalCruncherPublisher(host string) (*PortalCruncherPublisher, error) {
 }
 
 func (pub *PortalCruncherPublisher) Publish(topic Topic, message []byte) (int, error) {
+	pub.mutex.Lock()
+	defer pub.mutex.Unlock()
 	return pub.socket.SendMessageDontwait([]byte{byte(topic)}, message)
 }


### PR DESCRIPTION
So going back through the zeromq docs I saw that while a zeromq "context" is threadsafe, a zeromq socket is not. I was also able to reproduce the crashes we were seeing in prod locally with only 20 clients (not sure why dev isn't tripping). So just adding some mutexes around publishing and receiving messages appears to have fixed the crashes.