### PR TITLE
(WIP) Automate Staging

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -2124,8 +2124,8 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 				ShortUsage: "next staging stop",
 				ShortHelp:  "Shuts down the staging environment",
 				Exec: func(ctx context.Context, args []string) error {
-					if err := StopStaging(); err != nil {
-						handleRunTimeError(err.Error(), 1)
+					if errs := StopStaging(); errs != nil && len(errs) != 0 {
+						handleRunTimeError(errs[0].Error(), 1)
 					}
 					return nil
 				},


### PR DESCRIPTION
The process for load testing in staging is very manual. It involves starting instances and setting MIG instance counts manually. This PR adds some scripting to the next tool to automate some of this for us. Namely, it adds the following commands:

`next staging start` Starts the staging environment. You can optionally give a JSON file defining the configuration to use.
`next staging stop` Shuts down the staging environment.
`next staging example` Outputs an example configuration JSON file to use with `next staging start`. This command name might change to `next staging config example` once more configuration options are available, design is still a WIP. NOTE: server count isn't actually used. Eventually this will be removed from the example.

Once this is finished, I plan to make a slab article detailing the staging environment, how to set it up, things to know, etc. Until then, I'll jot some notes and planned features down here:

Notes:
- There are 50 servers per VM, and 2000 clients per VM. There is also an enforcement of 200 clients per server. This is why the server count config parameter isn't used; it can be inferred from the client count.
- Starting the staging environment is relatively quick. Stopping is slow however, and this is because the server backends, servers, and clients MIGs need to be stable before staging is started back up so that the load remains evenly distributed. Clients get a list of servers on VM startup, and servers can't load balance to new server backends due to the internal TCP load balancer issue (will go into more detail in the stab article).

Planned Features:
- Have some way to have a variable number of relays. If this is not easily accomplishable, automate the creation of new relays. Each relay has to have its own static internal IP address and its own datacenter entry with a unique, randomized lat long.
- Allow the template of various services to be changed. This would allow control over the amount of cores per VM, memory per VM, etc.
- Add a helper command to adjust the percent of accelerated sessions. Right now this is easily changed via Firestore, but a command via the next tool would be convenient.

Open to comments or feature suggestions.