### PR TITLE
Happy path Makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -755,6 +755,7 @@ build-relay:
 	@printf "Building relay... "
 	@mkdir -p $(DIST_DIR)
 	@cd $(RELAY_DIR) && $(MAKE) release
+	@cp cmd/relay/bin/relay $(DIST_DIR)
 	@echo "done"
 
 .PHONY: dev-relay

--- a/reference/relay/relay.cpp
+++ b/reference/relay/relay.cpp
@@ -14,6 +14,8 @@
 #include <map>
 #include <float.h>
 #include <signal.h>
+#include <atomic>
+
 #include "curl/curl.h"
 
 #define RELAY_MTU                                               1300


### PR DESCRIPTION
I modified the main Makefile to copy the `relay` binary into the ./dist directory, and added an include for `<atomic>` in relay.cpp.