### PR TITLE
Fix RouteShader Sync Issue

### DIFF
--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -128,19 +128,19 @@ type routingRulesSettings struct {
 }
 
 type routeShader struct {
-	DisableNetworkNext        bool           `firestore:"disableNetworkNext"`
-	SelectionPercent          int            `firestore:"selectionPercent"`
-	ABTest                    bool           `firestore:"abTest"`
-	ProMode                   bool           `firestore:"proMode"`
-	ReduceLatency             bool           `firestore:"reduceLatency"`
-	ReducePacketLoss          bool           `firestore:"reducePacketLoss"`
-	Multipath                 bool           `firestore:"multipath"`
-	AcceptableLatency         int32          `firestore:"acceptableLatency"`
-	LatencyThreshold          int32          `firestore:"latencyThreshold"`
-	AcceptablePacketLoss      float32        `firestore:"acceptablePacketLoss"`
-	BandwidthEnvelopeUpKbps   int32          `firestore:"bandwidthEnvelopeUpKbps"`
-	BandwidthEnvelopeDownKbps int32          `firestore:"bandwidthEnvelopeDownKbps"`
-	BannedUsers               map[int64]bool `firestore:"bannedUsers"`
+	DisableNetworkNext        bool            `firestore:"disableNetworkNext"`
+	SelectionPercent          int             `firestore:"selectionPercent"`
+	ABTest                    bool            `firestore:"abTest"`
+	ProMode                   bool            `firestore:"proMode"`
+	ReduceLatency             bool            `firestore:"reduceLatency"`
+	ReducePacketLoss          bool            `firestore:"reducePacketLoss"`
+	Multipath                 bool            `firestore:"multipath"`
+	AcceptableLatency         int32           `firestore:"acceptableLatency"`
+	LatencyThreshold          int32           `firestore:"latencyThreshold"`
+	AcceptablePacketLoss      float32         `firestore:"acceptablePacketLoss"`
+	BandwidthEnvelopeUpKbps   int32           `firestore:"bandwidthEnvelopeUpKbps"`
+	BandwidthEnvelopeDownKbps int32           `firestore:"bandwidthEnvelopeDownKbps"`
+	BannedUsers               map[string]bool `firestore:"bannedUsers"`
 }
 
 type internalConfig struct {
@@ -527,17 +527,17 @@ func (fs *Firestore) AddBuyer(ctx context.Context, b routing.Buyer) error {
 	}
 
 	// Add the buyer's routing rules settings to remote storage
-	if err := fs.setRoutingRulesSettingsForBuyerID(ctx, ref.ID, company.Name, b.RoutingRulesSettings); err != nil {
+	if err := fs.SetRoutingRulesSettingsForBuyerID(ctx, ref.ID, company.Name, b.RoutingRulesSettings); err != nil {
 		return &FirestoreError{err: err}
 	}
 
 	// Add the buyer's route shader to remote storage
-	if err := fs.setRouteShaderForBuyerID(ctx, ref.ID, company.Name, b.RouteShader); err != nil {
+	if err := fs.SetRouteShaderForBuyerID(ctx, ref.ID, company.Name, b.RouteShader); err != nil {
 		return &FirestoreError{err: err}
 	}
 
 	// Add the buyer's internal config to remote storage
-	if err := fs.setInternalConfigForBuyerID(ctx, ref.ID, company.Name, b.InternalConfig); err != nil {
+	if err := fs.SetInternalConfigForBuyerID(ctx, ref.ID, company.Name, b.InternalConfig); err != nil {
 		return &FirestoreError{err: err}
 	}
 
@@ -590,17 +590,17 @@ func (fs *Firestore) RemoveBuyer(ctx context.Context, id uint64) error {
 
 		if uint64(buyerInRemoteStorage.ID) == id {
 			// Delete the buyer's routing rules settings in remote storage
-			if err := fs.deleteRouteRulesSettingsForBuyerID(ctx, bdoc.Ref.ID); err != nil {
+			if err := fs.DeleteRouteRulesSettingsForBuyerID(ctx, bdoc.Ref.ID); err != nil {
 				return &FirestoreError{err: err}
 			}
 
 			// Delete the buyer's route shader in remote storage
-			if err := fs.deleteRouteShaderForBuyerID(ctx, bdoc.Ref.ID); err != nil {
+			if err := fs.DeleteRouteShaderForBuyerID(ctx, bdoc.Ref.ID); err != nil {
 				return &FirestoreError{err: err}
 			}
 
 			// Delete the buyer's internal config in remote storage
-			if err := fs.deleteInternalConfigForBuyerID(ctx, bdoc.Ref.ID); err != nil {
+			if err := fs.DeleteInternalConfigForBuyerID(ctx, bdoc.Ref.ID); err != nil {
 				return &FirestoreError{err: err}
 			}
 
@@ -690,17 +690,17 @@ func (fs *Firestore) SetBuyer(ctx context.Context, b routing.Buyer) error {
 			}
 
 			// Update the buyer's routing rules settings in firestore
-			if err := fs.setRoutingRulesSettingsForBuyerID(ctx, bdoc.Ref.ID, company.Name, b.RoutingRulesSettings); err != nil {
+			if err := fs.SetRoutingRulesSettingsForBuyerID(ctx, bdoc.Ref.ID, company.Name, b.RoutingRulesSettings); err != nil {
 				return &FirestoreError{err: err}
 			}
 
 			// Update the buyer's route shader in firestore
-			if err := fs.setRouteShaderForBuyerID(ctx, bdoc.Ref.ID, company.Name, b.RouteShader); err != nil {
+			if err := fs.SetRouteShaderForBuyerID(ctx, bdoc.Ref.ID, company.Name, b.RouteShader); err != nil {
 				return &FirestoreError{err: err}
 			}
 
 			// Update the buyer's internal config in firestore
-			if err := fs.setInternalConfigForBuyerID(ctx, bdoc.Ref.ID, company.Name, b.InternalConfig); err != nil {
+			if err := fs.SetInternalConfigForBuyerID(ctx, bdoc.Ref.ID, company.Name, b.InternalConfig); err != nil {
 				return &FirestoreError{err: err}
 			}
 
@@ -1974,17 +1974,17 @@ func (fs *Firestore) syncBuyers(ctx context.Context) error {
 			continue
 		}
 
-		rrs, err := fs.getRoutingRulesSettingsForBuyerID(ctx, buyerDoc.Ref.ID)
+		rrs, err := fs.GetRoutingRulesSettingsForBuyerID(ctx, buyerDoc.Ref.ID)
 		if err != nil {
 			level.Warn(fs.Logger).Log("msg", fmt.Sprintf("failed to completely read route shader for buyer %v, some fields will have default values", buyerDoc.Ref.ID), "err", err)
 		}
 
-		rs, err := fs.getRouteShaderForBuyerID(ctx, buyerDoc.Ref.ID)
+		rs, err := fs.GetRouteShaderForBuyerID(ctx, buyerDoc.Ref.ID)
 		if err != nil {
 			level.Warn(fs.Logger).Log("msg", fmt.Sprintf("failed to completely read route shader for buyer %v, some fields will have default values", buyerDoc.Ref.ID), "err", err)
 		}
 
-		ic, err := fs.getInternalConfigForBuyerID(ctx, buyerDoc.Ref.ID)
+		ic, err := fs.GetInternalConfigForBuyerID(ctx, buyerDoc.Ref.ID)
 		if err != nil {
 			level.Warn(fs.Logger).Log("msg", fmt.Sprintf("failed to completely read internal config for buyer %v, some fields will have default values", buyerDoc.Ref.ID), "err", err)
 		}
@@ -1999,12 +1999,6 @@ func (fs *Firestore) syncBuyers(ctx context.Context) error {
 			RouteShader:          rs,
 			InternalConfig:       ic,
 		}
-
-		level.Debug(fs.Logger).Log("buyer", buyer.CompanyCode,
-			"acceptable_latency", buyer.RouteShader.AcceptableLatency,
-			"rtt_threshold", buyer.RouteShader.LatencyThreshold,
-			"selection_percent", buyer.RouteShader.SelectionPercent,
-			"route_switch_threshold", buyer.InternalConfig.RouteSwitchThreshold)
 
 		buyers[buyer.ID] = buyer
 	}
@@ -2155,7 +2149,7 @@ func (fs *Firestore) syncCustomers(ctx context.Context) error {
 	return nil
 }
 
-func (fs *Firestore) deleteRouteRulesSettingsForBuyerID(ctx context.Context, ID string) error {
+func (fs *Firestore) DeleteRouteRulesSettingsForBuyerID(ctx context.Context, ID string) error {
 	// Comment below taken from old backend, at least attempting to explain why we need to append _0 (no existing entries have suffixes other than _0)
 	// "Must be of the form '<buyer key>_<tag id>'. The buyer key can be found by looking at the ID under Buyer; it should be something like 763IMDH693HLsr2LGTJY. The tag ID should be 0 (for default) or the fnv64a hash of the tag the customer is using. Therefore this value should look something like: 763IMDH693HLsr2LGTJY_0. This value can not be changed after the entity is created."
 	routeShaderID := ID + "_0"
@@ -2165,26 +2159,26 @@ func (fs *Firestore) deleteRouteRulesSettingsForBuyerID(ctx context.Context, ID 
 	return err
 }
 
-func (fs *Firestore) deleteRouteShaderForBuyerID(ctx context.Context, ID string) error {
-	routeShaderID := ID + "_0"
+func (fs *Firestore) DeleteRouteShaderForBuyerID(ctx context.Context, firestoreID string) error {
+	routeShaderID := firestoreID + "_0"
 
 	// Attempt to delete route shader for buyer
 	_, err := fs.Client.Collection("RouteShader4").Doc(routeShaderID).Delete(ctx)
 	return err
 }
 
-func (fs *Firestore) deleteInternalConfigForBuyerID(ctx context.Context, ID string) error {
-	internalConfigID := ID + "_0"
+func (fs *Firestore) DeleteInternalConfigForBuyerID(ctx context.Context, firestoreID string) error {
+	internalConfigID := firestoreID + "_0"
 
 	// Attempt to delete route shader for buyer
 	_, err := fs.Client.Collection("InternalConfig").Doc(internalConfigID).Delete(ctx)
 	return err
 }
 
-func (fs *Firestore) getRoutingRulesSettingsForBuyerID(ctx context.Context, ID string) (routing.RoutingRulesSettings, error) {
+func (fs *Firestore) GetRoutingRulesSettingsForBuyerID(ctx context.Context, firestoreID string) (routing.RoutingRulesSettings, error) {
 	// Comment below taken from old backend, at least attempting to explain why we need to append _0 (no existing entries have suffixes other than _0)
 	// "Must be of the form '<buyer key>_<tag id>'. The buyer key can be found by looking at the ID under Buyer; it should be something like 763IMDH693HLsr2LGTJY. The tag ID should be 0 (for default) or the fnv64a hash of the tag the customer is using. Therefore this value should look something like: 763IMDH693HLsr2LGTJY_0. This value can not be changed after the entity is created."
-	routeShaderID := ID + "_0"
+	routeShaderID := firestoreID + "_0"
 
 	// Set up our return value with default settings, which will be used if no settings found for buyer or other errors are encountered
 	rrs := routing.DefaultRoutingRulesSettings
@@ -2236,10 +2230,10 @@ func (fs *Firestore) getRoutingRulesSettingsForBuyerID(ctx context.Context, ID s
 	return rrs, nil
 }
 
-func (fs *Firestore) setRoutingRulesSettingsForBuyerID(ctx context.Context, ID string, name string, rrs routing.RoutingRulesSettings) error {
+func (fs *Firestore) SetRoutingRulesSettingsForBuyerID(ctx context.Context, firestoreID string, name string, rrs routing.RoutingRulesSettings) error {
 	// Comment below taken from old backend, at least attempting to explain why we need to append _0 (no existing entries have suffixes other than _0)
 	// "Must be of the form '<buyer key>_<tag id>'. The buyer key can be found by looking at the ID under Buyer; it should be something like 763IMDH693HLsr2LGTJY. The tag ID should be 0 (for default) or the fnv64a hash of the tag the customer is using. Therefore this value should look something like: 763IMDH693HLsr2LGTJY_0. This value can not be changed after the entity is created."
-	routeShaderID := ID + "_0"
+	routeShaderID := firestoreID + "_0"
 
 	// Convert the excluded user hashes to strings
 	excludedUserHashes := map[string]bool{}
@@ -2277,8 +2271,8 @@ func (fs *Firestore) setRoutingRulesSettingsForBuyerID(ctx context.Context, ID s
 	return err
 }
 
-func (fs *Firestore) getRouteShaderForBuyerID(ctx context.Context, buyerID string) (core.RouteShader, error) {
-	routeShaderID := buyerID + "_0"
+func (fs *Firestore) GetRouteShaderForBuyerID(ctx context.Context, firestoreID string) (core.RouteShader, error) {
+	routeShaderID := firestoreID + "_0"
 	rs := core.NewRouteShader()
 
 	rsDoc, err := fs.Client.Collection("RouteShader4").Doc(routeShaderID).Get(ctx)
@@ -2291,11 +2285,6 @@ func (fs *Firestore) getRouteShaderForBuyerID(ctx context.Context, buyerID strin
 	if err != nil {
 		return rs, err
 	}
-
-	level.Debug(fs.Logger).Log("buyerID", buyerID,
-		"acceptable_latency", tempRS.AcceptableLatency,
-		"rtt_threshold", tempRS.LatencyThreshold,
-		"selection_percent", tempRS.SelectionPercent)
 
 	rs.DisableNetworkNext = tempRS.DisableNetworkNext
 	rs.SelectionPercent = tempRS.SelectionPercent
@@ -2310,21 +2299,26 @@ func (fs *Firestore) getRouteShaderForBuyerID(ctx context.Context, buyerID strin
 	rs.BandwidthEnvelopeUpKbps = tempRS.BandwidthEnvelopeUpKbps
 	rs.BandwidthEnvelopeDownKbps = tempRS.BandwidthEnvelopeDownKbps
 
-	// Convert user IDs from int64 to uint64
-	for k, v := range tempRS.BannedUsers {
-		rs.BannedUsers[uint64(k)] = v
+	// Convert user IDs from string to uint64
+	for userHashString := range tempRS.BannedUsers {
+		userHash, err := strconv.ParseUint(userHashString, 16, 64)
+		if err != nil {
+			level.Warn(fs.Logger).Log("msg", "failed to parse banned user hash", "user_hash", userHashString, "err", err)
+			continue
+		}
+		rs.BannedUsers[userHash] = true
 	}
 
 	return rs, nil
 }
 
-func (fs *Firestore) setRouteShaderForBuyerID(ctx context.Context, buyerID string, name string, routeShader core.RouteShader) error {
-	routeShaderID := buyerID + "_0"
+func (fs *Firestore) SetRouteShaderForBuyerID(ctx context.Context, firestoreID string, name string, routeShader core.RouteShader) error {
+	routeShaderID := firestoreID + "_0"
 
-	// Convert user IDs from uint64 to int64
-	bannedUsers := make(map[int64]bool)
-	for k, v := range routeShader.BannedUsers {
-		bannedUsers[int64(k)] = v
+	// Convert user IDs from uint64 to string
+	bannedUsers := map[string]bool{}
+	for userHash := range routeShader.BannedUsers {
+		bannedUsers[fmt.Sprintf("%016x", userHash)] = true
 	}
 
 	rsFirestore := map[string]interface{}{
@@ -2344,12 +2338,12 @@ func (fs *Firestore) setRouteShaderForBuyerID(ctx context.Context, buyerID strin
 		"bannedUsers":               bannedUsers,
 	}
 
-	_, err := fs.Client.Collection("RouteShader4").Doc(routeShaderID).Set(ctx, rsFirestore, firestore.MergeAll)
+	_, err := fs.Client.Collection("RouteShader4").Doc(routeShaderID).Set(ctx, rsFirestore)
 	return err
 }
 
-func (fs *Firestore) getInternalConfigForBuyerID(ctx context.Context, buyerID string) (core.InternalConfig, error) {
-	internalConfigID := buyerID + "_0"
+func (fs *Firestore) GetInternalConfigForBuyerID(ctx context.Context, firestoreID string) (core.InternalConfig, error) {
+	internalConfigID := firestoreID + "_0"
 	ic := core.NewInternalConfig()
 
 	icDoc, err := fs.Client.Collection("InternalConfig").Doc(internalConfigID).Get(ctx)
@@ -2374,8 +2368,8 @@ func (fs *Firestore) getInternalConfigForBuyerID(ctx context.Context, buyerID st
 	return ic, nil
 }
 
-func (fs *Firestore) setInternalConfigForBuyerID(ctx context.Context, buyerID string, name string, internalConfig core.InternalConfig) error {
-	internalConfigID := buyerID + "_0"
+func (fs *Firestore) SetInternalConfigForBuyerID(ctx context.Context, firestoreID string, name string, internalConfig core.InternalConfig) error {
+	internalConfigID := firestoreID + "_0"
 
 	icFirestore := map[string]interface{}{
 		"displayName":                name,
@@ -2388,6 +2382,6 @@ func (fs *Firestore) setInternalConfigForBuyerID(ctx context.Context, buyerID st
 		"tryBeforeYouBuy":            internalConfig.TryBeforeYouBuy,
 	}
 
-	_, err := fs.Client.Collection("InternalConfig").Doc(internalConfigID).Set(ctx, icFirestore, firestore.MergeAll)
+	_, err := fs.Client.Collection("InternalConfig").Doc(internalConfigID).Set(ctx, icFirestore)
 	return err
 }

--- a/storage/firestore_test.go
+++ b/storage/firestore_test.go
@@ -2565,13 +2565,20 @@ func TestFirestore(t *testing.T) {
 			assert.NoError(t, err)
 		}()
 
+		expectedRouteShader := core.NewRouteShader()
+		expectedRouteShader.AcceptableLatency = -1
+		expectedRouteShader.LatencyThreshold = -1
+
+		expectedInternalConfig := core.NewInternalConfig()
+		expectedInternalConfig.MultipathOverloadThreshold = 10
+
 		expectedBuyer := routing.Buyer{
 			CompanyCode:          "local",
 			ID:                   1,
 			Live:                 false,
 			PublicKey:            make([]byte, crypto.KeySize),
-			RouteShader:          core.NewRouteShader(),
-			InternalConfig:       core.NewInternalConfig(),
+			RouteShader:          expectedRouteShader,
+			InternalConfig:       expectedInternalConfig,
 			RoutingRulesSettings: routing.DefaultRoutingRulesSettings,
 		}
 
@@ -2664,5 +2671,274 @@ func TestFirestore(t *testing.T) {
 		assert.NotEmpty(t, expectedRelay.FirestoreID)
 
 		assert.Equal(t, expectedRelay, actualRelay)
+	})
+
+	t.Run("Test buyer routing obects", func(t *testing.T) {
+		expectedRouteShader := core.NewRouteShader()
+		expectedRouteShader.AcceptableLatency = -1
+		expectedRouteShader.LatencyThreshold = -1
+		expectedRouteShader.BannedUsers[1234567890] = true
+
+		expectedInternalConfig := core.NewInternalConfig()
+		expectedInternalConfig.MultipathOverloadThreshold = 10
+
+		expectedCustomer := routing.Customer{
+			Code: "local",
+			Name: "Local",
+		}
+
+		expectedRoutingRulesSettings := routing.DefaultRoutingRulesSettings
+		expectedRoutingRulesSettings.RTTThreshold = routing.DefaultRoutingRulesSettings.RTTThreshold + 100
+		expectedRoutingRulesSettings.ExcludedUserHashes[1234567890] = true
+
+		expectedBuyer := routing.Buyer{
+			CompanyCode:          "local",
+			ID:                   1,
+			Live:                 false,
+			PublicKey:            make([]byte, crypto.KeySize),
+			RouteShader:          expectedRouteShader,
+			InternalConfig:       expectedInternalConfig,
+			RoutingRulesSettings: expectedRoutingRulesSettings,
+		}
+
+		t.Run("delete", func(t *testing.T) {
+			t.Run("not found", func(t *testing.T) {
+				fs, err := storage.NewFirestore(ctx, "default", log.NewNopLogger())
+				assert.NoError(t, err)
+
+				defer func() {
+					err := cleanFireStore(ctx, fs.Client)
+					assert.NoError(t, err)
+				}()
+
+				err = fs.SetSequenceNumber(ctx, -1)
+				assert.NoError(t, err)
+
+				err = fs.AddCustomer(ctx, expectedCustomer)
+				assert.NoError(t, err)
+
+				err = fs.AddBuyer(ctx, expectedBuyer)
+				assert.NoError(t, err)
+
+				err = fs.DeleteRouteRulesSettingsForBuyerID(ctx, "0")
+				assert.NoError(t, err)
+
+				err = fs.DeleteRouteShaderForBuyerID(ctx, "0")
+				assert.NoError(t, err)
+
+				err = fs.DeleteInternalConfigForBuyerID(ctx, "0")
+				assert.NoError(t, err)
+
+				err = fs.Sync(ctx)
+				assert.NoError(t, err)
+
+				actualBuyer, err := fs.Buyer(expectedBuyer.ID)
+				assert.NoError(t, err)
+
+				assert.Equal(t, expectedBuyer, actualBuyer)
+			})
+
+			t.Run("success", func(t *testing.T) {
+				fs, err := storage.NewFirestore(ctx, "default", log.NewNopLogger())
+				assert.NoError(t, err)
+
+				defer func() {
+					err := cleanFireStore(ctx, fs.Client)
+					assert.NoError(t, err)
+				}()
+
+				err = fs.SetSequenceNumber(ctx, -1)
+				assert.NoError(t, err)
+
+				err = fs.AddCustomer(ctx, expectedCustomer)
+				assert.NoError(t, err)
+
+				err = fs.AddBuyer(ctx, expectedBuyer)
+				assert.NoError(t, err)
+
+				// Grab the buyer for its firestore ID
+				bdocs := fs.Client.Collection("Buyer").Documents(ctx)
+
+				bdoc, err := bdocs.Next()
+				assert.NoError(t, err)
+
+				buyerFirestoreID := bdoc.Ref.ID
+
+				bdocs.Stop()
+
+				err = fs.DeleteRouteRulesSettingsForBuyerID(ctx, buyerFirestoreID)
+				assert.NoError(t, err)
+
+				err = fs.DeleteRouteShaderForBuyerID(ctx, buyerFirestoreID)
+				assert.NoError(t, err)
+
+				err = fs.DeleteInternalConfigForBuyerID(ctx, buyerFirestoreID)
+				assert.NoError(t, err)
+
+				err = fs.Sync(ctx)
+				assert.NoError(t, err)
+
+				actualBuyer, err := fs.Buyer(1)
+				assert.NoError(t, err)
+
+				assert.Equal(t, routing.DefaultRoutingRulesSettings, actualBuyer.RoutingRulesSettings)
+				assert.Equal(t, core.NewRouteShader(), actualBuyer.RouteShader)
+				assert.Equal(t, core.NewInternalConfig(), actualBuyer.InternalConfig)
+			})
+		})
+
+		t.Run("get", func(t *testing.T) {
+			t.Run("not found", func(t *testing.T) {
+				fs, err := storage.NewFirestore(ctx, "default", log.NewNopLogger())
+				assert.NoError(t, err)
+
+				defer func() {
+					err := cleanFireStore(ctx, fs.Client)
+					assert.NoError(t, err)
+				}()
+
+				err = fs.AddCustomer(ctx, expectedCustomer)
+				assert.NoError(t, err)
+
+				err = fs.AddBuyer(ctx, expectedBuyer)
+				assert.NoError(t, err)
+
+				actualRoutingRulesSettings, err := fs.GetRoutingRulesSettingsForBuyerID(ctx, "0")
+				assert.Error(t, err)
+
+				actualRouteShader, err := fs.GetRouteShaderForBuyerID(ctx, "0")
+				assert.Error(t, err)
+
+				actualInternalConfig, err := fs.GetInternalConfigForBuyerID(ctx, "0")
+				assert.Error(t, err)
+
+				assert.Equal(t, routing.DefaultRoutingRulesSettings, actualRoutingRulesSettings)
+				assert.Equal(t, core.NewRouteShader(), actualRouteShader)
+				assert.Equal(t, core.NewInternalConfig(), actualInternalConfig)
+			})
+
+			t.Run("success", func(t *testing.T) {
+				fs, err := storage.NewFirestore(ctx, "default", log.NewNopLogger())
+				assert.NoError(t, err)
+
+				defer func() {
+					err := cleanFireStore(ctx, fs.Client)
+					assert.NoError(t, err)
+				}()
+
+				err = fs.AddCustomer(ctx, expectedCustomer)
+				assert.NoError(t, err)
+
+				err = fs.AddBuyer(ctx, expectedBuyer)
+				assert.NoError(t, err)
+
+				// Grab the buyer for its firestore ID
+				bdocs := fs.Client.Collection("Buyer").Documents(ctx)
+
+				bdoc, err := bdocs.Next()
+				assert.NoError(t, err)
+
+				buyerFirestoreID := bdoc.Ref.ID
+
+				actualRoutingRulesSettings, err := fs.GetRoutingRulesSettingsForBuyerID(ctx, buyerFirestoreID)
+				assert.NoError(t, err)
+
+				actualRouteShader, err := fs.GetRouteShaderForBuyerID(ctx, buyerFirestoreID)
+				assert.NoError(t, err)
+
+				actualInternalConfig, err := fs.GetInternalConfigForBuyerID(ctx, buyerFirestoreID)
+				assert.NoError(t, err)
+
+				assert.Equal(t, expectedRoutingRulesSettings, actualRoutingRulesSettings)
+				assert.Equal(t, expectedRouteShader, actualRouteShader)
+				assert.Equal(t, expectedInternalConfig, actualInternalConfig)
+			})
+		})
+
+		t.Run("set", func(t *testing.T) {
+			t.Run("not found", func(t *testing.T) {
+				fs, err := storage.NewFirestore(ctx, "default", log.NewNopLogger())
+				assert.NoError(t, err)
+
+				defer func() {
+					err := cleanFireStore(ctx, fs.Client)
+					assert.NoError(t, err)
+				}()
+
+				err = fs.SetSequenceNumber(ctx, -1)
+				assert.NoError(t, err)
+
+				err = fs.AddCustomer(ctx, expectedCustomer)
+				assert.NoError(t, err)
+
+				err = fs.AddBuyer(ctx, expectedBuyer)
+				assert.NoError(t, err)
+
+				err = fs.SetRoutingRulesSettingsForBuyerID(ctx, "0", expectedCustomer.Name, routing.DefaultRoutingRulesSettings)
+				assert.NoError(t, err)
+
+				err = fs.SetRouteShaderForBuyerID(ctx, "0", expectedCustomer.Name, core.NewRouteShader())
+				assert.NoError(t, err)
+
+				err = fs.SetInternalConfigForBuyerID(ctx, "0", expectedCustomer.Name, core.NewInternalConfig())
+				assert.NoError(t, err)
+
+				err = fs.Sync(ctx)
+				assert.NoError(t, err)
+
+				actualBuyer, err := fs.Buyer(expectedBuyer.ID)
+				assert.NoError(t, err)
+
+				assert.Equal(t, expectedRoutingRulesSettings, actualBuyer.RoutingRulesSettings)
+				assert.Equal(t, expectedRouteShader, actualBuyer.RouteShader)
+				assert.Equal(t, expectedInternalConfig, actualBuyer.InternalConfig)
+			})
+
+			t.Run("success", func(t *testing.T) {
+				fs, err := storage.NewFirestore(ctx, "default", log.NewNopLogger())
+				assert.NoError(t, err)
+
+				defer func() {
+					err := cleanFireStore(ctx, fs.Client)
+					assert.NoError(t, err)
+				}()
+
+				err = fs.SetSequenceNumber(ctx, -1)
+				assert.NoError(t, err)
+
+				err = fs.AddCustomer(ctx, expectedCustomer)
+				assert.NoError(t, err)
+
+				err = fs.AddBuyer(ctx, expectedBuyer)
+				assert.NoError(t, err)
+
+				// Grab the buyer for its firestore ID
+				bdocs := fs.Client.Collection("Buyer").Documents(ctx)
+
+				bdoc, err := bdocs.Next()
+				assert.NoError(t, err)
+
+				buyerFirestoreID := bdoc.Ref.ID
+
+				err = fs.SetRoutingRulesSettingsForBuyerID(ctx, buyerFirestoreID, expectedCustomer.Name, routing.DefaultRoutingRulesSettings)
+				assert.NoError(t, err)
+
+				err = fs.SetRouteShaderForBuyerID(ctx, buyerFirestoreID, expectedCustomer.Name, core.NewRouteShader())
+				assert.NoError(t, err)
+
+				err = fs.SetInternalConfigForBuyerID(ctx, buyerFirestoreID, expectedCustomer.Name, core.NewInternalConfig())
+				assert.NoError(t, err)
+
+				err = fs.Sync(ctx)
+				assert.NoError(t, err)
+
+				actualBuyer, err := fs.Buyer(expectedBuyer.ID)
+				assert.NoError(t, err)
+
+				assert.Equal(t, routing.DefaultRoutingRulesSettings, actualBuyer.RoutingRulesSettings)
+				assert.Equal(t, core.NewRouteShader(), actualBuyer.RouteShader)
+				assert.Equal(t, core.NewInternalConfig(), actualBuyer.InternalConfig)
+			})
+		})
 	})
 }


### PR DESCRIPTION
Fixes an issue with the new route shader sync in dev. Apparently firestore doesn't like setting any map values that don't have a string key. This wasn't caught in the firestore tests because the codepath that sets the route shader doesn't return an error, just logs a warning. This is normally fine as long as there isn't a firestore marshaling issue, like there was here. So to remedy that, I've added some tests to the functions that handle the route shader and internal config directly so that these marshaling issues are caught in the tests.