### PR TITLE
Fix machine-dependent test

### DIFF
--- a/storage/multipath_veto_handler_test.go
+++ b/storage/multipath_veto_handler_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestNewMultipathVetoHandlerCouldNotPing(t *testing.T) {
-	_, err := storage.NewMultipathVetoHandler("0.1.2.3:6379", nil)
-	assert.Contains(t, err.Error(), "could not ping multipath veto redis instance: dial tcp 0.1.2.3:6379: connect")
+	_, err := storage.NewMultipathVetoHandler("", nil)
+	assert.Contains(t, err.Error(), "could not ping multipath veto redis instance")
 }
 
 func TestNewMultipathVetoHandlerSuccess(t *testing.T) {


### PR DESCRIPTION
This test was inconsistent on different machines because it would create the TCP socket and rely on the timeout to be quick enough to error out, when sometimes it would take too long that `make test` would fail. This change prevents the socket from being created by passing in a blank address.

If we go back through and update the tests in the codebase then this should probably use `redigomock` instead of `miniredis`, but this works for now.