### PR TITLE
Add extra fallback to direct metrics

### DIFF
--- a/modules/metrics/server_backend.go
+++ b/modules/metrics/server_backend.go
@@ -51,43 +51,67 @@ type SessionUpdateMetrics struct {
 	DirectSlices Counter
 	NextSlices   Counter
 
-	ReadPacketFailure       Counter
-	FallbackToDirect        Counter
-	BuyerNotFound           Counter
-	ClientLocateFailure     Counter
-	ReadSessionDataFailure  Counter
-	BadSessionID            Counter
-	BadSliceNumber          Counter
-	BuyerNotLive            Counter
-	DatacenterNotFound      Counter
-	NearRelaysLocateFailure Counter
-	NoRelaysInDatacenter    Counter
-	NoRoute                 Counter
-	MultipathOverload       Counter
-	LatencyWorse            Counter
-	WriteResponseFailure    Counter
+	ReadPacketFailure                          Counter
+	FallbackToDirectUnknownReason              Counter
+	FallbackToDirectBadRouteToken              Counter
+	FallbackToDirectNoNextRouteToContinue      Counter
+	FallbackToDirectPreviousUpdateStillPending Counter
+	FallbackToDirectBadContinueToken           Counter
+	FallbackToDirectRouteExpired               Counter
+	FallbackToDirectRouteRequestTimedOut       Counter
+	FallbackToDirectContinueRequestTimedOut    Counter
+	FallbackToDirectClientTimedOut             Counter
+	FallbackToDirectUpgradeResponseTimedOut    Counter
+	FallbackToDirectRouteUpdateTimedOut        Counter
+	FallbackToDirectDirectPongTimedOut         Counter
+	FallbackToDirectNextPongTimedOut           Counter
+	BuyerNotFound                              Counter
+	ClientLocateFailure                        Counter
+	ReadSessionDataFailure                     Counter
+	BadSessionID                               Counter
+	BadSliceNumber                             Counter
+	BuyerNotLive                               Counter
+	DatacenterNotFound                         Counter
+	NearRelaysLocateFailure                    Counter
+	NoRelaysInDatacenter                       Counter
+	NoRoute                                    Counter
+	MultipathOverload                          Counter
+	LatencyWorse                               Counter
+	WriteResponseFailure                       Counter
 }
 
 // EmptySessionUpdateMetrics is used for testing when we want to pass in metrics but don't care about their value.
 var EmptySessionUpdateMetrics = SessionUpdateMetrics{
-	HandlerMetrics:          &EmptyPacketHandlerMetrics,
-	DirectSlices:            &EmptyCounter{},
-	NextSlices:              &EmptyCounter{},
-	ReadPacketFailure:       &EmptyCounter{},
-	FallbackToDirect:        &EmptyCounter{},
-	BuyerNotFound:           &EmptyCounter{},
-	ClientLocateFailure:     &EmptyCounter{},
-	ReadSessionDataFailure:  &EmptyCounter{},
-	BadSessionID:            &EmptyCounter{},
-	BadSliceNumber:          &EmptyCounter{},
-	BuyerNotLive:            &EmptyCounter{},
-	DatacenterNotFound:      &EmptyCounter{},
-	NearRelaysLocateFailure: &EmptyCounter{},
-	NoRelaysInDatacenter:    &EmptyCounter{},
-	NoRoute:                 &EmptyCounter{},
-	MultipathOverload:       &EmptyCounter{},
-	LatencyWorse:            &EmptyCounter{},
-	WriteResponseFailure:    &EmptyCounter{},
+	HandlerMetrics:                             &EmptyPacketHandlerMetrics,
+	DirectSlices:                               &EmptyCounter{},
+	NextSlices:                                 &EmptyCounter{},
+	ReadPacketFailure:                          &EmptyCounter{},
+	FallbackToDirectUnknownReason:              &EmptyCounter{},
+	FallbackToDirectBadRouteToken:              &EmptyCounter{},
+	FallbackToDirectNoNextRouteToContinue:      &EmptyCounter{},
+	FallbackToDirectPreviousUpdateStillPending: &EmptyCounter{},
+	FallbackToDirectBadContinueToken:           &EmptyCounter{},
+	FallbackToDirectRouteExpired:               &EmptyCounter{},
+	FallbackToDirectRouteRequestTimedOut:       &EmptyCounter{},
+	FallbackToDirectContinueRequestTimedOut:    &EmptyCounter{},
+	FallbackToDirectClientTimedOut:             &EmptyCounter{},
+	FallbackToDirectUpgradeResponseTimedOut:    &EmptyCounter{},
+	FallbackToDirectRouteUpdateTimedOut:        &EmptyCounter{},
+	FallbackToDirectDirectPongTimedOut:         &EmptyCounter{},
+	FallbackToDirectNextPongTimedOut:           &EmptyCounter{},
+	BuyerNotFound:                              &EmptyCounter{},
+	ClientLocateFailure:                        &EmptyCounter{},
+	ReadSessionDataFailure:                     &EmptyCounter{},
+	BadSessionID:                               &EmptyCounter{},
+	BadSliceNumber:                             &EmptyCounter{},
+	BuyerNotLive:                               &EmptyCounter{},
+	DatacenterNotFound:                         &EmptyCounter{},
+	NearRelaysLocateFailure:                    &EmptyCounter{},
+	NoRelaysInDatacenter:                       &EmptyCounter{},
+	NoRoute:                                    &EmptyCounter{},
+	MultipathOverload:                          &EmptyCounter{},
+	LatencyWorse:                               &EmptyCounter{},
+	WriteResponseFailure:                       &EmptyCounter{},
 }
 
 // ServerBackendMetrics defines the set of metrics for the server backend.
@@ -417,12 +441,144 @@ func newSessionUpdateMetrics(ctx context.Context, handler Handler, serviceName s
 		return nil, err
 	}
 
-	m.FallbackToDirect, err = handler.NewCounter(ctx, &Descriptor{
+	m.FallbackToDirectUnknownReason, err = handler.NewCounter(ctx, &Descriptor{
 		DisplayName: handlerName + " Fallback To Direct",
 		ServiceName: serviceName,
 		ID:          handlerID + ".fallback_to_direct",
 		Unit:        "errors",
-		Description: "The number of times a " + packetDescription + " contained a fallback to direct signal.",
+		Description: "The number of times a " + packetDescription + " fell back to direct for some unknown reason.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectBadRouteToken, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.bad_route_token",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to a bad route token.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectNoNextRouteToContinue, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.no_next_route_to_continue",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to no next route to continue.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectPreviousUpdateStillPending, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.previous_update_still_pending",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to the previous update still pending.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectBadContinueToken, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.bad_continue_token",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to a bad continue token.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectRouteExpired, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.route_expired",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to the route expiring.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectRouteRequestTimedOut, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.route_request_timed_out",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to the route request timing out.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectContinueRequestTimedOut, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.continue_request_timed_out",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to the continue request timing out.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectClientTimedOut, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.client_timed_out",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to the client timing out.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectUpgradeResponseTimedOut, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.upgrade_response_timed_out",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to the upgrade response timing out.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectRouteUpdateTimedOut, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.route_update_timed_out",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to the route update timing out.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectDirectPongTimedOut, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.direct_pong_timed_out",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to the direct pong timing out.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.FallbackToDirectNextPongTimedOut, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Fallback To Direct",
+		ServiceName: serviceName,
+		ID:          handlerID + ".fallback_to_direct.next_pong_timed_out",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " fell back to direct due to the next pong timing out.",
 	})
 	if err != nil {
 		return nil, err

--- a/transport/server_handlers.go
+++ b/transport/server_handlers.go
@@ -359,8 +359,36 @@ func SessionUpdateHandlerFunc(logger log.Logger, getIPLocator func(sessionID uin
 
 		if packet.FallbackToDirect {
 			if !sessionData.FellBackToDirect {
-				metrics.FallbackToDirect.Add(1)
 				sessionData.FellBackToDirect = true
+
+				switch packet.Flags {
+				case FallbackFlagsBadRouteToken:
+					metrics.FallbackToDirectBadRouteToken.Add(1)
+				case FallbackFlagsNoNextRouteToContinue:
+					metrics.FallbackToDirectNoNextRouteToContinue.Add(1)
+				case FallbackFlagsPreviousUpdateStillPending:
+					metrics.FallbackToDirectPreviousUpdateStillPending.Add(1)
+				case FallbackFlagsBadContinueToken:
+					metrics.FallbackToDirectBadContinueToken.Add(1)
+				case FallbackFlagsRouteExpired:
+					metrics.FallbackToDirectRouteExpired.Add(1)
+				case FallbackFlagsRouteRequestTimedOut:
+					metrics.FallbackToDirectRouteRequestTimedOut.Add(1)
+				case FallbackFlagsContinueRequestTimedOut:
+					metrics.FallbackToDirectContinueRequestTimedOut.Add(1)
+				case FallbackFlagsClientTimedOut:
+					metrics.FallbackToDirectClientTimedOut.Add(1)
+				case FallbackFlagsUpgradeResponseTimedOut:
+					metrics.FallbackToDirectUpgradeResponseTimedOut.Add(1)
+				case FallbackFlagsRouteUpdateTimedOut:
+					metrics.FallbackToDirectRouteUpdateTimedOut.Add(1)
+				case FallbackFlagsDirectPongTimedOut:
+					metrics.FallbackToDirectDirectPongTimedOut.Add(1)
+				case FallbackFlagsNextPongTimedOut:
+					metrics.FallbackToDirectNextPongTimedOut.Add(1)
+				default:
+					metrics.FallbackToDirectUnknownReason.Add(1)
+				}
 			}
 			return
 		}

--- a/transport/server_handlers_session_update_test.go
+++ b/transport/server_handlers_session_update_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/alicebob/miniredis"
 	"github.com/go-kit/kit/log"
 	"github.com/networknext/backend/modules/billing"
+	"github.com/networknext/backend/modules/core"
 	"github.com/networknext/backend/modules/crypto"
 	"github.com/networknext/backend/modules/metrics"
-	"github.com/networknext/backend/modules/core"
 	"github.com/networknext/backend/routing"
 	"github.com/networknext/backend/storage"
 	"github.com/networknext/backend/transport"
@@ -681,7 +681,7 @@ func TestSessionUpdateHandlerFallbackToDirect(t *testing.T) {
 	assert.Equal(t, expectedSessionData, sessionData)
 	assert.Equal(t, expectedResponse, responsePacket)
 
-	assert.Equal(t, metrics.SessionUpdateMetrics.FallbackToDirect.Value(), 1.0)
+	assert.Equal(t, metrics.SessionUpdateMetrics.FallbackToDirectUnknownReason.Value(), 1.0)
 }
 
 func TestSessionUpdateHandlerDatacenterNotFound(t *testing.T) {


### PR DESCRIPTION
I'm getting some fallback to direct metrics in staging, but I can't tell why. So I've separated the fallback to direct metric into distinct metrics that will let me know what is up. Specifically I want to know if there is actually some issue that is causing fallback to directs, or if there is just some environment limitation, ex. not enough relays in staging yet to accommodate the sessions, not enough load test servers, etc.