### PR TITLE
increase expiration time limit for vanity redis test

### DIFF
--- a/modules/vanity/vanity_test.go
+++ b/modules/vanity/vanity_test.go
@@ -293,7 +293,7 @@ func TestUpdateMetrics(t *testing.T) {
 		sessionID := rand.Uint64()
 		sessionIDStr := fmt.Sprintf("%016x", sessionID)
 
-		vanityMetrics := vanity.NewVanityMetricHandler(tsMetricsHandler, vanityServiceMetrics, 1, nil, redisServer.Addr(), 5, 5, time.Millisecond*10, "testSet", logger)
+		vanityMetrics := vanity.NewVanityMetricHandler(tsMetricsHandler, vanityServiceMetrics, 1, nil, redisServer.Addr(), 5, 5, time.Millisecond*100, "testSet", logger)
 
 		conn := storage.NewRedisPool(redisServer.Addr(), 5, 5).Get()
 		defer conn.Close()
@@ -308,7 +308,7 @@ func TestUpdateMetrics(t *testing.T) {
 		assert.Equal(t, int64(1), members)
 
 		// Sleep for 20 milliseconds to let the expiration time limit reach
-		time.Sleep(time.Millisecond*20)
+		time.Sleep(time.Millisecond*200)
 
 		// Expire old sessions
 		err = vanityMetrics.ExpireOldSessions(conn)


### PR DESCRIPTION
semaphore is sometimes slow and the test fails inconsistently, so increasing the time here fixes that issue 