### PR TITLE
Remove Relay Public Key From next relay add

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"io/ioutil"
 	"net"
@@ -26,7 +27,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"hash/fnv"
 
 	"github.com/networknext/backend/crypto"
 	"github.com/networknext/backend/routing"
@@ -327,7 +327,6 @@ type seller struct {
 type relay struct {
 	Name                string
 	Addr                string
-	PublicKey           string
 	SellerID            string
 	DatacenterName      string
 	NicSpeedMbps        uint64
@@ -931,19 +930,13 @@ func main() {
 						handleRunTimeError(fmt.Sprintf("Could not resolve udp address %s: %v\n", relay.Addr, err), 1)
 					}
 
-					publicKey, err := base64.StdEncoding.DecodeString(relay.PublicKey)
-					if err != nil {
-						handleRunTimeError(fmt.Sprintf("Could not decode bas64 public key %s: %v\n", relay.PublicKey, err), 1)
-					}
-
 					// Build the actual Relay struct from the input relay struct
 					rid := crypto.HashID(relay.Addr)
 					realRelay := routing.Relay{
-						ID:        rid,
-						SignedID:  int64(rid),
-						Name:      relay.Name,
-						Addr:      *addr,
-						PublicKey: publicKey,
+						ID:       rid,
+						SignedID: int64(rid),
+						Name:     relay.Name,
+						Addr:     *addr,
 						Seller: routing.Seller{
 							ID: relay.SellerID,
 						},
@@ -972,7 +965,6 @@ func main() {
 							example := relay{
 								Name:                "amazon.ohio.2",
 								Addr:                "127.0.0.1:40000",
-								PublicKey:           "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
 								SellerID:            "5tCm7KjOw3EBYojLe6PC",
 								DatacenterName:      "amazon.ohio.2",
 								NicSpeedMbps:        1000,


### PR DESCRIPTION
Closes #621.

Removes the public key requirement from `next relay add` and from `next relay add example`. The user doesn't need to know the public key, the keypair is generated and taken care of in `next relay update` anyway.