### PR TITLE
moved <next sessions (id)> to <next session (id)>

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -560,7 +560,7 @@ func main() {
 		},
 	}
 
-	var sessionCommand = &ffcli.Command{
+	var sessionsCommand = &ffcli.Command{
 		Name:       "sessions",
 		ShortUsage: "next sessions",
 		ShortHelp:  "List sessions",
@@ -587,6 +587,18 @@ func main() {
 		},
 	}
 
+	var sessionCommand = &ffcli.Command{
+		Name:       "session",
+		ShortUsage: "next session <session id>",
+		ShortHelp:  "Display details for the specified session",
+		Exec: func(_ context.Context, args []string) error {
+			if len(args) != 1 {
+				fmt.Printf("A session ID must be provided (see ./next sessions).")
+			}
+			sessions(rpcClient, env, args[0], sessionCount)
+			return nil
+		},
+	}
 	var relaysCommand = &ffcli.Command{
 		Name:       "relays",
 		ShortUsage: "next relays <regex>",
@@ -1886,6 +1898,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 		selectCommand,
 		envCommand,
 		sessionCommand,
+		sessionsCommand,
 		relaysCommand,
 		relayCommand,
 		routesCommand,


### PR DESCRIPTION
Closes #1230 .

Since there are no other subcommands for `./next session` at the moment I omitted the `view` subcommand.

```
13:49 $ ./next session c1b0a18eacf3c314

Session is on Network Next

RTT improvement is 1.0ms

┌────────┬──────┬────────┬────────────┐
│ Name   │ RTT  │ Jitter │ PacketLoss │
├────────┼──────┼────────┼────────────┤
│ Direct │ 61.5 │ 40.6   │ 0.0        │
│ Next   │ 60.5 │ 29.2   │ 0.0        │
└────────┴──────┴────────┴────────────┘

Near Relays:
┌─────────────────────┬──────┬────────┬────────────┐
│ Name                │ RTT  │ Jitter │ PacketLoss │
├─────────────────────┼──────┼────────┼────────────┤
│ google.losangeles.1 │ 12.8 │ 18.8   │ 0.0        │
│ amazon.sanjose.1    │ 20.7 │ 24.1   │ 0.0        │
│ vultr.seattle       │ 38.3 │ 16.2   │ 0.0        │
│ vultr.dallas        │ 46.0 │ 17.2   │ 0.0        │
│ google.iowa.1       │ 58.4 │ 20.9   │ 0.0        │
│ vultr.chicago       │ 67.7 │ 26.3   │ 0.0        │
│ maxihost.chicago    │ 71.4 │ 14.3   │ 0.0        │
└─────────────────────┴──────┴────────┴────────────┘

Current Route:

       60ms: google.losangeles.1 - vultr.chicago

```