### PR TITLE
Added console debug to portal.js

### DIFF
--- a/cmd/portal/public/js/portal.js
+++ b/cmd/portal/public/js/portal.js
@@ -404,8 +404,9 @@ MapHandler = {
 						layers: layers
 					});
 				} else {
-					const isStaging = window.location.hostname == 'portal-staging.networknext.com';
-					if (UserHandler.isAdmin() && isStaging) {
+					const displayLayersDebug = ((window.location.hostname == 'portal-staging.networknext.com') ||
+									  		    (window.location.hostname == 'portal-dev.networknext.com'));
+					if (UserHandler.isAdmin() && displayLayersDebug) {
 							console.log("deckGL layers object:")
 							console.log(layers)
 					}


### PR DESCRIPTION
In the staging environment we keep seeing exactly the same error in the browser console log:

`deck: error during initialization of ScreenGridLayer({id: 'direct-layer'})`

at portal.js, line 408. This is difficult to debug in the happy path (0,0 is not added to the render layers) but will help us determine why the direct layer is blowing up deckGL. Can be removed later.