### PR TITLE
Remove sequence number firestore emulator requirement.

### DIFF
--- a/storage/firestore_test.go
+++ b/storage/firestore_test.go
@@ -78,6 +78,8 @@ func cleanFireStore(ctx context.Context, client *firestore.Client) error {
 }
 
 func TestSequenceNumbers(t *testing.T) {
+
+	checkFirestoreEmulator(t)
 	ctx := context.Background()
 
 	t.Run("Sync", func(t *testing.T) {


### PR DESCRIPTION
Added checkFirestoreEmulator() to sequence number tests in firestore_test.go. Now runs fine without GCP credentials files in place.