### PR TITLE
Fix Portal Cruncher Redis Ping

### DIFF
--- a/cmd/portal-cruncher/portal_cruncher.go
+++ b/cmd/portal-cruncher/portal_cruncher.go
@@ -376,21 +376,25 @@ func main() {
 					if time.Since(pingTime) >= time.Second*10 {
 						if err := clientTopSessions.Ping(); err != nil {
 							level.Error(logger).Log("msg", "failed to ping REDIS_HOST_TOP_SESSIONS", "err", err)
+							fmt.Println(err)
 							os.Exit(1)
 						}
 
 						if err := clientSessionMap.Ping(); err != nil {
 							level.Error(logger).Log("msg", "failed to ping REDIS_HOST_SESSION_MAP", "err", err)
+							fmt.Println(err)
 							os.Exit(1)
 						}
 
 						if err := clientSessionMeta.Ping(); err != nil {
 							level.Error(logger).Log("msg", "failed to ping REDIS_HOST_SESSION_META", "err", err)
+							fmt.Println(err)
 							os.Exit(1)
 						}
 
 						if err := clientSessionSlices.Ping(); err != nil {
 							level.Error(logger).Log("msg", "failed to ping REDIS_HOST_SESSION_SLICES", "err", err)
+							fmt.Println(err)
 							os.Exit(1)
 						}
 

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -54,7 +54,9 @@ func NewRawRedisClient(hostname string) (*RawRedisClient, error) {
 }
 
 func (r *RawRedisClient) Ping() error {
-	r.Command("PING", "")
+	if err := r.Command("PING", ""); err != nil {
+		return err
+	}
 
 	redisReplyReader := bufio.NewReader(r.conn)
 	_, err := redisReplyReader.ReadString('\n')
@@ -65,18 +67,20 @@ func (r *RawRedisClient) Ping() error {
 	return nil
 }
 
-func (r *RawRedisClient) Command(command string, format string, args ...interface{}) {
+func (r *RawRedisClient) Command(command string, format string, args ...interface{}) error {
 	if len(args) != 0 {
 		commandString := fmt.Sprintf(command+" "+format+"\r\n", args...)
 		if _, err := fmt.Fprint(r.conn, commandString); err != nil {
-			fmt.Printf("failed to write redis command '%s': %v\n", commandString, err)
+			return fmt.Errorf("failed to write redis command '%s': %v", commandString, err)
 		}
 	} else {
 		commandString := fmt.Sprintf(command+"\r\n", args...)
 		if _, err := fmt.Fprint(r.conn, commandString); err != nil {
-			fmt.Printf("failed to write redis command '%s': %v\n", commandString, err)
+			return fmt.Errorf("failed to write redis command '%s': %v", commandString, err)
 		}
 	}
+
+	return nil
 }
 
 func (r *RawRedisClient) StartCommand(command string) {


### PR DESCRIPTION
Now if the ping command fails, we will error out in the Ping function. Previously we wouldn't check if the write failed, so if it did we would always get no response and miss the error.