### PR TITLE
Don't send post session update when client ping times out

### DIFF
--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -306,7 +306,9 @@ func SessionUpdateHandlerFunc(logger log.Logger, getIPLocator func(sessionID uin
 				return
 			}
 
-			go PostSessionUpdate(postSessionHandler, &packet, &sessionData, &buyer, multipathVetoHandler, routeRelayNames, routeRelaySellers, nearRelays, &datacenter)
+			if !packet.ClientPingTimedOut {
+				go PostSessionUpdate(postSessionHandler, &packet, &sessionData, &buyer, multipathVetoHandler, routeRelayNames, routeRelaySellers, nearRelays, &datacenter)
+			}
 		}()
 
 		if packet.ClientPingTimedOut {


### PR DESCRIPTION
Right now the SDK will send session updates for about a minute after the client expires with a `ClientPingTimedOut` flag set to true. If we see updates with this flag set, we don't want to send a post session update. It's causing extra slices to be sent to the portal with unknown ISPs and datacenters and doesn't look good.