### PR TITLE
Need a make portal-local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ test-load: ## runs load tests
 #######################
 
 .PHONY: dev-portal
-dev-portal: build-portal ## runs a local portal
+dev-portal: build-portal-local ## runs a local portal
 	@PORT=20000 BASIC_AUTH_USERNAME=local BASIC_AUTH_PASSWORD=local UI_DIR=./cmd/portal/dist ./dist/portal
 
 .PHONY: dev-relay-backend
@@ -415,6 +415,16 @@ build-portal-cruncher:
 
 .PHONY: build-portal
 build-portal:
+	@printf "Building portal... \n"
+	@printf "TIMESTAMP: ${TIMESTAMP}\n"
+	@printf "SHA: ${SHA}\n"
+	@printf "RELEASE: ${RELEASE}\n"
+	@printf "COMMITMESSAGE: ${COMMITMESSAGE}\n"
+	@$(GO) build -ldflags "-s -w -X main.buildtime=$(TIMESTAMP) -X main.sha=$(SHA) -X main.release=$(RELEASE) -X main.commitMessage=$(echo "$COMMITMESSAGE")" -o ${DIST_DIR}/portal ./cmd/portal/portal.go
+	@printf "done\n"
+
+.PHONY: build-portal-local
+build-portal-local:
 	@printf "Building portal... \n"
 	@printf "TIMESTAMP: ${TIMESTAMP}\n"
 	@printf "SHA: ${SHA}\n"


### PR DESCRIPTION
build-portal is run every time semaphore runs causing different projects to always need access to the prod bucket. This will fix it so that we can reach out locally and semaphore will only talk to the buckets it has permission to talk to.