### PR TITLE
fixed overage print formatting

### DIFF
--- a/cmd/next/relays.go
+++ b/cmd/next/relays.go
@@ -104,7 +104,7 @@ func opsRelays(
 		}
 		overage := "n/a"
 		if relay.Overage > 0 {
-			overage = fmt.Sprintf("%.2f", relay.Overage.ToCents()/100)
+			overage = fmt.Sprintf("%.5f", relay.Overage.ToCents()/100)
 		}
 
 		var bwRule string


### PR DESCRIPTION
`next` tool fix - needed more decimal places displayed for the _overage_ field in the relays ops view.