### PR TITLE
Fix Billing Timestamp

### DIFF
--- a/modules/billing/googlepubsub.go
+++ b/modules/billing/googlepubsub.go
@@ -105,7 +105,7 @@ func (biller *GooglePubSubBiller) Bill(ctx context.Context, entry *BillingEntry)
 
 	client.bufferMutex.Lock()
 
-	if client.bufferMessageCount < client.BufferCountThreshold {
+	if client.bufferMessageCount < client.BufferCountThreshold || len(client.buffer) < client.MinBufferBytes {
 		client.buffer = append(client.buffer, data...)
 		client.bufferMessageCount++
 		client.Metrics.EntriesSubmitted.Add(1)

--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -704,6 +704,7 @@ func PostSessionUpdate(postSessionHandler *PostSessionHandler, packet *SessionUp
 	}
 
 	billingEntry := &billing.BillingEntry{
+		Timestamp:                 uint64(time.Now().Unix()),
 		BuyerID:                   packet.CustomerID,
 		UserHash:                  packet.UserHash,
 		SessionID:                 packet.SessionID,


### PR DESCRIPTION
The billing timestamp was wrong in BigQuery because we used the publish time from Google PubSub. However, this doesn't work with batching because batched messages will all erroneously have the same timestamp. To fix, just set the timestamp per entry directly in the server backend.