### PR TITLE
Quick PR to fix `next optimize` write size

### DIFF
--- a/modules/routing/route_matrix.go
+++ b/modules/routing/route_matrix.go
@@ -165,7 +165,7 @@ func (m *RouteMatrix) WriteTo(writer io.Writer, bufferSize int) (int64, error) {
 		return int64(writeStream.GetBytesProcessed()), err
 	}
 
-	n, err := writer.Write(writeStream.GetData())
+	n, err := writer.Write(writeStream.GetData()[:writeStream.GetBytesProcessed()])
 	return int64(n), err
 }
 


### PR DESCRIPTION
Wasn't slicing off the unused buffer bytes when calling `routeMatrix.WriteTo()`. Even though this is an edit the route matrix functionality, this `WriteTo()` function is currently only used by the next tool.