### PR TITLE
Fix a typo in the prod deploy semaphore file

### DIFF
--- a/.semaphore/production-deploy.yml
+++ b/.semaphore/production-deploy.yml
@@ -36,7 +36,7 @@ blocks:
           commands:
             - make build-api-artifacts-prod
             - make publish-api-artifacts-prod
-        - name: API
+        - name: Vanity
           commands:
             - make build-vanity-artifacts-prod
             - make publish-vanity-artifacts-prod


### PR DESCRIPTION
Semaphore couldn't run the deploy for prod due to having two jobs with the same name - a simple copy + paste error.