### PR TITLE
Sorted <buyer datacenter list> by datacenter name

### DIFF
--- a/cmd/next/buyers.go
+++ b/cmd/next/buyers.go
@@ -249,6 +249,10 @@ func datacenterMapsForBuyer(rpcClient jsonrpc.RPCClient, env Environment, buyer 
 		return
 	}
 
+	sort.Slice(reply.DatacenterMaps, func(i int, j int) bool {
+		return reply.DatacenterMaps[i].DatacenterName < reply.DatacenterMaps[j].DatacenterName
+	})
+
 	table.Output(reply.DatacenterMaps)
 
 }


### PR DESCRIPTION
Single level sort by dc name.

```09:50 $ ./next buyer datacenter list psy

┌────────────────────────┬──────────────────────────┬──────────────────┬───────────┬──────────────────┬────────────────┐
│ Alias                  │ DatacenterName           │ DatacenterID     │ BuyerName │ BuyerID          │ SupplierName   │
├────────────────────────┼──────────────────────────┼──────────────────┼───────────┼──────────────────┼────────────────┤
│ multiplay.amsterdam    │ 100tb.amsterdam          │ e422d6295e2ac0b0 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.london       │ 100tb.london             │ db5ff0cd2c88cde6 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.saltlakecity │ 100tb.saltlakecity       │ 635735d7079f058c │ Psyonix   │ b8e4f84ca63b2021 │ Salt Lake City │
│                        │ i3d.hongkong             │ c4381f0bb9119984 │ Psyonix   │ b8e4f84ca63b2021 │                │
│                        │ i3d.johannesburg         │ 0788113db6f9cb6d │ Psyonix   │ b8e4f84ca63b2021 │                │
│                        │ i3d.losangeles           │ 3d1ba3408c9731a0 │ Psyonix   │ b8e4f84ca63b2021 │                │
│                        │ i3d.rotterdam            │ 43d252003a4a6f57 │ Psyonix   │ b8e4f84ca63b2021 │                │
│                        │ i3d.saopaulo             │ 515a640333e961b7 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ i3d.saopaolo           │ i3d.saopaulo             │ 515a640333e961b7 │ Psyonix   │ b8e4f84ca63b2021 │                │
│                        │ i3d.sydney               │ d85791d26f54f5f3 │ Psyonix   │ b8e4f84ca63b2021 │                │
│                        │ i3d.tokyo                │ bca037df2dafa09b │ Psyonix   │ b8e4f84ca63b2021 │                │
│                        │ i3d.washingtondc         │ 946e5166c17ab220 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.newyork      │ inap.newyork             │ 323c61af696bff50 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.sanjose      │ inap.sanjose             │ bff617887aded8e4 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.ashburn      │ psychz.ashburn           │ 3bc9e5cffecf0431 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.saopaulo     │ psychz.saopaulo          │ 1ff83f37e0e4e178 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.taipei       │ psychz.taipei            │ e85a4a9dc473ea8c │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.tokyo        │ psychz.tokyo             │ c23ff3e3f018444a │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.sydney       │ serversaustralia.sydney  │ 5421f84fc6621983 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.dallas       │ serversdotcom.dallas     │ 3de103cd88b6b764 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.luxembourg   │ serversdotcom.luxembourg │ 4417257114b4b74f │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.singapore    │ serversdotcom.singapore  │ 67fb6118c55dd347 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.miami        │ velia.miami              │ fc585b217767e75f │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.stlouis      │ velia.stlouis            │ 3d4ddce0885ac395 │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.strasbourg   │ velia.strasbourg         │ 87b2d573f0758adc │ Psyonix   │ b8e4f84ca63b2021 │                │
│ multiplay.taiwan       │ zenlayer.taiwan          │ 3570aaf67ad7022f │ Psyonix   │ b8e4f84ca63b2021 │                │
└────────────────────────┴──────────────────────────┴──────────────────┴───────────┴──────────────────┴────────────────┘
```

Closes #1422 .
Closes #1415 .