### PR TITLE
Don't require a datacenter map for "local" datacenter

### DIFF
--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -113,6 +113,15 @@ func (e ErrDatacenterNotAllowed) Error() string {
 }
 
 func getDatacenter(storer storage.Storer, buyerID uint64, datacenterID uint64, datacenterName string) (routing.Datacenter, error) {
+	// We should always support the "local" datacenter, even without a datacenter mapping
+	if crypto.HashID("local") == datacenterID {
+		return routing.Datacenter{
+			ID:      crypto.HashID("local"),
+			Name:    "local",
+			Enabled: true,
+		}, nil
+	}
+
 	// enforce that whatever datacenter the server says it's in, we have a mapping for it
 	datacenterAliases := storer.GetDatacenterMapsForBuyer(buyerID)
 	for _, dcMap := range datacenterAliases {


### PR DESCRIPTION
After the change to have DatacenterMaps to be required, we accidentally stopped the "local" datacenter from working for onboarding customers. This PR corrects that by adding in an exception of the datacenter ID matches a hash of "local".