### PR TITLE
clear the big table portal data buffer after its done inserting

### DIFF
--- a/modules/portal_cruncher/portal_cruncher.go
+++ b/modules/portal_cruncher/portal_cruncher.go
@@ -240,6 +240,7 @@ func (cruncher *PortalCruncher) Start(ctx context.Context, numRedisInsertGorouti
 							errChan <- err
 							return
 						}
+						btPortalDataBuffer = btPortalDataBuffer[:0]
 
 					case <-ctx.Done():
 						return
@@ -669,6 +670,5 @@ func (cruncher *PortalCruncher) InsertIntoBigtable(ctx context.Context, btPortal
 		cruncher.btMetrics.WriteSliceSuccessCount.Add(1)
 	}
 
-	btPortalDataBuffer = btPortalDataBuffer[:0]
 	return nil
 }


### PR DESCRIPTION
After fixing the vanity metric error yesterday regarding the internal buffer, I also realized that the same thing may have been going on for bigtable. This PR clears the buffer after data has been inserted into bigtable. Hopefully it reduces the amount of writes to bigtable.