### PR TITLE
Predicted Next RTT in Billing Entry

### DIFF
--- a/billing/billing_entry.go
+++ b/billing/billing_entry.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	BillingEntryVersion = uint8(10)
+	BillingEntryVersion = uint8(11)
 
 	BillingEntryMaxRelays           = 5
 	BillingEntryMaxISPLength        = 64
@@ -56,6 +56,7 @@ type BillingEntry struct {
 	PlatformType              uint8
 	SDKVersion                string
 	PacketLoss                float32
+	PredictedNextRTT          float32
 }
 
 func WriteBillingEntry(entry *BillingEntry) []byte {
@@ -127,6 +128,8 @@ func WriteBillingEntry(entry *BillingEntry) []byte {
 	encoding.WriteString(data, &index, entry.SDKVersion, BillingEntryMaxSDKVersionLength)
 
 	encoding.WriteFloat32(data, &index, entry.PacketLoss)
+
+	encoding.WriteFloat32(data, &index, entry.PredictedNextRTT)
 
 	return data[:index]
 }
@@ -305,6 +308,12 @@ func ReadBillingEntry(entry *BillingEntry, data []byte) bool {
 
 	if entry.Version >= 9 {
 		if !encoding.ReadFloat32(data, &index, &entry.PacketLoss) {
+			return false
+		}
+	}
+
+	if entry.Version >= 11 {
+		if !encoding.ReadFloat32(data, &index, &entry.PredictedNextRTT) {
 			return false
 		}
 	}

--- a/billing/googlebigquery.go
+++ b/billing/googlebigquery.go
@@ -135,5 +135,9 @@ func (entry *BillingEntry) Save() (map[string]bigquery.Value, string, error) {
 		e["packetLoss"] = entry.PacketLoss
 	}
 
+	if entry.PredictedNextRTT > 0.0 {
+		e["predictedNextRTT"] = entry.PredictedNextRTT
+	}
+
 	return e, "", nil
 }


### PR DESCRIPTION
Adds `predictedNextRTT` as a new float field in the billing entry. This will be populated (when greater than 0) with the predicted RTT of the next route. This will also be filled in for direct routes, so that we can know how much we could be improving sessions if they were being accelerated.