### PR TITLE
Fix Score

### DIFF
--- a/cmd/portal-cruncher/portal_cruncher.go
+++ b/cmd/portal-cruncher/portal_cruncher.go
@@ -395,8 +395,14 @@ func main() {
 						point := &portalDataBuffer[j].Point
 						sessionID := fmt.Sprintf("%016x", meta.ID)
 						customerID := fmt.Sprintf("%016x", meta.BuyerID)
-						score := meta.DeltaRTT
 						next := meta.OnNetworkNext
+						score := meta.DeltaRTT
+						if score < 0 {
+							score = 0
+						}
+						if !next {
+							score = -meta.DirectRTT
+						}
 
 						// Check if we should randomize the location (for staging load test)
 						if point.Latitude == 0 && point.Longitude == 0 && strings.Contains(meta.ClientAddr, "10.128.") {


### PR DESCRIPTION
Fixes the score in redis to set next sessions to 0 if there is no improvement, and direct sessions to their negative direct RTT. This way next sessions will always be on top in the top sessions list.