### PR TITLE
Build libsodium from source in staging

### DIFF
--- a/.semaphore/staging-deploy.yml
+++ b/.semaphore/staging-deploy.yml
@@ -9,7 +9,7 @@ global_job_config:
     - name: sdk4-repo-access
   prologue:
     commands:
-      - sudo apt-get update && sudo apt-get -y install libsodium-dev libzmq3-dev gcc-8
+      - sudo apt-get update && sudo apt-get -y install libzmq3-dev gcc-8
       - gcloud auth activate-service-account --key-file=/home/semaphore/gcp-service-account.json
       - gcloud auth configure-docker -q
       - checkout
@@ -19,6 +19,15 @@ global_job_config:
       - ssh-add ~/.ssh/id_rsa_semaphoreci_sdk4
       - git submodule init sdk4
       - git submodule update sdk4
+      
+      # libsodium in apt is too old, build from source
+      - curl https://download.libsodium.org/libsodium/releases/libsodium-1.0.17.tar.gz --output libsodium-1.0.17.tar.gz
+      - tar -zxvf libsodium-1.0.17.tar.gz
+      - cd ./libsodium-1.0.17
+      - ./configure
+      - make && make check
+      - sudo make install
+      - cd ../
 blocks:
   - name: Build & Publish Artifacts
     dependencies: []


### PR DESCRIPTION
To get SDK4 working for the load test client and server, we need to use the correct version of libsodium (1.0.17). `apt` only has 1.0.16, so we need to modify the deploy to download and build 1.0.17 from source.