### PR TITLE
Fix for func tests from Jon

### DIFF
--- a/scripts/test-func-parallel.sh
+++ b/scripts/test-func-parallel.sh
@@ -51,7 +51,7 @@ for test in "${tests[@]}"; do
 done
 
 exitCode="0"
-processes="$(ps --ppid $$ | grep 'docker' | awk '{print $1}')"
+processes="$(pgrep -P $$)"
 
 while read process; do
     wait $process


### PR DESCRIPTION
This is a PR from @GodOfProgramming to fix the `make test-func-parallel` command