### PR TITLE
Use in-game packet loss for direct packet loss instead of ping packet loss

### DIFF
--- a/modules/transport/packet_server.go
+++ b/modules/transport/packet_server.go
@@ -17,7 +17,7 @@ const (
 	MaxDatacenterNameLength = 256
 	MaxSessionUpdateRetries = 10
 
-	SessionDataVersion = 8
+	SessionDataVersion = 9
 
 	MaxSessionDataSize = 511
 
@@ -571,20 +571,24 @@ func (packet *SessionResponsePacket) Serialize(stream encoding.Stream) error {
 }
 
 type SessionData struct {
-	Version          uint32
-	SessionID        uint64
-	SessionVersion   uint32
-	SliceNumber      uint32
-	ExpireTimestamp  uint64
-	Initial          bool
-	Location         routing.Location
-	RouteChanged     bool
-	RouteNumRelays   int32
-	RouteCost        int32
-	RouteRelayIDs    [core.MaxRelaysPerRoute]uint64
-	RouteState       core.RouteState
-	EverOnNext       bool
-	FellBackToDirect bool
+	Version                       uint32
+	SessionID                     uint64
+	SessionVersion                uint32
+	SliceNumber                   uint32
+	ExpireTimestamp               uint64
+	Initial                       bool
+	Location                      routing.Location
+	RouteChanged                  bool
+	RouteNumRelays                int32
+	RouteCost                     int32
+	RouteRelayIDs                 [core.MaxRelaysPerRoute]uint64
+	RouteState                    core.RouteState
+	EverOnNext                    bool
+	FellBackToDirect              bool
+	PrevPacketsSentClientToServer uint64
+	PrevPacketsSentServerToClient uint64
+	PrevPacketsLostClientToServer uint64
+	PrevPacketsLostServerToClient uint64
 }
 
 func UnmarshalSessionData(sessionData *SessionData, data []byte) error {
@@ -722,6 +726,13 @@ func (sessionData *SessionData) Serialize(stream encoding.Stream) error {
 	stream.SerializeBits(&sessionData.RouteState.MispredictCounter, 2)
 
 	stream.SerializeBits(&sessionData.RouteState.LatencyWorseCounter, 2)
+
+	if sessionData.Version >= 9 {
+		stream.SerializeUint64(&sessionData.PrevPacketsSentClientToServer)
+		stream.SerializeUint64(&sessionData.PrevPacketsSentServerToClient)
+		stream.SerializeUint64(&sessionData.PrevPacketsLostClientToServer)
+		stream.SerializeUint64(&sessionData.PrevPacketsLostServerToClient)
+	}
 
 	// IMPORTANT: Add new fields at the bottom. Never remove or change old fields or it becomes a disruptive update!
 


### PR DESCRIPTION
Closes #2622. Also replaces the `PacketLoss` field in the billing entry with this higher resolution slice packet loss.

Would appreciate a review from @gafferongames before merging, just want to make sure this does what was asked. Since this only increases resolution of direct packet loss, will there be any discrepancy for having direct vs next packet loss on different resolutions? Also, do we actually need to store the packets sent in the session data?