### PR TITLE
Embellish buyer not found err msg for dc map lookup

### DIFF
--- a/cmd/next/buyers.go
+++ b/cmd/next/buyers.go
@@ -221,20 +221,22 @@ func datacenterMapsForBuyer(rpcClient jsonrpc.RPCClient, env Environment, buyer 
 	var err error
 
 	buyerArgs := localjsonrpc.BuyersArgs{}
-	var buyers localjsonrpc.BuyersReply
-	if err = rpcClient.CallFor(&buyers, "OpsService.Buyers", buyerArgs); err != nil {
+	var buyersReply localjsonrpc.BuyersReply
+	if err = rpcClient.CallFor(&buyersReply, "OpsService.Buyers", buyerArgs); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
 	r := regexp.MustCompile("(?i)" + buyer) // case-insensitive regex
-	for _, buyer := range buyers.Buyers {
+	for _, buyer := range buyersReply.Buyers {
 		if r.MatchString(buyer.Name) || r.MatchString(fmt.Sprintf("%016x", buyer.ID)) {
 			buyerID = buyer.ID
 		}
 	}
 
 	if buyerID == 0 {
-		fmt.Printf("No match for provided buyer ID: %v\n", buyer)
+		fmt.Printf("No match for provided buyer ID: %v\n\n", buyer)
+		fmt.Println("Here is a current list of buyers in the system:")
+		buyers(rpcClient, env, false)
 		return
 	}
 


### PR DESCRIPTION
Added a list of current buyers to the output of `./next buyer datacenter list` if the buyer specified is not found.

Closes #1419 .

```
12:55 $ ./next buyer datacenter list "pink floyd"

No match for provided buyer ID: pink floyd

Here is a current list of buyers in the system:
┌─────────────────────────┬──────────────────┐
│ Name                    │ BuyerID          │
├─────────────────────────┼──────────────────┤
│ Liquid Bit              │ f0d3cc73dca0bc89 │
│ Velan Studios           │ e5cee310ae3e26bc │
│ Orionark                │ e2cd4671821abeb2 │
│ Turtle Rock Studios     │ c0ed3f02466425fb │
│ Network Next            │ bdbebdbf0f7be395 │
│ Psyonix                 │ b8e4f84ca63b2021 │
│ Andrews Test Company    │ 9d8dc84dfba2097f │
│ ESL Gaming Online, Inc. │ 1e4e8804454033c8 │
└─────────────────────────┴──────────────────┘
```