### PR TITLE
Billing Packets Sent

### DIFF
--- a/modules/billing/googlebigquery.go
+++ b/modules/billing/googlebigquery.go
@@ -268,5 +268,13 @@ func (entry *BillingEntry) Save() (map[string]bigquery.Value, string, error) {
 		e["multipathRestricted"] = entry.MultipathRestricted
 	}
 
+	if entry.ClientToServerPacketsSent > 0 {
+		e["clientToServerPacketsSent"] = int(entry.ClientToServerPacketsSent)
+	}
+
+	if entry.ServerToClientPacketsSent > 0 {
+		e["serverToClientPacketsSent"] = int(entry.ServerToClientPacketsSent)
+	}
+
 	return e, "", nil
 }

--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -1148,6 +1148,8 @@ func PostSessionUpdate(
 		LackOfDiversity:                 sessionData.RouteState.LackOfDiversity,
 		Pro:                             buyer.RouteShader.ProMode && !sessionData.RouteState.MultipathRestricted,
 		MultipathRestricted:             sessionData.RouteState.MultipathRestricted,
+		ClientToServerPacketsSent:       packet.PacketsSentClientToServer,
+		ServerToClientPacketsSent:       packet.PacketsSentServerToClient,
 	}
 
 	postSessionHandler.SendBillingEntry(billingEntry)


### PR DESCRIPTION
Adds `clientToServerPacketsSent` and `serverToClientPacketsSent` to the billing entry. Datascience needs this to use in conjunction with `clientToServerPacketsLost` and `serverToClientPacketsLost` to calculate total packet loss for the session.