### PR TITLE
Remove Jitter Check From Multipath Veto

### DIFF
--- a/routing/route_decision.go
+++ b/routing/route_decision.go
@@ -317,14 +317,14 @@ func DecideCommitted(onNNLastSlice bool, maxObservedSlices uint8, yolo bool, com
 // DecideMultipath will decide if we should serve a network next route to be used for multipath
 // If the decision function can't find a good enough reason to send a network next route, then it decides to go direct
 // If multipath isn't enabled then the decision isn't affected
-func DecideMultipath(rttMultipath bool, jitterMultipath bool, packetLossMultipath bool, rttThreshold float64, packetLossThreshold float64, inGamePacketLoss float64, connectionWired bool) DecisionFunc {
+func DecideMultipath(rttMultipath bool, jitterMultipath bool, packetLossMultipath bool, rttThreshold float64, packetLossThreshold float64, inGamePacketLoss float64) DecisionFunc {
 	return func(prevDecision Decision, predictedNextStats, lastNextStats, lastDirectStats *Stats) Decision {
 		decision := prevDecision
 
 		// If there was a ping spike and the session was using multipath, it might have been due
 		// to an overloaded connection from 2x multipath bandwidth, so "multipath veto" this user
 		if IsMultipath(decision) || IsVetoed(decision) {
-			if (lastDirectStats.RTT >= 500 || lastNextStats.RTT >= 500) || (connectionWired && (lastDirectStats.Jitter >= 500 || lastNextStats.Jitter >= 500)) {
+			if lastDirectStats.RTT >= 500 || lastNextStats.RTT >= 500 {
 				decision.OnNetworkNext = false
 				decision.Reason = DecisionMultipathVetoRTT
 				return decision

--- a/routing/route_decision_test.go
+++ b/routing/route_decision_test.go
@@ -263,7 +263,7 @@ func TestDecideMultipath(t *testing.T) {
 	packetLossThreshold := float64(routing.LocalRoutingRulesSettings.MultipathPacketLossThreshold)
 
 	// Test if multipath isn't enabled
-	routeDecisionFunc := routing.DecideMultipath(false, false, false, rttThreshold, packetLossThreshold, 0, false)
+	routeDecisionFunc := routing.DecideMultipath(false, false, false, rttThreshold, packetLossThreshold, 0)
 	predictedNNStats := &routing.Stats{RTT: 30}
 	directStats := &routing.Stats{RTT: 60}
 	decision := routing.Decision{}
@@ -271,7 +271,7 @@ func TestDecideMultipath(t *testing.T) {
 	assert.Equal(t, routing.Decision{}, decision)
 
 	// Test if multipath is already active
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, false)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0)
 	decision = routing.Decision{true, routing.DecisionRTTReductionMultipath}
 	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
 	assert.Equal(t, routing.Decision{true, routing.DecisionRTTReductionMultipath}, decision)
@@ -282,7 +282,7 @@ func TestDecideMultipath(t *testing.T) {
 	assert.Equal(t, routing.Decision{true, routing.DecisionRTTReductionMultipath}, decision)
 
 	// Test when multipath reason is high jitter
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, false)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0)
 	decision = routing.Decision{}
 	predictedNNStats = &routing.Stats{}
 	directStats = &routing.Stats{Jitter: 50, RTT: -6.0}
@@ -290,7 +290,7 @@ func TestDecideMultipath(t *testing.T) {
 	assert.Equal(t, routing.Decision{true, routing.DecisionHighJitterMultipath}, decision)
 
 	// Test when multipath reason is high ping packet loss
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, false)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0)
 	decision = routing.Decision{}
 	predictedNNStats = &routing.Stats{}
 	directStats = &routing.Stats{PacketLoss: 1, RTT: -6.0}
@@ -298,32 +298,17 @@ func TestDecideMultipath(t *testing.T) {
 	assert.Equal(t, routing.Decision{true, routing.DecisionHighPacketLossMultipath}, decision)
 
 	// Test when multipath reason is high in game packet loss
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 1, false)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 1)
 	decision = routing.Decision{}
 	predictedNNStats = &routing.Stats{}
 	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
 	assert.Equal(t, routing.Decision{true, routing.DecisionHighPacketLossMultipath}, decision)
 
 	// Test multipath veto with high RTT
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, false)
+	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0)
 	decision = routing.Decision{true, routing.DecisionRTTReductionMultipath}
 	directStats = &routing.Stats{RTT: 500}
 	predictedNNStats = &routing.Stats{}
 	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
 	assert.Equal(t, routing.Decision{false, routing.DecisionMultipathVetoRTT}, decision)
-
-	// Test multipath veto with high jitter and on a wired connection
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, true)
-	decision = routing.Decision{true, routing.DecisionHighJitterMultipath}
-	directStats = &routing.Stats{Jitter: 500}
-	predictedNNStats = &routing.Stats{}
-	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
-	assert.Equal(t, routing.Decision{false, routing.DecisionMultipathVetoRTT}, decision)
-
-	// Test multipath veto isn't triggered with high jitter on a wireless connection
-	routeDecisionFunc = routing.DecideMultipath(true, true, true, rttThreshold, packetLossThreshold, 0, false)
-	decision = routing.Decision{true, routing.DecisionHighJitterMultipath}
-	predictedNNStats = &routing.Stats{}
-	decision = routeDecisionFunc(decision, predictedNNStats, &routing.Stats{}, directStats)
-	assert.Equal(t, routing.Decision{true, routing.DecisionHighJitterMultipath}, decision)
 }

--- a/routing/route_test.go
+++ b/routing/route_test.go
@@ -17,7 +17,7 @@ func TestDecideUpgradeRoute(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -67,7 +67,7 @@ func TestDecideDowngradeRTTHysteresis(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -121,7 +121,7 @@ func TestDecideDowngradeRTTHysteresisYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -179,7 +179,7 @@ func TestDecideRTTVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -238,7 +238,7 @@ func TestDecideRTTVetoYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -297,7 +297,7 @@ func TestDecidePacketLossVetoEarlySlice(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -356,7 +356,7 @@ func TestDecidePacketLossVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -416,7 +416,7 @@ func TestDecidePacketLossVetoYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), routing.DefaultRoutingRulesSettings.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -474,7 +474,7 @@ func TestDecideStayOnDirectRoute(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -525,7 +525,7 @@ func TestDecideStayOnNNRoute(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -582,7 +582,7 @@ func TestValidateInitialSlice(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -639,7 +639,7 @@ func TestDecideCommitVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 		routing.DecideCommitted(true, uint8(rrs.TryBeforeYouBuyMaxSlices), rrs.EnableYouOnlyLiveOnce, committedData),
 	}
 
@@ -708,7 +708,7 @@ func TestValidateCommitted(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 		routing.DecideCommitted(true, uint8(rrs.TryBeforeYouBuyMaxSlices), rrs.EnableYouOnlyLiveOnce, committedData),
 	}
 
@@ -777,7 +777,7 @@ func TestDecideMultipathDirect(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -831,7 +831,7 @@ func TestDecideMultipathVetoed(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -888,7 +888,7 @@ func TestDecideMultipathVetoedYOLO(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -945,7 +945,7 @@ func TestDecideMultipathNoPacketLossVeto(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -997,7 +997,7 @@ func TestValidateMultipathRTT(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -1053,7 +1053,7 @@ func TestValidateMultipathJitter(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{
@@ -1109,7 +1109,7 @@ func TestValidateMultipathPacketLoss(t *testing.T) {
 		routing.DecideUpgradeRTT(float64(rrs.RTTThreshold)),
 		routing.DecideDowngradeRTT(float64(rrs.RTTHysteresis), rrs.EnableYouOnlyLiveOnce),
 		routing.DecideVeto(onNNSliceCounter, float64(rrs.RTTVeto), rrs.EnablePacketLossSafety, rrs.EnableYouOnlyLiveOnce),
-		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0, true),
+		routing.DecideMultipath(rrs.EnableMultipathForRTT, rrs.EnableMultipathForJitter, rrs.EnableMultipathForPacketLoss, float64(rrs.RTTThreshold), float64(rrs.MultipathPacketLossThreshold), 0),
 	}
 
 	lastNNStats := &routing.Stats{

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -1031,7 +1031,7 @@ func SessionUpdateHandlerFunc(params *SessionUpdateParams) func(io.Writer, *UDPP
 		var bestRoute *routing.Route
 		bestRoute, routeDecision = GetBestRoute(routeMatrix, nearRelayData, datacenterRelays, params.Storer, params.Metrics, &buyer,
 			sessionDataReadOnly.RouteHash, sessionDataReadOnly.RouteDecision, &lastNextStats, &lastDirectStats, inGamePacketLoss,
-			nextSliceCounter, &committedData, multipathVetoReason, packet.UserHash, packet.ConnectionType == ConnectionTypeWired, &directRoute)
+			nextSliceCounter, &committedData, multipathVetoReason, packet.UserHash, &directRoute)
 
 		if routeDecision.OnNetworkNext {
 			nextSliceCounter++
@@ -1050,7 +1050,7 @@ func SessionUpdateHandlerFunc(params *SessionUpdateParams) func(io.Writer, *UDPP
 // This function can either return a network next route or a direct route, and it also returns a reason as to why the route was chosen.
 func GetBestRoute(routeMatrix RouteProvider, nearRelayData []routing.NearRelayData, datacenterRelayIDs []uint64, storer storage.Storer, metrics *metrics.SessionMetrics,
 	buyer *routing.Buyer, prevRouteHash uint64, prevRouteDecision routing.Decision, lastNextStats *routing.Stats, lastDirectStats *routing.Stats, inGamePacketLoss float64,
-	onNNSliceCounter uint64, committedData *routing.CommittedData, multipathVetoReason routing.DecisionReason, userHash uint64, connectionWired bool, directRoute *routing.Route) (*routing.Route, routing.Decision) {
+	onNNSliceCounter uint64, committedData *routing.CommittedData, multipathVetoReason routing.DecisionReason, userHash uint64, directRoute *routing.Route) (*routing.Route, routing.Decision) {
 
 	// We need to get a next route to compare against direct
 	nextRoute := GetNextRoute(routeMatrix, nearRelayData, datacenterRelayIDs, storer, metrics, float64(buyer.RoutingRulesSettings.RTTEpsilon), prevRouteHash)
@@ -1101,7 +1101,7 @@ func GetBestRoute(routeMatrix RouteProvider, nearRelayData []routing.NearRelayDa
 	if multipathVetoReason&routing.DecisionMultipathVetoRTT == 0 {
 		deciderFuncs = append(deciderFuncs,
 			routing.DecideMultipath(buyer.RoutingRulesSettings.EnableMultipathForRTT, buyer.RoutingRulesSettings.EnableMultipathForJitter, buyer.RoutingRulesSettings.EnableMultipathForPacketLoss,
-				float64(buyer.RoutingRulesSettings.RTTThreshold), float64(buyer.RoutingRulesSettings.MultipathPacketLossThreshold), inGamePacketLoss, connectionWired))
+				float64(buyer.RoutingRulesSettings.RTTThreshold), float64(buyer.RoutingRulesSettings.MultipathPacketLossThreshold), inGamePacketLoss))
 	}
 
 	if buyer.RoutingRulesSettings.EnableTryBeforeYouBuy {


### PR DESCRIPTION
Removes the jitter check when checking for a multipath veto introduced in #2115. This is to test the theory that this check actually narrowed the PL difference between groups A and B.