### PR TITLE
Returns list of dc maps for a datacenter substring

### DIFF
--- a/cmd/next/datacenters.go
+++ b/cmd/next/datacenters.go
@@ -89,8 +89,10 @@ func removeDatacenter(rpcClient jsonrpc.RPCClient, env Environment, name string)
 
 func listDatacenterMaps(rpcClient jsonrpc.RPCClient, env Environment, datacenter string) {
 
-	var dcID uint64
+	var dcIDs []uint64
 	var err error
+
+	// get list of datacenters matching the given id/name/substring
 	datacentersArgs := localjsonrpc.DatacentersArgs{}
 	var datacenters localjsonrpc.DatacentersReply
 	if err = rpcClient.CallFor(&datacenters, "OpsService.Datacenters", datacentersArgs); err != nil {
@@ -101,26 +103,39 @@ func listDatacenterMaps(rpcClient jsonrpc.RPCClient, env Environment, datacenter
 	r := regexp.MustCompile("(?i)" + datacenter) // case-insensitive regex
 	for _, dc := range datacenters.Datacenters {
 		if r.MatchString(dc.Name) || r.MatchString(fmt.Sprintf("%016x", dc.ID)) {
-			dcID = dc.ID
+			dcIDs = append(dcIDs, dc.ID)
 		}
 	}
 
-	if dcID == 0 {
+	if len(dcIDs) == 0 {
 		fmt.Printf("No match for provided datacenter ID: %v\n", datacenter)
 		return
 	}
 
-	var reply localjsonrpc.ListDatacenterMapsReply
-	var arg = localjsonrpc.ListDatacenterMapsArgs{
-		DatacenterID: dcID,
+	// assemble the full list of maps
+	var dcMapsFull []localjsonrpc.DatacenterMapsFull
+	for _, id := range dcIDs {
+		var reply localjsonrpc.ListDatacenterMapsReply
+		var arg = localjsonrpc.ListDatacenterMapsArgs{
+			DatacenterID: id,
+		}
+
+		if err := rpcClient.CallFor(&reply, "OpsService.ListDatacenterMaps", arg); err != nil {
+			fmt.Printf("rpc error: %v\n", err)
+			handleJSONRPCError(env, err)
+			return
+		}
+
+		for _, dcMap := range reply.DatacenterMaps {
+			dcMapsFull = append(dcMapsFull, dcMap)
+		}
 	}
 
-	if err := rpcClient.CallFor(&reply, "OpsService.ListDatacenterMaps", arg); err != nil {
-		fmt.Printf("rpc error: %v\n", err)
-		handleJSONRPCError(env, err)
+	if len(dcMapsFull) == 0 {
+		fmt.Printf("No buyers found for the provided datacenter ID: %v\n", datacenter)
 		return
 	}
 
-	table.Output(reply.DatacenterMaps)
+	table.Output(dcMapsFull)
 
 }


### PR DESCRIPTION
Returns a list of dc maps for a given datacenter substring, or just the list for a give datacenter full name.

Closes #1420 .
Closes #1421 .


```
12:22 $ ./next datacenter buyers velia

┌──────────────────────┬──────────────────┬──────────────────┬───────────┬──────────────────┬──────────────┐
│ Alias                │ DatacenterName   │ DatacenterID     │ BuyerName │ BuyerID          │ SupplierName │
├──────────────────────┼──────────────────┼──────────────────┼───────────┼──────────────────┼──────────────┤
│ multiplay.miami      │ velia.miami      │ fc585b217767e75f │ Psyonix   │ b8e4f84ca63b2021 │              │
│ multiplay.stlouis    │ velia.stlouis    │ 3d4ddce0885ac395 │ Psyonix   │ b8e4f84ca63b2021 │              │
│ multiplay.strasbourg │ velia.strasbourg │ 87b2d573f0758adc │ Psyonix   │ b8e4f84ca63b2021 │              │
└──────────────────────┴──────────────────┴──────────────────┴───────────┴──────────────────┴──────────────┘

12:21 $ ./next datacenter buyers velia.miami

┌─────────────────┬────────────────┬──────────────────┬───────────┬──────────────────┬──────────────┐
│ Alias           │ DatacenterName │ DatacenterID     │ BuyerName │ BuyerID          │ SupplierName │
├─────────────────┼────────────────┼──────────────────┼───────────┼──────────────────┼──────────────┤
│ multiplay.miami │ velia.miami    │ fc585b217767e75f │ Psyonix   │ b8e4f84ca63b2021 │              │
└─────────────────┴────────────────┴──────────────────┴───────────┴──────────────────┴──────────────┘

12:22 $ ./next datacenter buyers vultr

No buyers found for the provided datacenter ID: vultr

```
