### PR TITLE
Checks for relay disabled prior to removal

### DIFF
--- a/cmd/next/relays.go
+++ b/cmd/next/relays.go
@@ -460,7 +460,7 @@ func removeRelay(rpcClient jsonrpc.RPCClient, env Environment, name string) {
 	}
 
 	if info.state != routing.RelayStateDisabled.String() {
-		fmt.Printf("Relay %s must be disabled prior to removal.", info.name)
+		fmt.Printf("Relay %s must be disabled prior to removal.\n\n", info.name)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Checks to make sure a relay has been disabled prior to removal. I originally had the code disable the relay if it had not already been disabled, but changed it to throw an error instead, following the issue request more closely.

~~WIP til I test in dev.~~ 


Closes #1266 .