### PR TITLE
Better Location Check

### DIFF
--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -776,21 +776,7 @@ func SessionUpdateHandlerFunc(params *SessionUpdateParams) func(io.Writer, *UDPP
 
 		timestamp := time.Now()
 
-		// Check if this user has been excluded from ever taking a network next route.
-		// If they have, then simply respond with the direct route and early out.
-		if _, ok := buyer.RoutingRulesSettings.ExcludedUserHashes[packet.UserHash]; ok {
-			routeDecision = routing.Decision{
-				OnNetworkNext: false,
-				Reason:        routing.DecisionExcludedUser,
-			}
-
-			sendRouteResponse(w, &directRoute, params, &packet, &response, serverDataReadOnly, &buyer, &lastNextStats, &lastDirectStats, &location, nearRelayData, routeDecision, sessionDataReadOnly.RouteDecision, sessionDataReadOnly.Initial, vetoReason, multipathVetoReason, nextSliceCounter,
-				committedData, sessionDataReadOnly.RouteHash, sessionDataReadOnly.RouteDecision.OnNetworkNext, timestamp, routeExpireTimestamp, sessionDataReadOnly.TokenVersion, params.RouterPrivateKey, nil, postSessionUpdateFunc) //sliceMutexes)
-
-			return
-		}
-
-		if location.IsZero() {
+		if newSession {
 			var err error
 			location, err = params.GetIPLocator().LocateIP(packet.ClientAddress.IP)
 
@@ -839,6 +825,20 @@ func SessionUpdateHandlerFunc(params *SessionUpdateParams) func(io.Writer, *UDPP
 
 			sendRouteResponse(w, &directRoute, params, &packet, &response, serverDataReadOnly, &buyer, &lastNextStats, &lastDirectStats, &location, nearRelayData, routeDecision, sessionDataReadOnly.RouteDecision, sessionDataReadOnly.Initial, vetoReason, multipathVetoReason, nextSliceCounter,
 				committedData, sessionDataReadOnly.RouteHash, sessionDataReadOnly.RouteDecision.OnNetworkNext, timestamp, routeExpireTimestamp, sessionDataReadOnly.TokenVersion, params.RouterPrivateKey, nil, postSessionUpdateFunc) //sliceMutexes)
+			return
+		}
+
+		// Check if this user has been excluded from ever taking a network next route.
+		// If they have, then simply respond with the direct route and early out.
+		if _, ok := buyer.RoutingRulesSettings.ExcludedUserHashes[packet.UserHash]; ok {
+			routeDecision = routing.Decision{
+				OnNetworkNext: false,
+				Reason:        routing.DecisionExcludedUser,
+			}
+
+			sendRouteResponse(w, &directRoute, params, &packet, &response, serverDataReadOnly, &buyer, &lastNextStats, &lastDirectStats, &location, nearRelayData, routeDecision, sessionDataReadOnly.RouteDecision, sessionDataReadOnly.Initial, vetoReason, multipathVetoReason, nextSliceCounter,
+				committedData, sessionDataReadOnly.RouteHash, sessionDataReadOnly.RouteDecision.OnNetworkNext, timestamp, routeExpireTimestamp, sessionDataReadOnly.TokenVersion, params.RouterPrivateKey, nil, postSessionUpdateFunc) //sliceMutexes)
+
 			return
 		}
 


### PR DESCRIPTION
Changed the location check to get the client's location only on the first slice rather than checking if the location is zero. This is because in staging, all of the locations are zero, so staging is running the location check every slice, when realistically this wouldn't happen in prod.

I've also moved the user exclusion check below the location check so that we can still have location information for users we exclude.