### PR TITLE
Iterate portal dev

### DIFF
--- a/transport/jsonrpc/buyer.go
+++ b/transport/jsonrpc/buyer.go
@@ -482,7 +482,7 @@ func (s *BuyersService) SessionDetails(r *http.Request, args *SessionDetailsArgs
 
 	reply.Slices = make([]transport.SessionSlice, 0)
 
-	sessionSlicesClient := s.RedisPoolSessionMeta.Get()
+	sessionSlicesClient := s.RedisPoolSessionSlices.Get()
 	defer sessionSlicesClient.Close()
 
 	slices, err := redis.Strings(sessionSlicesClient.Do("LRANGE", fmt.Sprintf("ss-%s", args.SessionID), "0", "-1"))


### PR DESCRIPTION
Should be the last fixes before we can take it to staging.

1. Fixed session counts resetting back to 0 every minute (wasn't seeing this locally, probably because clients all update at the same time). Fix was to take the max count between the current minute bucket and the previous minute bucket.
2. Fixed session slice data. Was using the meta pool when I should have used the slice pool. Didn't catch locally because it's all in the same redis server.