### PR TITLE
fixed next relay listing issues

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -492,12 +492,12 @@ func main() {
 
 	// Flags to hide relays in certain states
 	var relaysStateHideFlags [6]bool
-	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateEnabled], "noenabled", true, "hide enabled relays")
-	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateMaintenance], "nomaintenance", true, "hide relays in maintenance")
-	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateDisabled], "nodisabled", true, "hide disabled relays")
-	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateQuarantine], "noquarantined", true, "hide quarantined relays")
-	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateDecommissioned], "nodecommissioned", true, "hide decommissioned relays")
-	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateOffline], "nooffline", true, "hide offline relays")
+	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateEnabled], "noenabled", false, "hide enabled relays")
+	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateMaintenance], "nomaintenance", false, "hide relays in maintenance")
+	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateDisabled], "nodisabled", false, "hide disabled relays")
+	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateQuarantine], "noquarantined", false, "hide quarantined relays")
+	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateDecommissioned], "nodecommissioned", false, "hide decommissioned relays")
+	relaysfs.BoolVar(&relaysStateHideFlags[routing.RelayStateOffline], "nooffline", false, "hide offline relays")
 
 	// Flag to see relays that are down (haven't pinged backend in 30 seconds)
 	var relaysDownFlag bool
@@ -735,30 +735,6 @@ func main() {
 				relaysStateHideFlags[routing.RelayStateDisabled] = false
 				relaysStateHideFlags[routing.RelayStateQuarantine] = false
 				relaysStateHideFlags[routing.RelayStateOffline] = false
-			}
-
-			if relaysStateShowFlags[routing.RelayStateEnabled] {
-				relaysStateHideFlags[routing.RelayStateEnabled] = false
-			}
-
-			if relaysStateShowFlags[routing.RelayStateMaintenance] {
-				relaysStateHideFlags[routing.RelayStateMaintenance] = false
-			}
-
-			if relaysStateShowFlags[routing.RelayStateDisabled] {
-				relaysStateHideFlags[routing.RelayStateDisabled] = false
-			}
-
-			if relaysStateShowFlags[routing.RelayStateQuarantine] {
-				relaysStateHideFlags[routing.RelayStateQuarantine] = false
-			}
-
-			if relaysStateShowFlags[routing.RelayStateOffline] {
-				relaysStateHideFlags[routing.RelayStateOffline] = false
-			}
-
-			if relaysStateShowFlags[routing.RelayStateDecommissioned] {
-				relaysStateHideFlags[routing.RelayStateDecommissioned] = false
 			}
 
 			var arg string

--- a/cmd/next/relays.go
+++ b/cmd/next/relays.go
@@ -248,6 +248,9 @@ func relays(
 		Regex: regex,
 	}
 
+	// debugPrintRelayViewFlags("function entry", relaysStateHideFlags, relaysStateShowFlags)
+	// os.Exit(0)
+
 	var reply localjsonrpc.RelaysReply
 	if err := rpcClient.CallFor(&reply, "OpsService.Relays", args); err != nil {
 		handleJSONRPCError(env, err)
@@ -381,7 +384,6 @@ func relays(
 	}
 
 	if csvOutputFlag {
-
 		if relaysCount > 0 && int(relaysCount) < len(relaysCSV) {
 			relaysCSV = relaysCSV[:relaysCount+2] // +2 for heading lines
 		}
@@ -649,4 +651,25 @@ func modifyRelayField(
 
 	fmt.Printf("Field %s for relay %s updated successfully.\n", field, reply.Relays[0].Name)
 	return nil
+}
+
+func debugPrintRelayViewFlags(where string, hide [6]bool, show [6]bool) {
+	fmt.Printf("\nHidden States ( %s ):\n", where)
+	for i, hiddenRelayState := range hide {
+		state, err := routing.GetRelayStateSQL(int64(i))
+		if err != nil {
+			handleRunTimeError(fmt.Sprintf("error parsing relay state: %v'", err), 0)
+		}
+		fmt.Printf("\t%s: %t\n", state, hiddenRelayState)
+	}
+
+	fmt.Printf("\nShown States ( %s ):\n", where)
+	for i, shownRelayState := range show {
+		state, err := routing.GetRelayStateSQL(int64(i))
+		if err != nil {
+			handleRunTimeError(fmt.Sprintf("error parsing relay state: %v'", err), 0)
+		}
+		fmt.Printf("\t%s: %t\n", state, shownRelayState)
+	}
+	fmt.Println()
 }


### PR DESCRIPTION
Fixed the relay list limit (e.g. `./next relays -n 10`) as well as the relay state filters. 

`./next relays` now defaults to `./next relays -enabled`, as originally intended.