### PR TITLE
Fix server_backend4 Empty Route Matrix Read

### DIFF
--- a/cmd/server_backend4/server_backend4.go
+++ b/cmd/server_backend4/server_backend4.go
@@ -474,11 +474,13 @@ func mainReturnWithCode() int {
 					}
 
 					var newRouteMatrix4 routing.RouteMatrix4
-					rs := encoding.CreateReadStream(buffer)
-					if err := newRouteMatrix4.Serialize(rs); err != nil {
-						level.Error(logger).Log("msg", "could not serialize route matrix", "err", err)
-						time.Sleep(syncInterval)
-						continue // Don't swap route matrix if we fail to serialize
+					if len(buffer) > 0 {
+						rs := encoding.CreateReadStream(buffer)
+						if err := newRouteMatrix4.Serialize(rs); err != nil {
+							level.Error(logger).Log("msg", "could not serialize route matrix", "err", err)
+							time.Sleep(syncInterval)
+							continue // Don't swap route matrix if we fail to serialize
+						}
 					}
 
 					routeEntriesTime := time.Since(start)


### PR DESCRIPTION
Fixes an error when attempting to read an empty route matrix from the relay backend.