### PR TITLE
Relay data safety

### DIFF
--- a/cmd/func_backend/func_backend.go
+++ b/cmd/func_backend/func_backend.go
@@ -166,9 +166,9 @@ func TimeoutThread() {
 				continue
 			}
 		}
+
 		if backend.dirty {
 			fmt.Printf("-----------------------------\n")
-			allRelayData := backend.relayMap.GetAllRelayData()
 			for _, relayData := range allRelayData {
 				fmt.Printf("relay: %v\n", &relayData.Addr)
 			}
@@ -185,7 +185,7 @@ func TimeoutThread() {
 	}
 }
 
-func (backend *Backend) GetNearRelays() []*routing.RelayData {
+func (backend *Backend) GetNearRelays() []routing.RelayData {
 	backend.mutex.Lock()
 	allRelayData := backend.relayMap.GetAllRelayData()
 	backend.mutex.Unlock()

--- a/cmd/relay_backend/relay_backend.go
+++ b/cmd/relay_backend/relay_backend.go
@@ -417,13 +417,7 @@ func mainReturnWithCode() int {
 	go func() {
 		for {
 			// For now, exclude all valve relays
-			relayIDs := make([]uint64, 0)
-			allRelayData := relayMap.GetAllRelayData()
-			for _, relayData := range allRelayData {
-				if relayData.Seller.ID != "valve" { // Filter out any relays whose seller has a Firestore key of "valve"
-					relayIDs = append(relayIDs, relayData.ID)
-				}
-			}
+			relayIDs := relayMap.GetAllRelayIDs([]string{"valve"})  // Filter out any relays whose seller has a Firestore key of "valve"
 
 			numRelays := len(relayIDs)
 			relayAddresses := make([]net.UDPAddr, numRelays)
@@ -573,11 +567,7 @@ func mainReturnWithCode() int {
 	go func() {
 		for {
 			// All relays included
-			relayIDs := make([]uint64, 0)
-			allRelayData := relayMap.GetAllRelayData()
-			for _, relayData := range allRelayData {
-				relayIDs = append(relayIDs, relayData.ID)
-			}
+			relayIDs := relayMap.GetAllRelayIDs([]string{})
 
 			numRelays := len(relayIDs)
 			relayAddresses := make([]net.UDPAddr, numRelays)

--- a/routing/relay_map.go
+++ b/routing/relay_map.go
@@ -152,19 +152,46 @@ func (relayMap *RelayMap) GetRelayData(relayAddress string) *RelayData {
 	return relayMap.relays[relayAddress]
 }
 
-func (relayMap *RelayMap) GetAllRelayData() []*RelayData {
+func (relayMap *RelayMap) GetAllRelayData() []RelayData {
 	relayMap.RLock()
-	relays := make([]*RelayData, len(relayMap.relays))
+	relays := make([]RelayData, len(relayMap.relays))
 
 	index := 0
 	for _, relayData := range relayMap.relays {
-		relays[index] = relayData
+		relays[index] = *relayData
 		index++
 	}
 
 	relayMap.RUnlock()
 
 	return relays
+}
+
+func (relayMap *RelayMap) GetAllRelayIDs(excludeList []string) []uint64 {
+	relayMap.RLock()
+	defer relayMap.RUnlock()
+	relayIDs := make([]uint64, 0)
+
+
+	if len(excludeList) == 0 {
+		for _, relayData := range relayMap.relays {
+			relayIDs = append(relayIDs, relayData.ID)
+		}
+		return relayIDs
+	}
+
+	excludeMap := make(map[string]bool)
+	for _,exclude := range excludeList{
+		excludeMap[exclude] = true
+	}
+
+	for _, relayData := range relayMap.relays {
+		if _, ok := excludeMap[relayData.Seller.ID]; !ok {
+			relayIDs = append(relayIDs, relayData.ID)
+		}
+	}
+
+	return relayIDs
 }
 
 func (relayMap *RelayMap) RemoveRelayData(relayAddress string) {

--- a/routing/stats_database_test.go
+++ b/routing/stats_database_test.go
@@ -282,10 +282,10 @@ func TestStatsDatabase(t *testing.T) {
 			for _, r := range allRelayData {
 				if i == 0 {
 					r.Datacenter.ID = 0
-					relayMap.AddRelayDataEntry(r.Addr.String(), r)
+					relayMap.AddRelayDataEntry(r.Addr.String(), &r)
 				} else {
 					r.Datacenter.ID = uint64(i)
-					relayMap.AddRelayDataEntry(r.Addr.String(), r)
+					relayMap.AddRelayDataEntry(r.Addr.String(), &r)
 				}
 				i++
 			}


### PR DESCRIPTION
- changes GetAllRelayData to a copy instead of a reference for data safety
- Adds GetRelayIDs to increase speed where the whole relay data is not needed.