### PR TITLE
fixed next cmd typo

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -1441,7 +1441,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 								ForceNext:                  ic.ForceNext,
 								LargeCustomer:              ic.LargeCustomer,
 								Uncommitted:                ic.Uncommitted,
-								MaxRTT:                     int32(ic.MaxLatencyTradeOff),
+								MaxRTT:                     int32(ic.MaxRTT),
 							})
 
 							return nil


### PR DESCRIPTION
Fixed a typo in the utility function for `next buyer config add`.