### PR TITLE
Multipath Veto Jitter

### DIFF
--- a/routing/route_decision_test.go
+++ b/routing/route_decision_test.go
@@ -263,7 +263,7 @@ func TestDecideMultipath(t *testing.T) {
 	packetLossThreshold := float64(routing.LocalRoutingRulesSettings.MultipathPacketLossThreshold)
 
 	// Test if multipath isn't enabled
-	routeDecisionFunc := routing.DecideMultipath(false, false, false, rttThreshold, packetLossThreshold, 0)
+	routeDecisionFunc := routing.DecideMultipath(false, false, false, rttThreshold, packetLossThreshold, 0, false)
 	predictedNNStats := &routing.Stats{RTT: 30}
 	directStats := &routing.Stats{RTT: 60}
 	decision := routing.Decision{}
@@ -271,7 +271,7 @@ func TestDecideMultipath(t *testing.T) {
 	assert.Equal(t, routing.Decision{}, decision)
 
 	// Test if multipath is already active
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, false)
 	decision = routing.Decision{true, routing.DecisionRTTReductionMultipath}
 	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
 	assert.Equal(t, routing.Decision{true, routing.DecisionRTTReductionMultipath}, decision)
@@ -282,7 +282,7 @@ func TestDecideMultipath(t *testing.T) {
 	assert.Equal(t, routing.Decision{true, routing.DecisionRTTReductionMultipath}, decision)
 
 	// Test when multipath reason is high jitter
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, false)
 	decision = routing.Decision{}
 	predictedNNStats = &routing.Stats{}
 	directStats = &routing.Stats{Jitter: 50, RTT: -6.0}
@@ -290,7 +290,7 @@ func TestDecideMultipath(t *testing.T) {
 	assert.Equal(t, routing.Decision{true, routing.DecisionHighJitterMultipath}, decision)
 
 	// Test when multipath reason is high ping packet loss
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, false)
 	decision = routing.Decision{}
 	predictedNNStats = &routing.Stats{}
 	directStats = &routing.Stats{PacketLoss: 1, RTT: -6.0}
@@ -298,9 +298,32 @@ func TestDecideMultipath(t *testing.T) {
 	assert.Equal(t, routing.Decision{true, routing.DecisionHighPacketLossMultipath}, decision)
 
 	// Test when multipath reason is high in game packet loss
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 1)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 1, false)
 	decision = routing.Decision{}
 	predictedNNStats = &routing.Stats{}
 	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
 	assert.Equal(t, routing.Decision{true, routing.DecisionHighPacketLossMultipath}, decision)
+
+	// Test multipath veto with high RTT
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, false)
+	decision = routing.Decision{true, routing.DecisionRTTReductionMultipath}
+	directStats = &routing.Stats{RTT: 500}
+	predictedNNStats = &routing.Stats{}
+	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
+	assert.Equal(t, routing.Decision{false, routing.DecisionMultipathVetoRTT}, decision)
+
+	// Test multipath veto with high jitter and on a wired connection
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, true)
+	decision = routing.Decision{true, routing.DecisionHighJitterMultipath}
+	directStats = &routing.Stats{Jitter: 500}
+	predictedNNStats = &routing.Stats{}
+	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
+	assert.Equal(t, routing.Decision{false, routing.DecisionMultipathVetoRTT}, decision)
+
+	// Test multipath veto isn't triggered with high jitter on a wireless connection
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, false)
+	decision = routing.Decision{true, routing.DecisionHighJitterMultipath}
+	predictedNNStats = &routing.Stats{}
+	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
+	assert.Equal(t, routing.Decision{true, routing.DecisionHighJitterMultipath}, decision)
 }

--- a/routing/route_test.go
+++ b/routing/route_test.go
@@ -17,7 +17,7 @@ func TestDecideUpgradeRoute(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -67,7 +67,7 @@ func TestDecideDowngradeRTTHysteresis(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -121,7 +121,7 @@ func TestDecideDowngradeRTTHysteresisYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -179,7 +179,7 @@ func TestDecideRTTVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -238,7 +238,7 @@ func TestDecideRTTVetoYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -297,7 +297,7 @@ func TestDecidePacketLossVetoEarlySlice(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -356,7 +356,7 @@ func TestDecidePacketLossVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -416,7 +416,7 @@ func TestDecidePacketLossVetoYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -474,7 +474,7 @@ func TestDecideStayOnDirectRoute(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -525,7 +525,7 @@ func TestDecideStayOnNNRoute(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -582,7 +582,7 @@ func TestValidateInitialSlice(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -639,7 +639,7 @@ func TestDecideCommitVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 		routing.DecideCommitted(true, uint8(rrs.TryBeforeYouBuyMaxSlices), rrs.EnableYouOnlyLiveOnce, committedData),
 	}
 
@@ -708,7 +708,7 @@ func TestValidateCommitted(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 		routing.DecideCommitted(true, uint8(rrs.TryBeforeYouBuyMaxSlices), rrs.EnableYouOnlyLiveOnce, committedData),
 	}
 
@@ -777,7 +777,7 @@ func TestDecideMultipathDirect(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -831,7 +831,7 @@ func TestDecideMultipathVetoed(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -888,7 +888,7 @@ func TestDecideMultipathVetoedYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -945,7 +945,7 @@ func TestDecideMultipathNoPacketLossVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -997,7 +997,7 @@ func TestValidateMultipathRTT(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -1053,7 +1053,7 @@ func TestValidateMultipathJitter(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -1109,7 +1109,7 @@ func TestValidateMultipathPacketLoss(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
 	}
 
 	lastNNStats := &routing.Stats{

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -1031,7 +1031,7 @@ func SessionUpdateHandlerFunc(params *SessionUpdateParams) func(io.Writer, *UDPP
 		var bestRoute *routing.Route
 		bestRoute, routeDecision = GetBestRoute(routeMatrix, nearRelayData, datacenterRelays, params.Storer, params.Metrics, &buyer,
 			sessionDataReadOnly.RouteHash, sessionDataReadOnly.RouteDecision, &lastNextStats, &lastDirectStats, inGamePacketLoss,
-			nextSliceCounter, &committedData, multipathVetoReason, packet.UserHash, &directRoute)
+			nextSliceCounter, &committedData, multipathVetoReason, packet.UserHash, packet.ConnectionType == ConnectionTypeWired, &directRoute)
 
 		if routeDecision.OnNetworkNext {
 			nextSliceCounter++
@@ -1050,7 +1050,7 @@ func SessionUpdateHandlerFunc(params *SessionUpdateParams) func(io.Writer, *UDPP
 // This function can either return a network next route or a direct route, and it also returns a reason as to why the route was chosen.
 func GetBestRoute(routeMatrix RouteProvider, nearRelayData []routing.NearRelayData, datacenterRelayIDs []uint64, storer storage.Storer, metrics *metrics.SessionMetrics,
 	buyer *routing.Buyer, prevRouteHash uint64, prevRouteDecision routing.Decision, lastNextStats *routing.Stats, lastDirectStats *routing.Stats, inGamePacketLoss float64,
-	onNNSliceCounter uint64, committedData *routing.CommittedData, multipathVetoReason routing.DecisionReason, userHash uint64, directRoute *routing.Route) (*routing.Route, routing.Decision) {
+	onNNSliceCounter uint64, committedData *routing.CommittedData, multipathVetoReason routing.DecisionReason, userHash uint64, connectionWired bool, directRoute *routing.Route) (*routing.Route, routing.Decision) {
 
 	// We need to get a next route to compare against direct
 	nextRoute := GetNextRoute(routeMatrix, nearRelayData, datacenterRelayIDs, storer, metrics, float64(buyer.RoutingRulesSettings.RTTEpsilon), prevRouteHash)
@@ -1101,7 +1101,7 @@ func GetBestRoute(routeMatrix RouteProvider, nearRelayData []routing.NearRelayDa
 	if multipathVetoReason&routing.DecisionMultipathVetoRTT == 0 {
 		deciderFuncs = append(deciderFuncs,
 			routing.DecideMultipath(buyer.RoutingRulesSettings.EnableMultipathForRTT, buyer.RoutingRulesSettings.EnableMultipathForJitter, buyer.RoutingRulesSettings.EnableMultipathForPacketLoss,
-				float64(buyer.RoutingRulesSettings.RTTThreshold), float64(buyer.RoutingRulesSettings.MultipathPacketLossThreshold), inGamePacketLoss))
+				float64(buyer.RoutingRulesSettings.RTTThreshold), float64(buyer.RoutingRulesSettings.MultipathPacketLossThreshold), inGamePacketLoss, connectionWired))
 	}
 
 	if buyer.RoutingRulesSettings.EnableTryBeforeYouBuy {


### PR DESCRIPTION
This PR adds a jitter check for the multipath veto if the user's connection is wired. This is so we can check with the AB test if we are somehow inducing higher jitter in group A and if so, attempt to lower it.