### PR TITLE
Nibblins conversion fix

### DIFF
--- a/routing/nibblin.go
+++ b/routing/nibblin.go
@@ -9,7 +9,7 @@ func CentsToNibblins(cents float64) Nibblin {
 }
 
 func DollarsToNibblins(dollars float64) Nibblin {
-	return Nibblin(dollars * 1e7)
+	return Nibblin(dollars * 1e11)
 }
 
 func (n Nibblin) ToCents() float64 {
@@ -17,5 +17,5 @@ func (n Nibblin) ToCents() float64 {
 }
 
 func (n Nibblin) ToDollars() float64 {
-	return float64(n) / 1e7
+	return float64(n) / 1e11
 }


### PR DESCRIPTION
Fixed the _ToDollars()_ method. It is only used to change the display in the `next` tool so no emergency.