### PR TITLE
Fallback To Direct Metrics for server_backend4

### DIFF
--- a/metrics/server_backend4.go
+++ b/metrics/server_backend4.go
@@ -49,6 +49,7 @@ type SessionUpdate4Metrics struct {
 	HandlerMetrics *PacketHandlerMetrics
 
 	ReadPacketFailure       Counter
+	FallbackToDirect        Counter
 	BuyerNotFound           Counter
 	ClientLocateFailure     Counter
 	ReadSessionDataFailure  Counter
@@ -68,6 +69,7 @@ type SessionUpdate4Metrics struct {
 var EmptySessionUpdate4Metrics = SessionUpdate4Metrics{
 	HandlerMetrics:          &EmptyPacketHandlerMetrics,
 	ReadPacketFailure:       &EmptyCounter{},
+	FallbackToDirect:        &EmptyCounter{},
 	BuyerNotFound:           &EmptyCounter{},
 	ClientLocateFailure:     &EmptyCounter{},
 	ReadSessionDataFailure:  &EmptyCounter{},
@@ -383,6 +385,17 @@ func newSessionUpdateMetrics(ctx context.Context, handler Handler, serviceName s
 		ID:          handlerID + ".read_packet_failure",
 		Unit:        "errors",
 		Description: "The number of times a " + packetDescription + " failed to read.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirect, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " contained a fallback to direct signal.",
 	})
 	if err != nil {
 		return nil, err

--- a/transport/server_handlers4.go
+++ b/transport/server_handlers4.go
@@ -252,6 +252,12 @@ func SessionUpdateHandlerFunc4(logger log.Logger, getIPLocator func(sessionID ui
 			return
 		}
 
+		if packet.FallbackToDirect {
+			level.Error(logger).Log("err", "received fallback to direct")
+			metrics.FallbackToDirect.Add(1)
+			return
+		}
+
 		buyer, err := storer.Buyer(packet.CustomerID)
 		if err != nil {
 			level.Error(logger).Log("msg", "buyer not found", "err", err)


### PR DESCRIPTION
Adds a fallback to direct metric for server_backend4. We previously had this in the old server_backend, but it wasn't ported over until now.