### PR TITLE
Fix `next view route`

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -2015,7 +2015,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 		Subcommands: []*ffcli.Command{
 			{
 				Name:       "cost",
-				ShortUsage: "next view cost",
+				ShortUsage: "next view costs",
 				ShortHelp:  "View the entries of the cost matrix",
 				Exec: func(ctx context.Context, args []string) error {
 					input := "cost.bin"
@@ -2025,7 +2025,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 			},
 			{
 				Name:       "route",
-				ShortUsage: "next view route [srcRelay] [destRelay]",
+				ShortUsage: "next view routes [srcRelay] [destRelay]",
 				ShortHelp:  "View the entries of the route matrix with optional relay filtering.",
 				Exec: func(ctx context.Context, args []string) error {
 					input := "optimize.bin"

--- a/cmd/next/routes.go
+++ b/cmd/next/routes.go
@@ -111,6 +111,10 @@ func viewRouteMatrix(inputFile string, srcRelayNameFilter string, destRelayNameF
 			Relays      string
 		}{}
 
+		if entry.NumRoutes == 0 {
+			continue
+		}
+
 		if len(entry.RouteNumRelays) == 0 {
 			handleRunTimeError(fmt.Sprintln("RouteNumRelays empty or nil"), 0)
 		}


### PR DESCRIPTION
Fixes `next view route` so we can see routes in the route matrix again.

Also renamed to `next view costs` and `next view routes` so it's a bit more clear.