### PR TITLE
Fix Route Matrix WriteTo()

### DIFF
--- a/modules/routing/route_matrix.go
+++ b/modules/routing/route_matrix.go
@@ -161,8 +161,12 @@ func (m *RouteMatrix) WriteTo(writer io.Writer, bufferSize int) (int64, error) {
 		return 0, err
 	}
 
-	err = m.Serialize(writeStream)
-	return int64(writeStream.GetBytesProcessed()), err
+	if err = m.Serialize(writeStream); err != nil {
+		return int64(writeStream.GetBytesProcessed()), err
+	}
+
+	n, err := writer.Write(writeStream.GetData())
+	return int64(n), err
 }
 
 func (m *RouteMatrix) WriteAnalysisTo(writer io.Writer) {


### PR DESCRIPTION
The route matrix's `WriteTo()` function takes in a writer to write the data to, but it wasn't actually utilizing it.