### PR TITLE
Additional auth error code changes

### DIFF
--- a/modules/transport/jsonrpc/auth.go
+++ b/modules/transport/jsonrpc/auth.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	jwtmiddleware "github.com/auth0/go-jwt-middleware"
 	"github.com/dgrijalva/jwt-go"
@@ -74,7 +73,6 @@ type account struct {
 	Name        string             `json:"name"`
 	Email       string             `json:"email"`
 	Roles       []*management.Role `json:"roles"`
-	CreatedAt   time.Time          `json:"created_at"`
 }
 
 var roleIDs []string = []string{


### PR DESCRIPTION
Noticed after merging the last PR that auth and storage related failures should log out the error BEFORE it is overwritten with the portal error code. This way the lower level error isn't suppressed when debugging. Also, the AddUserAccount endpoint needed another field removed from an auth0 call to keep it from failing.