### PR TITLE
Fix Post Session Portal Retry

### DIFF
--- a/transport/post_session_handler.go
+++ b/transport/post_session_handler.go
@@ -97,7 +97,7 @@ func (post *PostSessionData) ProcessPortalData(publisher pubsub.Publisher, maxRe
 	var byteCount int
 
 	var retryCount int
-	for retryCount > maxRetries { // only retry so many times, then error out after that
+	for retryCount < maxRetries { // only retry so many times, then error out after that
 		singleByteCount, err := publisher.Publish(pubsub.TopicPortalCruncherSessionData, sessionBytes)
 		if err != nil {
 			errno := zmq4.AsErrno(err)
@@ -120,7 +120,7 @@ func (post *PostSessionData) ProcessPortalData(publisher pubsub.Publisher, maxRe
 	}
 
 	retryCount = 0
-	for retryCount > maxRetries { // only retry so many times, then error out after that
+	for retryCount < maxRetries { // only retry so many times, then error out after that
 		singleByteCount, err := publisher.Publish(pubsub.TopicPortalCruncherSessionCounts, countBytes)
 		if err != nil {
 			errno := zmq4.AsErrno(err)


### PR DESCRIPTION
Fixes sending data to the portal cruncher, had my signs backwards, so it was never sending anything.