### PR TITLE
Actually wait the necessary ping time

### DIFF
--- a/portal_cruncher/portal_cruncher.go
+++ b/portal_cruncher/portal_cruncher.go
@@ -137,6 +137,8 @@ func (cruncher *PortalCruncher) Start(ctx context.Context, numRedisInsertGorouti
 			for {
 				// Periodically ping the redis instances and error out if we don't get a pong
 				if time.Since(pingTime) >= redisPingDuration {
+					pingTime = time.Now()
+
 					if err := cruncher.PingRedis(); err != nil {
 						errChan <- err
 						return


### PR DESCRIPTION
Well this must be why pinging redis took up so much time on the profiler. I never updated the ping time so it would ping every iteration 🤦 