### PR TITLE
Add EnvelopeBytesUp and EnvelopeBytesDown to Billing Entry

### DIFF
--- a/billing/billing_entry.go
+++ b/billing/billing_entry.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	BillingEntryVersion = uint8(9)
+	BillingEntryVersion = uint8(10)
 
 	BillingEntryMaxRelays           = 5
 	BillingEntryMaxISPLength        = 64
@@ -41,6 +41,8 @@ type BillingEntry struct {
 	Initial                   bool
 	NextBytesUp               uint64
 	NextBytesDown             uint64
+	EnvelopeBytesUp           uint64
+	EnvelopeBytesDown         uint64
 	DatacenterID              uint64
 	RTTReduction              bool
 	PacketLossReduction       bool
@@ -98,6 +100,8 @@ func WriteBillingEntry(entry *BillingEntry) []byte {
 	if entry.Next {
 		encoding.WriteUint64(data, &index, entry.NextBytesUp)
 		encoding.WriteUint64(data, &index, entry.NextBytesDown)
+		encoding.WriteUint64(data, &index, entry.EnvelopeBytesUp)
+		encoding.WriteUint64(data, &index, entry.EnvelopeBytesDown)
 	}
 
 	encoding.WriteUint64(data, &index, entry.DatacenterID)
@@ -219,6 +223,15 @@ func ReadBillingEntry(entry *BillingEntry, data []byte) bool {
 			}
 			if !encoding.ReadUint64(data, &index, &entry.NextBytesDown) {
 				return false
+			}
+
+			if entry.Version >= 10 {
+				if !encoding.ReadUint64(data, &index, &entry.EnvelopeBytesUp) {
+					return false
+				}
+				if !encoding.ReadUint64(data, &index, &entry.EnvelopeBytesDown) {
+					return false
+				}
 			}
 		}
 	}

--- a/billing/googlebigquery.go
+++ b/billing/googlebigquery.go
@@ -104,6 +104,8 @@ func (entry *BillingEntry) Save() (map[string]bigquery.Value, string, error) {
 		e["initial"] = entry.Initial
 		e["nextBytesUp"] = int(entry.NextBytesUp)
 		e["nextBytesDown"] = int(entry.NextBytesDown)
+		e["envelopeBytesUp"] = int(entry.EnvelopeBytesUp)
+		e["envelopeBytesDown"] = int(entry.EnvelopeBytesDown)
 	}
 
 	e["datacenterID"] = int(entry.DatacenterID)

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -1227,6 +1227,8 @@ type PostSessionUpdateParams struct {
 	nextRelaysPrice     []routing.Nibblin
 	nextBytesUp         uint64
 	nextBytesDown       uint64
+	envelopeBytesUp     uint64
+	envelopeBytesDown   uint64
 	prevInitial         bool
 	abTest              bool
 	packetLoss          float32
@@ -1397,6 +1399,8 @@ func buildBillingEntry(params *PostSessionUpdateParams) *billing.BillingEntry {
 		Initial:                   params.prevInitial,
 		NextBytesUp:               params.nextBytesUp,
 		NextBytesDown:             params.nextBytesDown,
+		EnvelopeBytesUp:           params.envelopeBytesUp,
+		EnvelopeBytesDown:         params.envelopeBytesDown,
 		DatacenterID:              params.serverDataReadOnly.Datacenter.ID,
 		RTTReduction:              params.prevRouteDecision.Reason&routing.DecisionRTTReduction != 0 || params.prevRouteDecision.Reason&routing.DecisionRTTReductionMultipath != 0,
 		PacketLossReduction:       params.prevRouteDecision.Reason&routing.DecisionHighPacketLossMultipath != 0,
@@ -1665,6 +1669,8 @@ func sendRouteResponse(w io.Writer, chosenRoute *routing.Route, params *SessionU
 		nextRelaysPrice:     nextRelaysPrice,
 		nextBytesUp:         usageBytesUp,
 		nextBytesDown:       usageBytesDown,
+		envelopeBytesUp:     envelopeBytesUp,
+		envelopeBytesDown:   envelopeBytesDown,
 		prevInitial:         prevInitial,
 		abTest:              buyer.RoutingRulesSettings.EnableABTest,
 		packetLoss:          float32(inGamePacketLoss),


### PR DESCRIPTION
Adds the envelope values up and down in bytes to the billing entry. This is so these values can be used in the price per GB calculation rather than the actual bandwidth usage.