### PR TITLE
Add SDK4 Submodule to Semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,8 +15,8 @@ global_job_config:
       - make clean
       - chmod 0600 ~/.ssh/id_rsa_semaphoreci_sdk4
       - ssh-add ~/.ssh/id_rsa_semaphoreci_sdk4
-      - git submodule init
-      - git submodule update
+      - git submodule init sdk4
+      - git submodule update sdk4
 blocks:
   - name: Unit Tests
     task:


### PR DESCRIPTION
Semaphore couldn't build SDK4 because the filepath doesn't exist, so this PR has Semaphore pull in the submoduled sdk4 so it can build the load test client and server properly.