### PR TITLE
Bring Back Multi Clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,10 @@ dev-reference-relay: build-relay-ref ## runs a local reference relay
 dev-client3: build-client3  ## runs a local client (sdk3)
 	@./dist/client3
 
+.PHONY: dev-multi-clients3
+dev-multi-clients3: build-client3  ## runs 10 local clients (sdk3)
+	@./scripts/client-spawner.sh -n 10 -v 3
+
 .PHONY: dev-server3
 dev-server3: build-sdk3 build-server3  ## runs a local server (sdk3)
 	@./dist/server3
@@ -354,6 +358,10 @@ dev-server3: build-sdk3 build-server3  ## runs a local server (sdk3)
 .PHONY: dev-client4
 dev-client4: build-client4  ## runs a local client (sdk4)
 	@./dist/client4
+
+.PHONY: dev-multi-clients4
+dev-multi-clients4: build-client4  ## runs 10 local clients (sdk4)
+	@./scripts/client-spawner.sh -n 10 -v 4
 
 .PHONY: dev-server4
 dev-server4: build-sdk4 build-server4  ## runs a local server (sdk4)

--- a/scripts/client-spawner.sh
+++ b/scripts/client-spawner.sh
@@ -4,6 +4,7 @@ export NEXT_CUSTOMER_PUBLIC_KEY=leN7D7+9vr24uT4f1Ba8PEEvIQA/UkGZLlT+sdeLRHKsVqaZ
 export NEXT_CUSTOMER_PRIVATE_KEY=leN7D7+9vr3TEZexVmvbYzdH1hbpwBvioc6y1c9Dhwr4ZaTkEWyX2Li5Ph/UFrw8QS8hAD9SQZkuVP6x14tEcqxWppmrvbdn
 
 num_clients=1
+version=3
 
 print_usage() {
     printf "Usage: client-spawner.sh -n number\n\n"
@@ -22,9 +23,10 @@ print_env() {
   printf "NEXT_CUSTOMER_PRIVATE_KEY: ${NEXT_CUSTOMER_PRIVATE_KEY}\n"
 }
 
-while getopts 'n:h' flag; do
+while getopts 'n:v:h' flag; do
   case "${flag}" in
     n) num_clients="${OPTARG}" ;;
+    v) version="${OPTARG}" ;;
     h) print_usage
        exit 1 ;;
     *) print_usage
@@ -34,11 +36,22 @@ done
 
 trap "kill 0" EXIT
 
-for ((r=0 ; r<${num_clients} ; r++)); do
-./dist/client &
-pid="$!"
-printf "PID ${pid}: Client opened\n"
-done
+if [ "$version" = "3" ]; then
+  for ((r=0 ; r<${num_clients} ; r++)); do
+    ./dist/client3 &
+    pid="$!"
+    printf "PID ${pid}: Client opened\n"
+  done
+elif [ "$version" = "4" ]; then
+  for ((r=0 ; r<${num_clients} ; r++)); do
+    ./dist/client4 &
+    pid="$!"
+    printf "PID ${pid}: Client opened\n"
+  done
+else
+  printf "Unknown client version $version\n"
+  exit
+fi
 
 print_env
 


### PR DESCRIPTION
Looks like `make dev-multi-clients` got removed when the make commands were updated with SDK versions 3 and 4, so I updated the `client-spawner.sh` script to support either SDK 3 or 4 and added `make dev-multi-clients3` and `make dev-multi-clients4`.