### PR TITLE
add HexID to json responses for Buyers and Datacenters

### DIFF
--- a/modules/transport/jsonrpc/ops.go
+++ b/modules/transport/jsonrpc/ops.go
@@ -189,6 +189,7 @@ type buyer struct {
 	CompanyCode string `json:"company_code"`
 	ShortName   string `json:"short_name"`
 	ID          uint64 `json:"id"`
+	HexID       string `json:"hexID"`
 }
 
 func (s *OpsService) Buyers(r *http.Request, args *BuyersArgs, reply *BuyersReply) error {
@@ -201,6 +202,7 @@ func (s *OpsService) Buyers(r *http.Request, args *BuyersArgs, reply *BuyersRepl
 		}
 		reply.Buyers = append(reply.Buyers, buyer{
 			ID:          b.ID,
+			HexID:       fmt.Sprintf("%016x", b.ID),
 			CompanyName: c.Name,
 			CompanyCode: b.CompanyCode,
 			ShortName:   b.ShortName,
@@ -852,6 +854,7 @@ type DatacentersReply struct {
 
 type datacenter struct {
 	Name         string  `json:"name"`
+	HexID        string  `json:"hexID"`
 	ID           uint64  `json:"id"`
 	SignedID     int64   `json:"signed_id"`
 	Latitude     float32 `json:"latitude"`
@@ -863,6 +866,7 @@ func (s *OpsService) Datacenters(r *http.Request, args *DatacentersArgs, reply *
 	for _, d := range s.Storage.Datacenters() {
 		reply.Datacenters = append(reply.Datacenters, datacenter{
 			Name:      d.Name,
+			HexID:     fmt.Sprintf("%016x", d.ID),
 			ID:        d.ID,
 			Latitude:  d.Location.Latitude,
 			Longitude: d.Location.Longitude,


### PR DESCRIPTION
I added a _HexID_ to field to the json responses for the _OpsService.Buyers_ and _OpsService.Datacenters_ endpoints so that non-go clients can get access to the IDs. No changes have been made to the routing types.