### PR TITLE
Vanity metrics aggregation fix

### DIFF
--- a/modules/vanity/vanity.go
+++ b/modules/vanity/vanity.go
@@ -540,20 +540,18 @@ func (vm *VanityMetricHandler) GetVanityMetricJSON(ctx context.Context, sd *metr
 			return nil, errors.New(errStr)
 		}
 
-		// Extract the max point value from the list of points
-		maxPointVal := int64(0)
+		// Take the sum of the list of points
+		sumPointVal := int64(0)
 		for _, points := range pointsList {
 			for _, point := range points {
-				if point.Value.GetInt64Value() > maxPointVal {
-					maxPointVal = point.Value.GetInt64Value()
-				}
+				sumPointVal += point.Value.GetInt64Value()
 			}
 		}
 
-		floatPointVal := float64(maxPointVal)
+		floatPointVal := float64(sumPointVal)
 		// Check if the a slice metric needs hours calculated
 		if vm.hourMetricsMap[displayName] {
-			seconds := time.Second * time.Duration(10*maxPointVal)
+			seconds := time.Second * time.Duration(10*sumPointVal)
 			hours := seconds.Hours()
 			// Round to 3 decimal places
 			floatPointVal = math.Round(hours*1000) / 1000


### PR DESCRIPTION
Another bug popped up while testing vanity metrics in staging regarding the aggregation of the time series data stored in Stackdriver. While testing in dev, I used the Aggregation Aligner to sum values per alignment period, which never resulted in an array with more than one element (likely due to the small number of clients), and by taking the max of this array, I was always getting the "correct" value. During the load test with 100k clients, the Aggregation Aligner resulted in an array with more than element, and by taking the max, the API service reported the incorrect value.

To fix this issue, I added an Aggregation Reducer, which sums across each alignment period after the Aggregation Aligner does its job. This should always result in an array with one value, the sum of the time series. Just to be sure, however, I also replaced the max function with a summation to ensure all array elements are accounted for.