### PR TITLE
Sort portal slices

### DIFF
--- a/transport/jsonrpc/buyer.go
+++ b/transport/jsonrpc/buyer.go
@@ -504,6 +504,10 @@ func (s *BuyersService) SessionDetails(r *http.Request, args *SessionDetailsArgs
 		reply.Slices = append(reply.Slices, sessionSlice)
 	}
 
+	sort.Slice(reply.Slices, func(i, j int) bool {
+		return reply.Slices[i].Timestamp.Before(reply.Slices[j].Timestamp)
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
Sorts the session slices by ascending timestamp. I initially omitted this because I was hoping that redis' list would keep everything sorted, but now I realize that if multiple goroutines are trying to update the same list at once then there's no guarantee of order.