### PR TITLE
Fix Portal Count Endpoint

### DIFF
--- a/modules/transport/jsonrpc/buyer.go
+++ b/modules/transport/jsonrpc/buyer.go
@@ -431,7 +431,7 @@ func (s *BuyersService) TotalSessions(r *http.Request, args *TotalSessionsArgs, 
 		}
 
 		totalCount := firstTotalCount
-		if secondTotalCount > firstNextCount {
+		if secondTotalCount > firstTotalCount {
 			totalCount = secondTotalCount
 		}
 


### PR DESCRIPTION
Fixes the session count endpoint on the portal for the per-buyer view. Had the wrong variable in the if check.