### PR TITLE
Jitter and PL in Portal

### DIFF
--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -808,6 +808,8 @@ func SessionUpdateHandlerFunc(params *SessionUpdateParams) UDPHandlerFunc {
 				for j, clientNearRelayID := range packet.NearRelayIDs {
 					if nearRelay.ID == clientNearRelayID {
 						nearRelays[i].ClientStats.RTT = float64(packet.NearRelayMinRTT[j])
+						nearRelays[i].ClientStats.Jitter = float64(packet.NearRelayJitter[j])
+						nearRelays[i].ClientStats.PacketLoss = float64(packet.NearRelayPacketLoss[j])
 					}
 				}
 			}


### PR DESCRIPTION
Added back jitter and PL for near relays in the portal. Must have been removed by accident at some point when redoing the routing logic. I was able to repro locally and confirm fix locally.

(I believe this is unrelated to the red relay dashboard in prod. I just happen to find that while attempting to solve this.)