### PR TITLE
BQ billing sql query fix

### DIFF
--- a/modules/transport/jsonrpc/buyer.go
+++ b/modules/transport/jsonrpc/buyer.go
@@ -1433,7 +1433,6 @@ type GetAllSessionBillingInfoReply struct {
 
 func (s *BuyersService) GetAllSessionBillingInfo(r *http.Request, args *GetAllSessionBillingInfoArg, reply *GetAllSessionBillingInfoReply) error {
 
-	fmt.Println("--> Entering GetAllSessionBillingInfo()")
 	ctx := context.Background()
 	sessionID := int64(args.SessionID)
 


### PR DESCRIPTION
2 column names in the SQL used to query BQ for billing data were incorrect. Fixed. I tested the generated SQL directly in the BQ web UI.

In case anyone is interested, this is the SQL being generated for session ID 0x565fdb367bc9fe2c in prod:

```
 select timeStamp, buyerID, sessionID, sliceNumber, next, directRTT, directJitter, directPacketLoss, nextRTT, nextJitter, nextPacketLoss, nextRelays, totalPrice, clientToServerPacketsLost, serverToClientPacketsLost, committed, flagged, multipath, nextBytesUp, nextBytesDown, initial, datacenterID, rttReduction, packetLossReduction, nextRelaysPrice, userHash, latitude, longitude, isp, abTest, connectionType, platformType, sdkVersion, packetLoss, envelopeBytesUp, envelopeBytesDown, predictedNextRTT, multipathVetoed, debug from network-next-v3-prod.prod.billing where sessionId = 6223934237100867116 and DATE(timestamp) >= '1968-05-01' order by sliceNumber asc
```