### PR TITLE
Fix Relay Stats Endpoint

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -975,7 +975,7 @@ func main() {
 								IncludedBandwidthGB: 1,
 								ManagementAddr:      "127.0.0.1",
 								SSHUser:             "root",
-								SSHPort:             40000,
+								SSHPort:             22,
 							}
 
 							jsonBytes, err := json.MarshalIndent(example, "", "\t")

--- a/cmd/portal/portal.go
+++ b/cmd/portal/portal.go
@@ -428,10 +428,15 @@ func main() {
 				level.Error(logger).Log("msg", "unable to get relay stats", "err", err)
 				continue
 			}
-			defer res.Body.Close()
+
+			if res.ContentLength == -1 {
+				res.Body.Close()
+				continue
+			}
 
 			data := make([]byte, res.ContentLength)
 			res.Body.Read(data)
+			res.Body.Close()
 
 			index := 0
 
@@ -475,16 +480,19 @@ func main() {
 				var major uint8
 				if !encoding.ReadUint8(data, &index, &major) {
 					level.Error(logger).Log("msg", "unable to relay stats major version")
+					break
 				}
 
 				var minor uint8
 				if !encoding.ReadUint8(data, &index, &minor) {
 					level.Error(logger).Log("msg", "unable to relay stats minor version")
+					break
 				}
 
 				var patch uint8
 				if !encoding.ReadUint8(data, &index, &patch) {
 					level.Error(logger).Log("msg", "unable to relay stats patch version")
+					break
 				}
 
 				relay.Version = fmt.Sprintf("%d.%d.%d", major, minor, patch)

--- a/transport/relay_handlers.go
+++ b/transport/relay_handlers.go
@@ -656,6 +656,7 @@ func RoutesHandlerFunc(GetRouteMatrix func() *routing.RouteMatrix, statsdb *rout
 func RelayStatsFunc(logger log.Logger, rmap *routing.RelayMap) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, request *http.Request) {
 		if bin, err := rmap.MarshalBinary(); err == nil {
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(bin)))
 			w.WriteHeader(http.StatusOK)
 			w.Write(bin)
 		} else {


### PR DESCRIPTION
Adding the 40th relay to staging caused the relay_stats endpoint to become large enough where Go doesn't automatically fill out the `Content-Length` header for you. So I added that in manually, along with a -1 check on the portal side so it doesn't crash like this again.

I also noticed a potential leak in closing the HTTP response body, so I fixed that up as well. The close was deferred, but it was running in an indefinite for loop, so it wouldn't ever close the connection.