### PR TITLE
Add Fallback To Direct to Billing Entry

### DIFF
--- a/modules/billing/googlebigquery.go
+++ b/modules/billing/googlebigquery.go
@@ -172,5 +172,15 @@ func (entry *BillingEntry) Save() (map[string]bigquery.Value, string, error) {
 		e["debug"] = entry.Debug
 	}
 
+	e["fallbackToDirect"] = entry.FallbackToDirect
+
+	if entry.ClientFlags != 0 {
+		e["clientFlags"] = int(entry.ClientFlags)
+	}
+
+	if entry.UserFlags != 0 {
+		e["userFlags"] = int(entry.UserFlags)
+	}
+
 	return e, "", nil
 }

--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -571,8 +571,6 @@ func SessionUpdateHandlerFunc(logger log.Logger, getIPLocator func(sessionID uin
 		}
 
 		if buyer.Debug {
-			response.HasDebug = true
-
 			for i := int32(0); i < routeNumRelays; i++ {
 				debug += routeRelayNames[i]
 				if i < routeNumRelays-1 {
@@ -581,6 +579,9 @@ func SessionUpdateHandlerFunc(logger log.Logger, getIPLocator func(sessionID uin
 			}
 
 			response.Debug = debug
+			if response.Debug != "" {
+				response.HasDebug = true
+			}
 		}
 
 		level.Debug(logger).Log("msg", "session updated successfully", "source_address", incoming.SourceAddr.String(), "server_address", packet.ServerAddress.String(), "client_address", packet.ClientAddress.String())
@@ -763,6 +764,9 @@ func PostSessionUpdate(postSessionHandler *PostSessionHandler, packet *SessionUp
 		PredictedNextRTT:          float32(sessionData.RouteCost),
 		MultipathVetoed:           multipathVetoed,
 		Debug:                     debug,
+		FallbackToDirect:          packet.FallbackToDirect,
+		ClientFlags:               packet.Flags,
+		UserFlags:                 packet.UserFlags,
 	}
 
 	postSessionHandler.SendBillingEntry(billingEntry)


### PR DESCRIPTION
This PR adds `fallbackToDirect`, `clientFlags`, and `userFlags` to the billing entry. `clientFlags`, and `userFlags` are only set when they are non-zero. I've also updated the backend to not output blank debug strings in the session update response.