### PR TITLE
Fix makefile build and publish server backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -592,7 +592,7 @@ build-relay-backend-artifacts-prod: build-relay-backend ## builds the relay back
 
 .PHONY: build-server-backend-artifacts-prod
 build-server-backend-artifacts-prod: build-server-backend ## builds the server backend artifacts prod
-	./deploy/build-artifacts.sh -e prod -s server-backend
+	./deploy/build-artifacts.sh -e prod -s server_backend
 
 .PHONY: publish-billing-artifacts-dev
 publish-billing-artifacts-dev: ## publishes the billing artifacts to GCP Storage with gsutil dev
@@ -688,7 +688,7 @@ publish-relay-backend-artifacts-prod: ## publishes the relay backend artifacts t
 
 .PHONY: publish-server-backend-artifacts-prod
 publish-server-backend-artifacts-prod: ## publishes the server backend artifacts to GCP Storage with gsutil prod
-	./deploy/publish.sh -e prod -b $(ARTIFACT_BUCKET_PROD) -s server-backend
+	./deploy/publish.sh -e prod -b $(ARTIFACT_BUCKET_PROD) -s server_backend
 
 .PHONY: publish-bootstrap-script-dev
 publish-bootstrap-script-dev:


### PR DESCRIPTION
Changes the server backend from kebab back to snake case.

I think the easiest way to fix our deploy setup right now is to have the deploy.sh script take in both the snake and kebab case versions of each service and use the snake case when fetching the artifact from GCP and the kebab case when accessing the VMs.