### PR TITLE
Staging and ESL Portal Data

### DIFF
--- a/transport/post_session_handler.go
+++ b/transport/post_session_handler.go
@@ -88,7 +88,7 @@ func (post *PostSessionData) ProcessPortalData(publisher pubsub.Publisher) (int,
 	}
 
 	var byteCount int
-	if post.PortalCountData.InstanceID != 5128824641664751290 {
+	if post.PortalCountData.InstanceID == 1822264092253140855 /*Staging*/ || post.PortalCountData.InstanceID == 1014894662482511101 /*ESL*/ {
 		singleByteCount, err := publisher.Publish(pubsub.TopicPortalCruncherSessionData, sessionBytes)
 		byteCount += singleByteCount
 		if err != nil {


### PR DESCRIPTION
Only allow staging and ESL server backends to send portal data to the portal cruncher.