### PR TITLE
Fix Portal Cruncher Tests

### DIFF
--- a/cmd/portal_cruncher/portal_cruncher.go
+++ b/cmd/portal_cruncher/portal_cruncher.go
@@ -376,10 +376,10 @@ func ReceivePortalMessage(portalSubscriber pubsub.Subscriber, metrics *metrics.P
 }
 
 func RedisHandler(
-	clientTopSessions *storage.RawRedisClient,
-	clientSessionMap *storage.RawRedisClient,
-	clientSessionMeta *storage.RawRedisClient,
-	clientSessionSlices *storage.RawRedisClient,
+	clientTopSessions storage.RedisClient,
+	clientSessionMap storage.RedisClient,
+	clientSessionMeta storage.RedisClient,
+	clientSessionSlices storage.RedisClient,
 	messageChan chan []byte,
 	portalDataBuffer []transport.SessionPortalData,
 	flushTime time.Time,
@@ -425,10 +425,10 @@ func PullMessage(messageChan chan []byte) (transport.SessionPortalData, error) {
 }
 
 func InsertToRedis(
-	clientTopSessions *storage.RawRedisClient,
-	clientSessionMap *storage.RawRedisClient,
-	clientSessionMeta *storage.RawRedisClient,
-	clientSessionSlices *storage.RawRedisClient,
+	clientTopSessions storage.RedisClient,
+	clientSessionMap storage.RedisClient,
+	clientSessionMeta storage.RedisClient,
+	clientSessionSlices storage.RedisClient,
 	portalDataBuffer []transport.SessionPortalData,
 	minutes int64) {
 
@@ -554,7 +554,7 @@ func createRedis(redisHostTopSessions string, redisHostSessionMap string, redisH
 	return clientTopSessions, clientSessionMap, clientSessionMeta, clientSessionSlices, nil
 }
 
-func pingRedis(clientTopSessions *storage.RawRedisClient, clientSessionMap *storage.RawRedisClient, clientSessionMeta *storage.RawRedisClient, clientSessionSlices *storage.RawRedisClient) error {
+func pingRedis(clientTopSessions storage.RedisClient, clientSessionMap storage.RedisClient, clientSessionMeta storage.RedisClient, clientSessionSlices storage.RedisClient) error {
 	if err := clientTopSessions.Ping(); err != nil {
 		return err
 	}

--- a/storage/redis.go
+++ b/storage/redis.go
@@ -6,36 +6,12 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
-
-	"github.com/gomodule/redigo/redis"
 )
 
-func NewRedisPool(hostname string, maxIdleConnections int, maxActiveConnections int) *redis.Pool {
-	pool := redis.Pool{
-		MaxIdle:     maxIdleConnections,
-		MaxActive:   maxActiveConnections,
-		IdleTimeout: 60 * time.Second,
-		Dial: func() (redis.Conn, error) {
-			return redis.Dial("tcp", hostname)
-		},
-	}
-
-	return &pool
-}
-
-func ValidateRedisPool(pool *redis.Pool) error {
-	redisConn := pool.Get()
-	defer redisConn.Close()
-
-	redisConn.Send("PING")
-	redisConn.Flush()
-	pong, err := redisConn.Receive()
-	if err != nil || pong != "PONG" {
-		return fmt.Errorf("could not ping: %v", err)
-	}
-
-	return nil
+type RedisClient interface {
+	Ping() error
+	Command(command string, format string, args ...interface{}) error
+	Close() error
 }
 
 type RawRedisClient struct {

--- a/storage/redis_pool.go
+++ b/storage/redis_pool.go
@@ -1,0 +1,35 @@
+package storage
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+func NewRedisPool(hostname string, maxIdleConnections int, maxActiveConnections int) *redis.Pool {
+	pool := redis.Pool{
+		MaxIdle:     maxIdleConnections,
+		MaxActive:   maxActiveConnections,
+		IdleTimeout: 60 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", hostname)
+		},
+	}
+
+	return &pool
+}
+
+func ValidateRedisPool(pool *redis.Pool) error {
+	redisConn := pool.Get()
+	defer redisConn.Close()
+
+	redisConn.Send("PING")
+	redisConn.Flush()
+	pong, err := redisConn.Receive()
+	if err != nil || pong != "PONG" {
+		return fmt.Errorf("could not ping: %v", err)
+	}
+
+	return nil
+}

--- a/storage/redis_pool_test.go
+++ b/storage/redis_pool_test.go
@@ -1,0 +1,41 @@
+package storage_test
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis"
+	"github.com/networknext/backend/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRedisPool(t *testing.T) {
+	addr := "127.0.0.1:6739"
+	maxIdleConnections := 5
+	maxActiveConnections := 64
+
+	pool := storage.NewRedisPool(addr, maxIdleConnections, maxActiveConnections)
+	assert.Equal(t, maxIdleConnections, pool.MaxIdle)
+	assert.Equal(t, maxActiveConnections, pool.MaxActive)
+}
+
+func TestValidateRedisPoolFailure(t *testing.T) {
+	addr := ""
+	maxIdleConnections := 5
+	maxActiveConnections := 64
+
+	pool := storage.NewRedisPool(addr, maxIdleConnections, maxActiveConnections)
+	err := storage.ValidateRedisPool(pool)
+	assert.Error(t, err)
+}
+
+func TestValidateRedisPoolSuccess(t *testing.T) {
+	redisServer, err := miniredis.Run()
+	assert.NoError(t, err)
+
+	maxIdleConnections := 5
+	maxActiveConnections := 64
+
+	pool := storage.NewRedisPool(redisServer.Addr(), maxIdleConnections, maxActiveConnections)
+	err = storage.ValidateRedisPool(pool)
+	assert.NoError(t, err)
+}

--- a/storage/redis_test.go
+++ b/storage/redis_test.go
@@ -9,38 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewRedisPool(t *testing.T) {
-	addr := "127.0.0.1:6739"
-	maxIdleConnections := 5
-	maxActiveConnections := 64
-
-	pool := storage.NewRedisPool(addr, maxIdleConnections, maxActiveConnections)
-	assert.Equal(t, maxIdleConnections, pool.MaxIdle)
-	assert.Equal(t, maxActiveConnections, pool.MaxActive)
-}
-
-func TestValidateRedisPoolFailure(t *testing.T) {
-	addr := ""
-	maxIdleConnections := 5
-	maxActiveConnections := 64
-
-	pool := storage.NewRedisPool(addr, maxIdleConnections, maxActiveConnections)
-	err := storage.ValidateRedisPool(pool)
-	assert.Error(t, err)
-}
-
-func TestValidateRedisPoolSuccess(t *testing.T) {
-	redisServer, err := miniredis.Run()
-	assert.NoError(t, err)
-
-	maxIdleConnections := 5
-	maxActiveConnections := 64
-
-	pool := storage.NewRedisPool(redisServer.Addr(), maxIdleConnections, maxActiveConnections)
-	err = storage.ValidateRedisPool(pool)
-	assert.NoError(t, err)
-}
-
 func TestNewRawRedisClientFailure(t *testing.T) {
 	_, err := storage.NewRawRedisClient("")
 	assert.Error(t, err)


### PR DESCRIPTION
There were two problems with the tests I wrote for the portal cruncher. One was "solved" by using time.Sleep() to wait for the TCP packets to travel over the socket, but I've solved it a better way in this PR by removing sockets altogether and keeping the transfer all in memory. While debugging this, I also ran into another bug with the tests that caused a failure if the test was ran near a minute boundary (since the portal cruncher stores the portal data keyed on the current minute). With these two fixes these tests should be reliable now.