### PR TITLE
Converted start/end dates to utc, fixed machine type error

### DIFF
--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -888,6 +888,10 @@ func (fs *Firestore) AddRelay(ctx context.Context, r routing.Relay) error {
 		LastUpdateTime:     r.LastUpdateTime,
 		MRC:                int64(r.MRC),
 		Overage:            int64(r.Overage),
+		BWRule:             int32(r.BWRule),
+		ContractTerm:       r.ContractTerm,
+		StartDate:          r.StartDate.UTC(),
+		EndDate:            r.EndDate.UTC(),
 		Type:               serverType,
 	}
 
@@ -1499,9 +1503,9 @@ func (fs *Firestore) syncRelays(ctx context.Context) error {
 		var serverType routing.MachineType
 		switch r.Type {
 		case "vm":
-			serverType = routing.BareMetal
-		case "bare-metal":
 			serverType = routing.VirtualMachine
+		case "bare-metal":
+			serverType = routing.BareMetal
 		case "n/a":
 			serverType = routing.NoneSpecified
 		default:
@@ -1530,8 +1534,8 @@ func (fs *Firestore) syncRelays(ctx context.Context) error {
 			Overage:             routing.Nibblin(r.Overage),
 			BWRule:              bwRule,
 			ContractTerm:        r.ContractTerm,
-			StartDate:           r.StartDate,
-			EndDate:             r.EndDate,
+			StartDate:           r.StartDate.UTC(),
+			EndDate:             r.EndDate.UTC(),
 			Type:                serverType,
 		}
 

--- a/storage/firestore_test.go
+++ b/storage/firestore_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	"github.com/go-kit/kit/log"
@@ -1172,12 +1173,19 @@ func TestFirestore(t *testing.T) {
 			}
 
 			expected := routing.Relay{
-				ID:         1,
-				Name:       "local",
-				Addr:       *addr,
-				PublicKey:  make([]byte, crypto.KeySize),
-				Seller:     seller,
-				Datacenter: datacenter,
+				ID:           1,
+				Name:         "local",
+				Addr:         *addr,
+				PublicKey:    make([]byte, crypto.KeySize),
+				Seller:       seller,
+				Datacenter:   datacenter,
+				MRC:          19700000000000,
+				Overage:      26000000000000,
+				BWRule:       routing.BWRuleBurst,
+				ContractTerm: 12,
+				StartDate:    time.Now(),
+				EndDate:      time.Now(),
+				Type:         routing.BareMetal,
 			}
 
 			err = fs.AddSeller(ctx, seller)
@@ -1230,20 +1238,34 @@ func TestFirestore(t *testing.T) {
 
 		expected := []routing.Relay{
 			{
-				ID:         1,
-				Name:       "local",
-				Addr:       *addr1,
-				PublicKey:  make([]byte, crypto.KeySize),
-				Seller:     seller,
-				Datacenter: datacenter,
+				ID:           1,
+				Name:         "local",
+				Addr:         *addr1,
+				PublicKey:    make([]byte, crypto.KeySize),
+				Seller:       seller,
+				Datacenter:   datacenter,
+				MRC:          19700000000000,
+				Overage:      26000000000000,
+				BWRule:       routing.BWRuleBurst,
+				ContractTerm: 12,
+				StartDate:    time.Now(),
+				EndDate:      time.Now(),
+				Type:         routing.BareMetal,
 			},
 			{
-				ID:         2,
-				Name:       "local",
-				Addr:       *addr2,
-				PublicKey:  make([]byte, crypto.KeySize),
-				Seller:     seller,
-				Datacenter: datacenter,
+				ID:           2,
+				Name:         "local",
+				Addr:         *addr2,
+				PublicKey:    make([]byte, crypto.KeySize),
+				Seller:       seller,
+				Datacenter:   datacenter,
+				MRC:          19700000000000,
+				Overage:      26000000000000,
+				BWRule:       routing.BWRuleBurst,
+				ContractTerm: 12,
+				StartDate:    time.Now(),
+				EndDate:      time.Now(),
+				Type:         routing.VirtualMachine,
 			},
 		}
 
@@ -1276,10 +1298,17 @@ func TestFirestore(t *testing.T) {
 			assert.NoError(t, err)
 
 			expected := routing.Relay{
-				ID:        1,
-				Name:      "local",
-				Addr:      *addr,
-				PublicKey: make([]byte, crypto.KeySize),
+				ID:           1,
+				Name:         "local",
+				Addr:         *addr,
+				PublicKey:    make([]byte, crypto.KeySize),
+				MRC:          19700000000000,
+				Overage:      26000000000000,
+				BWRule:       routing.BWRuleBurst,
+				ContractTerm: 12,
+				StartDate:    time.Now(),
+				EndDate:      time.Now(),
+				Type:         routing.BareMetal,
 			}
 
 			err = fs.AddRelay(ctx, expected)
@@ -1306,11 +1335,18 @@ func TestFirestore(t *testing.T) {
 			}
 
 			expected := routing.Relay{
-				ID:        1,
-				Name:      "local",
-				Addr:      *addr,
-				PublicKey: make([]byte, crypto.KeySize),
-				Seller:    seller,
+				ID:           1,
+				Name:         "local",
+				Addr:         *addr,
+				PublicKey:    make([]byte, crypto.KeySize),
+				Seller:       seller,
+				MRC:          19700000000000,
+				Overage:      26000000000000,
+				BWRule:       routing.BWRuleBurst,
+				ContractTerm: 12,
+				StartDate:    time.Now(),
+				EndDate:      time.Now(),
+				Type:         routing.BareMetal,
 			}
 
 			err = fs.AddSeller(ctx, seller)
@@ -1350,12 +1386,19 @@ func TestFirestore(t *testing.T) {
 			}
 
 			expected := routing.Relay{
-				ID:         1,
-				Name:       "local",
-				Addr:       *addr,
-				PublicKey:  make([]byte, crypto.KeySize),
-				Seller:     seller,
-				Datacenter: datacenter,
+				ID:           1,
+				Name:         "local",
+				Addr:         *addr,
+				PublicKey:    make([]byte, crypto.KeySize),
+				Seller:       seller,
+				Datacenter:   datacenter,
+				MRC:          19700000000000,
+				Overage:      26000000000000,
+				BWRule:       routing.BWRuleBurst,
+				ContractTerm: 12,
+				StartDate:    time.Now(),
+				EndDate:      time.Now(),
+				Type:         routing.BareMetal,
 			}
 
 			err = fs.AddSeller(ctx, seller)
@@ -1418,12 +1461,19 @@ func TestFirestore(t *testing.T) {
 			}
 
 			relay := routing.Relay{
-				ID:         crypto.HashID(addr.String()),
-				Name:       "local",
-				Addr:       *addr,
-				PublicKey:  make([]byte, crypto.KeySize),
-				Seller:     seller,
-				Datacenter: datacenter,
+				ID:           crypto.HashID(addr.String()),
+				Name:         "local",
+				Addr:         *addr,
+				PublicKey:    make([]byte, crypto.KeySize),
+				Seller:       seller,
+				Datacenter:   datacenter,
+				MRC:          19700000000000,
+				Overage:      26000000000000,
+				BWRule:       routing.BWRuleBurst,
+				ContractTerm: 12,
+				StartDate:    time.Now(),
+				EndDate:      time.Now(),
+				Type:         routing.BareMetal,
 			}
 
 			err = fs.AddSeller(ctx, seller)
@@ -1494,13 +1544,20 @@ func TestFirestore(t *testing.T) {
 			}
 
 			expected := routing.Relay{
-				ID:         crypto.HashID(addr.String()),
-				Name:       "local",
-				Addr:       *addr,
-				PublicKey:  make([]byte, crypto.KeySize),
-				Seller:     seller,
-				Datacenter: datacenter,
-				State:      routing.RelayStateEnabled,
+				ID:           crypto.HashID(addr.String()),
+				Name:         "local",
+				Addr:         *addr,
+				PublicKey:    make([]byte, crypto.KeySize),
+				Seller:       seller,
+				Datacenter:   datacenter,
+				State:        routing.RelayStateEnabled,
+				MRC:          19700000000000,
+				Overage:      26000000000000,
+				BWRule:       routing.BWRuleBurst,
+				ContractTerm: 12,
+				StartDate:    time.Now(),
+				EndDate:      time.Now(),
+				Type:         routing.BareMetal,
 			}
 
 			err = fs.AddSeller(ctx, seller)
@@ -1875,15 +1932,25 @@ func TestFirestore(t *testing.T) {
 		addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:40000")
 		assert.NoError(t, err)
 
+		startDate, _ := time.Parse("January 2, 2006", "January 2, 2006")
+		endDate, _ := time.Parse("January 2, 2006", "January 2, 2007")
+
 		expectedRelay := routing.Relay{
-			ID:          crypto.HashID(addr.String()),
-			Name:        "local",
-			Addr:        *addr,
-			PublicKey:   make([]byte, crypto.KeySize),
-			Seller:      expectedSeller,
-			Datacenter:  expectedDatacenter,
-			MaxSessions: 3000,
-			UpdateKey:   make([]byte, 32),
+			ID:           crypto.HashID(addr.String()),
+			Name:         "local",
+			Addr:         *addr,
+			PublicKey:    make([]byte, crypto.KeySize),
+			Seller:       expectedSeller,
+			Datacenter:   expectedDatacenter,
+			MaxSessions:  3000,
+			UpdateKey:    make([]byte, 32),
+			MRC:          19700000000000,
+			Overage:      26000000000000,
+			BWRule:       routing.BWRuleBurst,
+			ContractTerm: 12,
+			StartDate:    startDate,
+			EndDate:      endDate,
+			Type:         routing.BareMetal,
 		}
 
 		err = fs.AddBuyer(ctx, expectedBuyer)


### PR DESCRIPTION
Small update and logic fix to the `./next relay ops` command set. Updated the FirestoreTest suite as well.