### PR TITLE
Add route switched metric

### DIFF
--- a/modules/metrics/server_backend.go
+++ b/modules/metrics/server_backend.go
@@ -76,6 +76,7 @@ type SessionUpdateMetrics struct {
 	NearRelaysLocateFailure                    Counter
 	NoRelaysInDatacenter                       Counter
 	RouteDoesNotExist                          Counter
+	RouteSwitched                              Counter
 	NoRoute                                    Counter
 	MultipathOverload                          Counter
 	LatencyWorse                               Counter
@@ -112,6 +113,7 @@ var EmptySessionUpdateMetrics = SessionUpdateMetrics{
 	NearRelaysLocateFailure:                    &EmptyCounter{},
 	NoRelaysInDatacenter:                       &EmptyCounter{},
 	RouteDoesNotExist:                          &EmptyCounter{},
+	RouteSwitched:                              &EmptyCounter{},
 	NoRoute:                                    &EmptyCounter{},
 	MultipathOverload:                          &EmptyCounter{},
 	LatencyWorse:                               &EmptyCounter{},
@@ -704,6 +706,17 @@ func newSessionUpdateMetrics(ctx context.Context, handler Handler, serviceName s
 		ID:          handlerID + ".route_does_not_exist",
 		Unit:        "errors",
 		Description: "The number of times a route no longer exists for a " + packetDescription + ".",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.RouteSwitched, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Route Switched",
+		ServiceName: serviceName,
+		ID:          handlerID + ".route_switched",
+		Unit:        "errors",
+		Description: "The number of times a route switched for a " + packetDescription + ".",
 	})
 	if err != nil {
 		return nil, err

--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -564,6 +564,8 @@ func SessionUpdateHandlerFunc(logger log.Logger, getIPLocator func(sessionID uin
 
 					// Check if the route has changed
 					if nextRouteSwitched {
+						metrics.RouteSwitched.Add(1)
+
 						// Create a next token here rather than a continue token since the route has switched
 						HandleNextToken(&sessionData, storer, &buyer, &packet, routeNumRelays, routeRelays[:], routeMatrix.RelayIDs, routerPrivateKey, &response, internalIPSellers, enableInternalIPs)
 					} else {

--- a/modules/transport/server_handlers_session_update_test.go
+++ b/modules/transport/server_handlers_session_update_test.go
@@ -2528,9 +2528,12 @@ func TestSessionUpdateHandlerRouteSwitched(t *testing.T) {
 	var err error
 	emptySessionUpdateMetrics := metrics.EmptySessionUpdateMetrics
 	expectedMetrics.SessionUpdateMetrics = &emptySessionUpdateMetrics
-	expectedMetrics.SessionUpdateMetrics.NextSlices, err = metricsHandler.NewCounter(context.Background(), &metrics.Descriptor{})
+	expectedMetrics.SessionUpdateMetrics.NextSlices, err = metricsHandler.NewCounter(context.Background(), &metrics.Descriptor{ID: "next_slices"})
+	assert.NoError(t, err)
+	expectedMetrics.SessionUpdateMetrics.RouteSwitched, err = metricsHandler.NewCounter(context.Background(), &metrics.Descriptor{ID: "route_switched"})
 	assert.NoError(t, err)
 	expectedMetrics.SessionUpdateMetrics.NextSlices.Add(1)
+	expectedMetrics.SessionUpdateMetrics.RouteSwitched.Add(1)
 
 	metrics, err := metrics.NewServerBackendMetrics(context.Background(), &metricsHandler)
 	assert.NoError(t, err)


### PR DESCRIPTION
Adds a metric for each time a session switches routes.