### PR TITLE
Safe Billing Read

### DIFF
--- a/billing/billing_entry.go
+++ b/billing/billing_entry.go
@@ -223,3 +223,133 @@ func ReadBillingEntry(entry *BillingEntry, data []byte) bool {
 
 	return true
 }
+
+func ReadBillingEntryUserHashV5(entry *BillingEntry, data []byte) bool {
+	index := 0
+	if !encoding.ReadUint8(data, &index, &entry.Version) {
+		return false
+	}
+	if entry.Version > BillingEntryVersion {
+		return false
+	}
+	if !encoding.ReadUint64(data, &index, &entry.BuyerID) {
+		return false
+	}
+	if entry.Version >= 5 {
+		if !encoding.ReadUint64(data, &index, &entry.UserHash) {
+			return false
+		}
+	}
+	if !encoding.ReadUint64(data, &index, &entry.SessionID) {
+		return false
+	}
+	if !encoding.ReadUint32(data, &index, &entry.SliceNumber) {
+		return false
+	}
+	if !encoding.ReadFloat32(data, &index, &entry.DirectRTT) {
+		return false
+	}
+	if !encoding.ReadFloat32(data, &index, &entry.DirectJitter) {
+		return false
+	}
+	if !encoding.ReadFloat32(data, &index, &entry.DirectPacketLoss) {
+		return false
+	}
+	if !encoding.ReadBool(data, &index, &entry.Next) {
+		return false
+	}
+
+	if entry.Next {
+		if !encoding.ReadFloat32(data, &index, &entry.NextRTT) {
+			return false
+		}
+		if !encoding.ReadFloat32(data, &index, &entry.NextJitter) {
+			return false
+		}
+		if !encoding.ReadFloat32(data, &index, &entry.NextPacketLoss) {
+			return false
+		}
+		if !encoding.ReadUint8(data, &index, &entry.NumNextRelays) {
+			return false
+		}
+		if entry.NumNextRelays > BillingEntryMaxRelays {
+			return false
+		}
+		for i := 0; i < int(entry.NumNextRelays); i++ {
+			if !encoding.ReadUint64(data, &index, &entry.NextRelays[i]) {
+				return false
+			}
+		}
+		if !encoding.ReadUint64(data, &index, &entry.TotalPrice) {
+			return false
+		}
+	}
+	if entry.Version >= 2 {
+		if !encoding.ReadUint64(data, &index, &entry.ClientToServerPacketsLost) {
+			return false
+		}
+		if !encoding.ReadUint64(data, &index, &entry.ServerToClientPacketsLost) {
+			return false
+		}
+	}
+
+	if entry.Version >= 3 {
+		if !encoding.ReadBool(data, &index, &entry.Committed) {
+			return false
+		}
+
+		if !encoding.ReadBool(data, &index, &entry.Flagged) {
+			return false
+		}
+
+		if !encoding.ReadBool(data, &index, &entry.Multipath) {
+			return false
+		}
+
+		if !encoding.ReadBool(data, &index, &entry.Initial) {
+			return false
+		}
+
+		if entry.Next {
+			if !encoding.ReadUint64(data, &index, &entry.NextBytesUp) {
+				return false
+			}
+			if !encoding.ReadUint64(data, &index, &entry.NextBytesDown) {
+				return false
+			}
+		}
+	}
+
+	if entry.Version >= 4 {
+		if !encoding.ReadUint64(data, &index, &entry.DatacenterID) {
+			return false
+		}
+
+		if entry.Next {
+			if !encoding.ReadBool(data, &index, &entry.RTTReduction) {
+				return false
+			}
+			if !encoding.ReadBool(data, &index, &entry.PacketLossReduction) {
+				return false
+			}
+		}
+	}
+
+	if entry.Version >= 5 {
+		if entry.Next {
+			if !encoding.ReadUint8(data, &index, &entry.NumNextRelays) {
+				return false
+			}
+			if entry.NumNextRelays > BillingEntryMaxRelays {
+				return false
+			}
+			for i := 0; i < int(entry.NumNextRelays); i++ {
+				if !encoding.ReadUint64(data, &index, &entry.NextRelaysPrice[i]) {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}

--- a/billing/pubsub_forwarder.go
+++ b/billing/pubsub_forwarder.go
@@ -47,27 +47,10 @@ func NewPubSubForwarder(ctx context.Context, biller Biller, logger log.Logger, m
 // Forward reads the billing entry from pubsub and writes it to BigQuery
 func (psf *PubSubForwarder) Forward(ctx context.Context) {
 	err := psf.pubsubSubscription.Receive(ctx, func(ctx context.Context, m *pubsub.Message) {
-		// Check if the message is batched or unbatched (for compatibility with old data)
-		var messageLength uint32
-		var offset int
-		if !encoding.ReadUint32(m.Data, &offset, &messageLength) {
-			level.Error(psf.Logger).Log("msg", "failed to detect if message is batched or unbatched", "offset", offset, "length", len(m.Data))
+		entries, err := psf.unbatchMessages(m)
+		if err != nil {
+			level.Error(psf.Logger).Log("err", err)
 			psf.Metrics.ErrorMetrics.BillingBatchedReadFailure.Add(1)
-		}
-
-		var entries [][]byte
-		if messageLength <= uint32(len(m.Data)) {
-			// This is a new, batched message
-			var err error
-			entries, err = psf.unbatchMessages(m)
-			if err != nil {
-				level.Error(psf.Logger).Log("err", err)
-				psf.Metrics.ErrorMetrics.BillingBatchedReadFailure.Add(1)
-			}
-		} else {
-			// This is an old, unbatched message. ignore it and ack
-			m.Ack()
-			return
 		}
 
 		psf.Metrics.EntriesReceived.Add(float64(len(entries)))
@@ -81,27 +64,38 @@ func (psf *PubSubForwarder) Forward(ctx context.Context) {
 					level.Error(psf.Logger).Log("msg", "could not submit billing entry", "err", err)
 				}
 			} else {
-				entryVetoStr := os.Getenv("BILLING_ENTRY_VETO")
-				entryVeto, err := strconv.ParseBool(entryVetoStr)
-
-				if err != nil {
-					level.Error(psf.Logger).Log("msg", "failed to parse veto env var", "err", err)
-					psf.Metrics.ErrorMetrics.BillingReadFailure.Add(1)
-					return
-				}
-
-				if entryVeto {
+				// This might be an old version of the billing entry, so try and read it with user hash on version 5
+				if ReadBillingEntryUserHashV5(&billingEntries[i], entries[i]) {
 					m.Ack()
-					return
+					psf.Metrics.EntriesReadUserHashV5.Add(1)
+					billingEntries[i].Timestamp = uint64(m.PublishTime.Unix())
+					if err := psf.Biller.Bill(context.Background(), &billingEntries[i]); err != nil {
+						level.Error(psf.Logger).Log("msg", "could not submit billing entry", "err", err)
+					}
+				} else {
+					entryVetoStr := os.Getenv("BILLING_ENTRY_VETO")
+					entryVeto, err := strconv.ParseBool(entryVetoStr)
+
+					if err != nil {
+						level.Error(psf.Logger).Log("msg", "failed to parse veto env var", "err", err)
+						psf.Metrics.ErrorMetrics.BillingReadFailure.Add(1)
+						return
+					}
+
+					if entryVeto {
+						m.Ack()
+						return
+					}
+
+					psf.Metrics.ErrorMetrics.BillingReadFailure.Add(1)
 				}
-				psf.Metrics.ErrorMetrics.BillingReadFailure.Add(1)
 			}
 		}
 	})
-	if err != context.Canceled {
-		level.Error(psf.Logger).Log("msg", "could not setup to receive pubsub messages", "err", err)
-		os.Exit(1)
-	}
+
+	// If the Receive function returns for any reason, we want to immediately exit and restart the service
+	level.Error(psf.Logger).Log("msg", "stopped receive loop", "err", err)
+	os.Exit(1)
 }
 
 func (psf *PubSubForwarder) unbatchMessages(m *pubsub.Message) ([][]byte, error) {

--- a/metrics/metrics_types.go
+++ b/metrics/metrics_types.go
@@ -396,19 +396,21 @@ var EmptyBillingServiceMetrics BillingServiceMetrics = BillingServiceMetrics{
 }
 
 type BillingMetrics struct {
-	EntriesReceived  Counter
-	EntriesSubmitted Counter
-	EntriesQueued    Gauge
-	EntriesFlushed   Counter
-	ErrorMetrics     BillingErrorMetrics
+	EntriesReceived       Counter
+	EntriesSubmitted      Counter
+	EntriesQueued         Gauge
+	EntriesFlushed        Counter
+	EntriesReadUserHashV5 Counter
+	ErrorMetrics          BillingErrorMetrics
 }
 
 var EmptyBillingMetrics BillingMetrics = BillingMetrics{
-	EntriesReceived:  &EmptyCounter{},
-	EntriesSubmitted: &EmptyCounter{},
-	EntriesQueued:    &EmptyGauge{},
-	EntriesFlushed:   &EmptyCounter{},
-	ErrorMetrics:     EmptyBillingErrorMetrics,
+	EntriesReceived:       &EmptyCounter{},
+	EntriesSubmitted:      &EmptyCounter{},
+	EntriesQueued:         &EmptyGauge{},
+	EntriesFlushed:        &EmptyCounter{},
+	EntriesReadUserHashV5: &EmptyCounter{},
+	ErrorMetrics:          EmptyBillingErrorMetrics,
 }
 
 type BillingErrorMetrics struct {
@@ -2078,6 +2080,17 @@ func NewBillingServiceMetrics(ctx context.Context, metricsHandler Handler) (*Bil
 		ID:          "billing.entries.written",
 		Unit:        "entries",
 		Description: "The total number of billing entries written to BigQuery",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	billingServiceMetrics.BillingMetrics.EntriesReadUserHashV5, err = metricsHandler.NewCounter(ctx, &Descriptor{
+		DisplayName: "Billing Entries Read User Hash V5",
+		ServiceName: "billing",
+		ID:          "billing.entries.read.user_hash_v5",
+		Unit:        "entries",
+		Description: "The total number of billing entries read from PubSub with the user hash on version 5",
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There are still some old billing entries that are failing to read and clogging up the pubsub queue:
1. Entries on V5 without the user hash
2. Entries on V5 with the user hash
3. Entries on V6 with the user hash (this is the current version)

Type 1 and type 3 can already be read with the code as is (type 1 will pass because it skips the user hash check, since it's versioned on version 6).
Type 2 is the current blocker. So to fix it, I went the safe way and if a billing entry fails to read, try to read it with the user hash on V5. This way we won't ack anything without the read succeeding. I did this instead of just acking the older V5 since I didn't know how many entries are V5 vs V6. So I also added metric to track how many V5 reads we make.

I also think I fixed an issue where the billing service just silently stops working. I've removed an if check in the `Forward()` function so if the pubsub receive loops stops for any reason, the service will shut down and be restarted by systemd.