### PR TITLE
Include Near Cost in RTT Check

### DIFF
--- a/routing/route_matrix.go
+++ b/routing/route_matrix.go
@@ -146,6 +146,8 @@ func (m *RouteMatrix) GetAcceptableRoutes(near []NearRelayData, destIDs []uint64
 
 			entry := &m.Entries[entryIndex]
 
+			nearCost := int32(math.Ceil(nearRelay.ClientStats.RTT))
+
 			// During this first pass, we can calculate the maximum route size and
 			// use this value to preallocate the routes slice
 			maxRoutesSize += entry.NumRoutes
@@ -153,7 +155,7 @@ func (m *RouteMatrix) GetAcceptableRoutes(near []NearRelayData, destIDs []uint64
 			// The routes in each route matrix entry are sorted by ascending RTT,
 			// so we only need to check the first one to find the best RTT
 			for routeIndex := 0; routeIndex < int(entry.NumRoutes); routeIndex++ {
-				routeRTT := entry.RouteRTT[routeIndex]
+				routeRTT := entry.RouteRTT[routeIndex] + nearCost
 				if routeRTT < bestRouteRTT {
 					// Make sure any relay in the route isn't encumbered when considering it for the best route RTT
 					isEncumbered := false
@@ -200,8 +202,10 @@ func (m *RouteMatrix) GetAcceptableRoutes(near []NearRelayData, destIDs []uint64
 
 			entry := &m.Entries[entryIndex]
 
+			nearCost := int32(math.Ceil(nearRelay.ClientStats.RTT))
+
 			for routeIndex := 0; routeIndex < int(entry.NumRoutes); routeIndex++ {
-				routeRTT := entry.RouteRTT[routeIndex]
+				routeRTT := entry.RouteRTT[routeIndex] + nearCost
 
 				// Since the routes in the route matrix entry are sorted by ascending RTT,
 				// if we find a route that's not acceptable, we can early out
@@ -234,7 +238,7 @@ func (m *RouteMatrix) GetAcceptableRoutes(near []NearRelayData, destIDs []uint64
 				route := &Route{
 					RelayIDs: routeRelayIDs,
 					Stats: Stats{
-						RTT: math.Ceil(nearRelay.ClientStats.RTT) + float64(routeRTT),
+						RTT: float64(routeRTT),
 					},
 				}
 

--- a/routing/route_matrix_test.go
+++ b/routing/route_matrix_test.go
@@ -1385,6 +1385,59 @@ func TestRouteMatrix(t *testing.T) {
 			}
 		})
 
+		t.Run("acceptable routes with near cost", func(t *testing.T) {
+			near := []routing.NearRelayData{{ID: 2836356269, ClientStats: routing.Stats{RTT: 10}}}
+			dest := []uint64{3263834878, 1500948990}
+			expected := []routing.Route{
+				{
+					RelayIDs: []uint64{2836356269, 1370686037, 2923051732, 1884974764, 3263834878},
+					Stats:    routing.Stats{RTT: 192},
+				},
+				{
+					RelayIDs: []uint64{2836356269, 1370686037, 2641807504, 3263834878},
+					Stats:    routing.Stats{RTT: 192},
+				},
+				{
+					RelayIDs: []uint64{2836356269, 1370686037, 1348914502, 1884974764, 3263834878},
+					Stats:    routing.Stats{RTT: 192},
+				},
+				{
+					RelayIDs: []uint64{2836356269, 1370686037, 2576485547, 1835585494, 3263834878},
+					Stats:    routing.Stats{RTT: 193},
+				},
+				{
+					RelayIDs: []uint64{2836356269, 1348914502, 1884974764, 3263834878},
+					Stats:    routing.Stats{RTT: 193},
+				},
+				{
+					RelayIDs: []uint64{2836356269, 1370686037, 2663193268, 2504465311, 3263834878},
+					Stats:    routing.Stats{RTT: 194},
+				},
+				{
+					RelayIDs: []uint64{2836356269, 1370686037, 427962386, 2504465311, 3263834878},
+					Stats:    routing.Stats{RTT: 194},
+				},
+				{
+					RelayIDs: []uint64{2836356269, 1370686037, 4058587524, 1350942731, 3263834878},
+					Stats:    routing.Stats{RTT: 194},
+				},
+			}
+
+			actual, err := routeMatrixCopy.GetAcceptableRoutes(near, dest, 0, 5)
+			assert.NoError(t, err)
+			assert.Equal(t, len(expected), len(actual))
+
+			for routeidx, route := range expected {
+				assert.Equal(t, len(expected[routeidx].RelayIDs), len(route.RelayIDs))
+
+				for relayidx := range route.RelayIDs {
+					assert.Equal(t, expected[routeidx].RelayIDs[relayidx], actual[routeidx].RelayIDs[relayidx])
+				}
+
+				assert.Equal(t, expected[routeidx].Stats, actual[routeidx].Stats)
+			}
+		})
+
 		t.Run("contains route and route is still acceptable", func(t *testing.T) {
 			near := []routing.NearRelayData{{ID: 2836356269}}
 			dest := []uint64{3263834878, 1500948990}


### PR DESCRIPTION
This PR includes the near cost (RTT from game client -> near relay) in the RTT check when getting acceptable routes. Not sure this will fix routes in dev yet, but we should have this check here anyway.