### PR TITLE
Add Route Near Relay RTT to Billing

### DIFF
--- a/modules/billing/googlebigquery.go
+++ b/modules/billing/googlebigquery.go
@@ -182,5 +182,9 @@ func (entry *BillingEntry) Save() (map[string]bigquery.Value, string, error) {
 		e["userFlags"] = int(entry.UserFlags)
 	}
 
+	if entry.NearRelayRTT != 0 {
+		e["nearRelayRTT"] = entry.NearRelayRTT
+	}
+
 	return e, "", nil
 }

--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -724,6 +724,16 @@ func PostSessionUpdate(postSessionHandler *PostSessionHandler, packet *SessionUp
 		multipathVetoed = true
 	}
 
+	var nearRelayRTT float32
+	if sessionData.RouteNumRelays > 0 {
+		for i := range nearRelays {
+			if nearRelays[i].ID == sessionData.RouteRelayIDs[0] {
+				nearRelayRTT = float32(nearRelays[i].ClientStats.RTT)
+				break
+			}
+		}
+	}
+
 	billingEntry := &billing.BillingEntry{
 		Timestamp:                 uint64(time.Now().Unix()),
 		BuyerID:                   packet.CustomerID,
@@ -769,6 +779,7 @@ func PostSessionUpdate(postSessionHandler *PostSessionHandler, packet *SessionUp
 		FallbackToDirect:          packet.FallbackToDirect,
 		ClientFlags:               packet.Flags,
 		UserFlags:                 packet.UserFlags,
+		NearRelayRTT:              nearRelayRTT,
 	}
 
 	postSessionHandler.SendBillingEntry(billingEntry)


### PR DESCRIPTION
Adds the route's near relay RTT to the billing table so that it can be extracted and used in the route misprediction calculation. 

Because the route matrix can only know about RTT values between relays, the SDK needs to complete the job by measuring the RTT between the client and the first relay in the route. It does this by pinging 32 relays closest to the client and only finding routes that include one of those relays as the first hop.