### PR TITLE
Remove SDK Version Parameter in Bootstrap

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -35,7 +35,7 @@ gsutil cp "$bucket/libpgm-5.2.so.0" '/usr/local/lib'
 # Copy libzmq from GCP Storage
 gsutil cp "$bucket/libzmq.so" '/usr/local/lib'
 
-# Copy libzmq from GCP Storage
+# Copy libnext from GCP Storage
 gsutil cp "$bucket/libnext.so" '/usr/local/lib'
 
 # Refresh the known libs on the system


### PR DESCRIPTION
We don't need it anymore. Noticed it when I was trying to get the server backend to work in dev but the startup script was pulling the wrong server backend from the GCP bucket.