### PR TITLE
added MultipathRestricted to next session dump

### DIFF
--- a/cmd/next/bigquery_data.go
+++ b/cmd/next/bigquery_data.go
@@ -75,4 +75,5 @@ type BigQueryBillingEntry struct {
 	NextLatencyTooHigh              bigquery.NullBool
 	RouteChanged                    bigquery.NullBool
 	CommitVeto                      bigquery.NullBool
+	MultipathRestricted             bigquery.NullBool
 }

--- a/cmd/next/session_dump.go
+++ b/cmd/next/session_dump.go
@@ -125,6 +125,7 @@ func dumpSession(rpcClient jsonrpc.RPCClient, env Environment, sessionID uint64)
 		"Committed",
 		"Flagged",
 		"Multipath",
+		"MultipathRestricted",
 		"RttReduction",
 		"PacketLossReduction",
 		"FallbackToDirect",
@@ -434,6 +435,11 @@ func dumpSession(rpcClient jsonrpc.RPCClient, env Environment, sessionID uint64)
 		if billingEntry.CommitVeto.Bool {
 			commitVeto = "true"
 		}
+		// MultipathRestricted
+		multipathRestricted := ""
+		if billingEntry.MultipathRestricted.Bool {
+			multipathRestricted = "true"
+		}
 
 		bqBillingDataEntryCSV = append(bqBillingDataEntryCSV, []string{
 			sliceNumber,
@@ -481,6 +487,7 @@ func dumpSession(rpcClient jsonrpc.RPCClient, env Environment, sessionID uint64)
 			committed,
 			flagged,
 			multipath,
+			multipathRestricted,
 			rttReduction,
 			plReduction,
 			fallbackToDirect,
@@ -546,6 +553,7 @@ func GetAllSessionBillingInfo(sessionID int64, env Environment) ([]BigQueryBilli
 	committed,
 	flagged,
 	multipath,
+	multipathRestricted,
 	nextBytesUp,
 	nextBytesDown,
 	datacenterID,


### PR DESCRIPTION
This is a followup to #2653 - no need to merge until the field is being used in BQ.