### PR TITLE
Fix SDK3 Happy Path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,10 @@ ifndef MAXMIND_ISP_DB_URI
 export MAXMIND_ISP_DB_URI = ./testdata/GeoIP2-ISP-Test.mmdb
 endif
 
+ifndef LOCAL_RELAYS
+export LOCAL_RELAYS = 10
+endif
+
 ifndef SESSION_MAP_INTERVAL
 export SESSION_MAP_INTERVAL = 1s
 endif
@@ -946,7 +950,7 @@ dev-relay: build-relay ## runs a local relay
 
 .PHONY: dev-multi-relays
 dev-multi-relays: build-relay ## runs 10 local relays
-	./scripts/relay-spawner.sh -n 20 -p 10000
+	./scripts/relay-spawner.sh -n 10 -p 10000
 
 #######################
 

--- a/cmd/relay_backend/relay_backend.go
+++ b/cmd/relay_backend/relay_backend.go
@@ -37,10 +37,6 @@ import (
 	"github.com/networknext/backend/storage"
 )
 
-// MaxRelayCount is the maximum number of relays you can run locally with the firestore emulator
-// An equal number of valve relays will also be added
-const MaxRelayCount = 10
-
 var (
 	buildtime     string
 	commitMessage string

--- a/routing/routing_rules_settings.go
+++ b/routing/routing_rules_settings.go
@@ -90,8 +90,8 @@ type RoutingRulesSettings struct {
 
 var DefaultRoutingRulesSettings = RoutingRulesSettings{
 	MaxNibblinsPerGB:             250000000,
-	EnvelopeKbpsUp:               256,
-	EnvelopeKbpsDown:             256,
+	EnvelopeKbpsUp:               1024,
+	EnvelopeKbpsDown:             1024,
 	AcceptableLatency:            -1.0,
 	RTTThreshold:                 5.0,
 	RTTEpsilon:                   2.0,
@@ -109,8 +109,8 @@ var DefaultRoutingRulesSettings = RoutingRulesSettings{
 // forcing with 'Mode: ModeForceNext`).
 var LocalRoutingRulesSettings = RoutingRulesSettings{
 	MaxNibblinsPerGB:             250000000,
-	EnvelopeKbpsUp:               100,
-	EnvelopeKbpsDown:             100,
+	EnvelopeKbpsUp:               1024,
+	EnvelopeKbpsDown:             1024,
 	AcceptableLatency:            -1.0,
 	RTTThreshold:                 -5,
 	RTTEpsilon:                   0.1,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -227,6 +227,7 @@ func SeedStorage(logger log.Logger, ctx context.Context, db Storer, relayPublicK
 		if err := db.AddBuyer(ctx, routing.Buyer{
 			ID:                   customerID,
 			CompanyCode:          "local",
+			Live:                 true,
 			PublicKey:            customerPublicKey,
 			RoutingRulesSettings: routing.LocalRoutingRulesSettings,
 		}); err != nil {
@@ -236,6 +237,7 @@ func SeedStorage(logger log.Logger, ctx context.Context, db Storer, relayPublicK
 		if err := db.AddBuyer(ctx, routing.Buyer{
 			ID:                   0,
 			CompanyCode:          "ghost-army",
+			Live:                 true,
 			PublicKey:            customerPublicKey,
 			RoutingRulesSettings: routing.LocalRoutingRulesSettings,
 		}); err != nil {
@@ -279,7 +281,7 @@ func SeedStorage(logger log.Logger, ctx context.Context, db Storer, relayPublicK
 			numRelays := uint64(10)
 			numRelays, err := strconv.ParseUint(val, 10, 64)
 			if err != nil {
-				level.Warn(logger).Log("msg", fmt.Sprintf("LOCAL_PORTAL_RELAYS not valid number, defaulting to 10: %v\n", err))
+				level.Warn(logger).Log("msg", fmt.Sprintf("LOCAL_RELAYS not valid number, defaulting to 10: %v\n", err))
 			}
 			level.Info(logger).Log("msg", fmt.Sprintf("adding %d relays to local firestore\n", numRelays))
 			for i := uint64(0); i < numRelays; i++ {
@@ -296,6 +298,7 @@ func SeedStorage(logger log.Logger, ctx context.Context, db Storer, relayPublicK
 					ManagementAddr: addr.String(),
 					SSHUser:        "root",
 					SSHPort:        22,
+					MaxSessions:    3000,
 					MRC:            19700000000000,
 					Overage:        26000000000000,
 					BWRule:         routing.BWRuleBurst,
@@ -326,6 +329,7 @@ func SeedStorage(logger log.Logger, ctx context.Context, db Storer, relayPublicK
 				ManagementAddr: "127.0.0.1",
 				SSHUser:        "root",
 				SSHPort:        22,
+				MaxSessions:    3000,
 				MRC:            19700000000000,
 				Overage:        26000000000000,
 				BWRule:         routing.BWRuleBurst,
@@ -350,6 +354,7 @@ func SeedStorage(logger log.Logger, ctx context.Context, db Storer, relayPublicK
 				ManagementAddr: "127.0.0.1",
 				SSHUser:        "root",
 				SSHPort:        22,
+				MaxSessions:    3000,
 			}); err != nil {
 				level.Error(logger).Log("msg", "could not add relay to storage", "err", err)
 				os.Exit(1)
@@ -367,6 +372,7 @@ func SeedStorage(logger log.Logger, ctx context.Context, db Storer, relayPublicK
 				ManagementAddr: "127.0.0.1",
 				SSHUser:        "root",
 				SSHPort:        22,
+				MaxSessions:    3000,
 			}); err != nil {
 				level.Error(logger).Log("msg", "could not add relay to storage", "err", err)
 				os.Exit(1)


### PR DESCRIPTION
Fixes the happy path for SDK3. There were just a bunch of small issues that added up. Namely the way relays were added to storage, buyers not being live, and bandwidth envelope being too small.

SDK4 happy path might still be broken. I will ensure that both the SDK3 happy path and SDK4 happy path work in my server_backend4 PR #2091 before merging.