### PR TITLE
Issue 1894

### DIFF
--- a/storage/firestore.go
+++ b/storage/firestore.go
@@ -1298,6 +1298,7 @@ func (fs *Firestore) SetRelay(ctx context.Context, r routing.Relay) error {
 			// Set the data to update the relay with
 			newRelayData := map[string]interface{}{
 				"name":            r.Name,
+				"publicAddress":   r.Addr.String(),
 				"state":           r.State,
 				"lastUpdateTime":  r.LastUpdateTime,
 				"stateUpdateTime": time.Now(),

--- a/transport/jsonrpc/ops.go
+++ b/transport/jsonrpc/ops.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"regexp"
 	"sort"
@@ -695,6 +696,7 @@ func (s *OpsService) RemoveRelay(r *http.Request, args *RemoveRelayArgs, reply *
 	shortDate := time.Now().Format("2006-01-02")
 	shortTime := time.Now().Format("15:04:05")
 	relay.Name = fmt.Sprintf("%s-%s-%s", relay.Name, shortDate, shortTime)
+	relay.Addr = net.UDPAddr{} // clear the address to 0 when removed
 
 	if err = s.Storage.SetRelay(context.Background(), relay); err != nil {
 		err = fmt.Errorf("RemoveRelay() Storage.SetRelay error: %w", err)


### PR DESCRIPTION
Closes #1894 

Clears the address field when removing a relay. The unit tests pass and I didn't notice any weirdness from running the happy path now that the address is set in the SetRelay func