### PR TITLE
Dev Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,7 @@ deploy-portal-cruncher-dev: ## builds and deploys the portal cruncher to dev
 	./deploy/deploy.sh -e dev -c dev-1 -t portal-cruncher -b gs://development_artifacts
 
 .PHONY: deploy-relay-backend-staging
-deploy-relay-backend-prod: ## builds and deploys the relay backend to prod
+deploy-relay-backend-staging: ## builds and deploys the relay backend to prod
 	./deploy/deploy.sh -e staging -c staging-1 -t relay-backend -b gs://staging_artifacts
 
 .PHONY: deploy-portal-cruncher-staging

--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -1677,7 +1677,8 @@ func (fs *Firestore) syncRelays(ctx context.Context) error {
 		// Get datacenter
 		ddoc, err := r.Datacenter.Get(ctx)
 		if err != nil {
-			return &FirestoreError{err: err}
+			level.Warn(fs.Logger).Log("msg", fmt.Sprintf("failed to get datacenter reference %s on relay %016x", r.Datacenter.ID, rid), "err", err)
+			continue
 		}
 
 		var d datacenter
@@ -1703,7 +1704,8 @@ func (fs *Firestore) syncRelays(ctx context.Context) error {
 		// Get seller
 		sdoc, err := r.Seller.Get(ctx)
 		if err != nil {
-			return &FirestoreError{err: err}
+			level.Warn(fs.Logger).Log("msg", fmt.Sprintf("failed to get seller reference %s on relay %016x", r.Datacenter.ID, rid), "err", err)
+			continue
 		}
 
 		var s seller


### PR DESCRIPTION
This PR fixes a few issues:
1. The deploy commands were throwing a warning because one of the makefile names was copy+pasted incorrectly.
2. The firestore relay sync should continue if a datacenter or seller reference isn't found.