### PR TITLE
removed noisy printf in next dcmaps command

### DIFF
--- a/cmd/next/buyers.go
+++ b/cmd/next/buyers.go
@@ -222,10 +222,6 @@ func datacenterMapsForBuyer(
 			return
 		}
 
-		for _, dcMap := range reply.DatacenterMaps {
-			fmt.Printf("dcMap: %s\n", dcMap)
-		}
-
 		if signedIDs {
 			var newMaps []localjsonrpc.DatacenterMapsFull
 			for _, dcMap := range reply.DatacenterMaps {


### PR DESCRIPTION
I removed the noisy printf in the `next buyer datacenters` command.