### PR TITLE
Add back signature checks in the server backend

### DIFF
--- a/modules/backend/helpers.go
+++ b/modules/backend/helpers.go
@@ -254,6 +254,7 @@ func GetStorer(ctx context.Context, logger log.Logger, gcpProjectID string, env 
 				return nil, err
 			}
 			customerID := binary.LittleEndian.Uint64(customerPublicKey[:8])
+			customerPublicKey = customerPublicKey[8:]
 
 			if !envvar.Exists("RELAY_PUBLIC_KEY") {
 				return nil, errors.New("RELAY_PUBLIC_KEY not set")
@@ -320,6 +321,7 @@ func GetStorer(ctx context.Context, logger log.Logger, gcpProjectID string, env 
 			return storer, err
 		}
 		customerID := binary.LittleEndian.Uint64(customerPublicKey[:8])
+		customerPublicKey = customerPublicKey[8:]
 
 		if !envvar.Exists("RELAY_PUBLIC_KEY") {
 			return storer, errors.New("RELAY_PUBLIC_KEY not set")

--- a/modules/crypto/crypto.go
+++ b/modules/crypto/crypto.go
@@ -9,15 +9,14 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/poly1305"
-
-	"github.com/spaolacci/murmur3"
 )
 
 const (
-	MACSize        = poly1305.TagSize
-	NonceSize      = chacha20poly1305.NonceSizeX
-	KeySize        = chacha20poly1305.KeySize
-	PacketHashSize = 8
+	MACSize             = poly1305.TagSize
+	NonceSize           = chacha20poly1305.NonceSizeX
+	KeySize             = chacha20poly1305.KeySize
+	PacketHashSize      = 8
+	PacketSignatureSize = 64
 )
 
 var (
@@ -49,13 +48,6 @@ var (
 // HashID hashes a string to a uint64 so it can be used as IDs for Relays, Datacenters, etc.
 func HashID(s string) uint64 {
 	hash := fnv.New64a()
-	hash.Write([]byte(s))
-	return hash.Sum64()
-}
-
-// For hashing when speed is the only thing desired
-func FastHash(s string) uint64 {
-	hash := murmur3.New64()
 	hash.Write([]byte(s))
 	return hash.Sum64()
 }
@@ -117,13 +109,6 @@ func Seal(data []byte, nonce []byte, publicKey []byte, privateKey []byte) []byte
 	return box.Seal(nil, data, &n, &pub, &priv)
 }
 
-// Sign wraps sodiumSign with is a wrapper around libsodium
-// We wrap this to avoid including C in other libs breaking
-// code linting
-func Sign(privateKey []byte, data []byte) []byte {
-	return sodiumSign(data, privateKey)
-}
-
 // SignPacket wraps sodiumSignPacket with is a wrapper around libsodium
 // We wrap this to avoid including C in other libs breaking
 // code linting
@@ -131,18 +116,11 @@ func SignPacket(key []byte, data []byte) []byte {
 	return sodiumSignPacket(data, key)
 }
 
-// Verify wraps sodiumVerify with is a wrapper around libsodium
+// VerifyPacket wraps sodiumVerifyPacket with is a wrapper around libsodium
 // We wrap this to avoid including C in other libs breaking
 // code linting
-func Verify(publicKey []byte, data []byte, sig []byte) bool {
-	return sodiumVerify(data, sig, publicKey)
-}
-
-// Hash wraps sodiumHash with is a wrapper around libsodium
-// We wrap this to avoid including C in other libs breaking
-// code linting
-func Hash(key []byte, data []byte) []byte {
-	return sodiumHash(data, key)
+func VerifyPacket(publicKey []byte, data []byte) bool {
+	return sodiumVerifyPacket(data, publicKey)
 }
 
 // HashPacket wraps hashPacket with is a wrapper around libsodium
@@ -150,13 +128,6 @@ func Hash(key []byte, data []byte) []byte {
 // code linting
 func HashPacket(key []byte, data []byte) {
 	sodiumHashPacket(data, key)
-}
-
-// Check wraps sodiumCheck with is a wrapper around libsodium
-// We wrap this to avoid including C in other libs breaking
-// code linting
-func Check(key []byte, data []byte) bool {
-	return sodiumCheck(data, key)
 }
 
 // IsNetworkNextPacket wraps sodiumIsNetworkNextPacket with is a wrapper around libsodium

--- a/modules/crypto/sodium.go
+++ b/modules/crypto/sodium.go
@@ -17,6 +17,21 @@ func sodiumSignPacket(packetData []byte, privateKey []byte) []byte {
 	return signedPacketData
 }
 
+// This function assumes that the packetData already has the first 9 bytes (packet type and packet hash) removed,
+// since the server backend will remove these bytes before passing it to the handlers for signature checking
+func sodiumVerifyPacket(packetData []byte, publicKey []byte) bool {
+	if len(packetData) < C.crypto_sign_BYTES || len(publicKey) != C.crypto_sign_PUBLICKEYBYTES {
+		return false
+	}
+
+	messageLength := len(packetData) - C.crypto_sign_BYTES
+
+	var state C.crypto_sign_state
+	C.crypto_sign_init(&state)
+	C.crypto_sign_update(&state, (*C.uchar)(&packetData[0]), C.ulonglong(messageLength))
+	return C.crypto_sign_final_verify(&state, (*C.uchar)(&packetData[messageLength]), (*C.uchar)(&publicKey[0])) == 0
+}
+
 func sodiumHashPacket(packetData []byte, hashKey []byte) {
 	messageLength := len(packetData) - PacketHashSize - 1
 	if messageLength > 32 {
@@ -30,66 +45,6 @@ func sodiumHashPacket(packetData []byte, hashKey []byte) {
 		(*C.uchar)(&hashKey[0]),
 		C.ulong(C.crypto_generichash_KEYBYTES),
 	)
-}
-
-func sodiumSign(sign_data []byte, private_key []byte) []byte {
-	if len(private_key) != C.crypto_sign_BYTES {
-		return nil
-	}
-	signature := make([]byte, C.crypto_sign_BYTES)
-	var state C.crypto_sign_state
-	C.crypto_sign_init(&state)
-	C.crypto_sign_update(&state, (*C.uchar)(&sign_data[0]), C.ulonglong(len(sign_data)))
-	C.crypto_sign_final_create(&state, (*C.uchar)(&signature[0]), nil, (*C.uchar)(&private_key[0]))
-	return signature
-}
-
-func sodiumVerify(sign_data []byte, signature []byte, public_key []byte) bool {
-	if len(public_key) != C.crypto_sign_PUBLICKEYBYTES || len(signature) != C.crypto_sign_BYTES {
-		return false
-	}
-	var state C.crypto_sign_state
-	C.crypto_sign_init(&state)
-	C.crypto_sign_update(&state, (*C.uchar)(&sign_data[0]), C.ulonglong(len(sign_data)))
-	return C.crypto_sign_final_verify(&state, (*C.uchar)(&signature[0]), (*C.uchar)(&public_key[0])) == 0
-}
-
-func sodiumHash(data []byte, key []byte) []byte {
-	signedPacketData := make([]byte, len(data)+PacketHashSize)
-	C.crypto_generichash(
-		(*C.uchar)(&signedPacketData[0]),
-		C.ulong(PacketHashSize),
-		(*C.uchar)(&data[0]),
-		C.ulonglong(len(data)),
-		(*C.uchar)(&key[0]),
-		C.ulong(C.crypto_generichash_KEYBYTES),
-	)
-	for i := 0; i < len(data); i++ {
-		signedPacketData[PacketHashSize+i] = data[i]
-	}
-	return signedPacketData
-}
-
-func sodiumCheck(data []byte, key []byte) bool {
-	if len(data) <= PacketHashSize {
-		return false
-	}
-
-	hash := make([]byte, PacketHashSize)
-	C.crypto_generichash(
-		(*C.uchar)(&hash[0]),
-		C.ulong(PacketHashSize),
-		(*C.uchar)(&data[PacketHashSize]),
-		C.ulonglong(len(data)-PacketHashSize),
-		(*C.uchar)(&key[0]),
-		C.ulong(C.crypto_generichash_KEYBYTES),
-	)
-	for i := 0; i < PacketHashSize; i++ {
-		if hash[i] != data[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func sodiumIsNetworkNextPacket(packetData []byte, hashKey []byte) bool {

--- a/modules/metrics/server_backend.go
+++ b/modules/metrics/server_backend.go
@@ -10,6 +10,7 @@ type ServerInitMetrics struct {
 
 	ReadPacketFailure            Counter
 	BuyerNotFound                Counter
+	SignatureCheckFailed         Counter
 	SDKTooOld                    Counter
 	DatacenterNotFound           Counter
 	MisconfiguredDatacenterAlias Counter
@@ -22,6 +23,7 @@ var EmptyServerInitMetrics = ServerInitMetrics{
 	HandlerMetrics:               &EmptyPacketHandlerMetrics,
 	ReadPacketFailure:            &EmptyCounter{},
 	BuyerNotFound:                &EmptyCounter{},
+	SignatureCheckFailed:         &EmptyCounter{},
 	SDKTooOld:                    &EmptyCounter{},
 	DatacenterNotFound:           &EmptyCounter{},
 	MisconfiguredDatacenterAlias: &EmptyCounter{},
@@ -35,6 +37,7 @@ type ServerUpdateMetrics struct {
 
 	ReadPacketFailure            Counter
 	BuyerNotFound                Counter
+	SignatureCheckFailed         Counter
 	SDKTooOld                    Counter
 	DatacenterNotFound           Counter
 	MisconfiguredDatacenterAlias Counter
@@ -46,6 +49,7 @@ var EmptyServerUpdateMetrics = ServerUpdateMetrics{
 	HandlerMetrics:               &EmptyPacketHandlerMetrics,
 	ReadPacketFailure:            &EmptyCounter{},
 	BuyerNotFound:                &EmptyCounter{},
+	SignatureCheckFailed:         &EmptyCounter{},
 	SDKTooOld:                    &EmptyCounter{},
 	DatacenterNotFound:           &EmptyCounter{},
 	MisconfiguredDatacenterAlias: &EmptyCounter{},
@@ -74,6 +78,7 @@ type SessionUpdateMetrics struct {
 	FallbackToDirectDirectPongTimedOut         Counter
 	FallbackToDirectNextPongTimedOut           Counter
 	BuyerNotFound                              Counter
+	SignatureCheckFailed                       Counter
 	ClientLocateFailure                        Counter
 	ReadSessionDataFailure                     Counter
 	BadSessionID                               Counter
@@ -116,6 +121,7 @@ var EmptySessionUpdateMetrics = SessionUpdateMetrics{
 	FallbackToDirectDirectPongTimedOut:         &EmptyCounter{},
 	FallbackToDirectNextPongTimedOut:           &EmptyCounter{},
 	BuyerNotFound:                              &EmptyCounter{},
+	SignatureCheckFailed:                       &EmptyCounter{},
 	ClientLocateFailure:                        &EmptyCounter{},
 	ReadSessionDataFailure:                     &EmptyCounter{},
 	BadSessionID:                               &EmptyCounter{},
@@ -331,6 +337,17 @@ func newServerInitMetrics(ctx context.Context, handler Handler, serviceName stri
 		return nil, err
 	}
 
+	m.SignatureCheckFailed, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Signature Check Failed",
+		ServiceName: serviceName,
+		ID:          handlerID + ".signature_check_failed",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " failed the signature check to verify the customer's identity.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	m.SDKTooOld, err = handler.NewCounter(ctx, &Descriptor{
 		DisplayName: handlerName + " SDK Too Old",
 		ServiceName: serviceName,
@@ -415,6 +432,17 @@ func newServerUpdateMetrics(ctx context.Context, handler Handler, serviceName st
 		ID:          handlerID + ".buyer_not_found",
 		Unit:        "errors",
 		Description: "The number of times a " + packetDescription + " contained an unknown customer ID.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.SignatureCheckFailed, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Signature Check Failed",
+		ServiceName: serviceName,
+		ID:          handlerID + ".signature_check_failed",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " failed the signature check to verify the customer's identity.",
 	})
 	if err != nil {
 		return nil, err
@@ -658,6 +686,17 @@ func newSessionUpdateMetrics(ctx context.Context, handler Handler, serviceName s
 		ID:          handlerID + ".buyer_not_found",
 		Unit:        "errors",
 		Description: "The number of times a " + packetDescription + " contained an unknown customer ID.",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m.SignatureCheckFailed, err = handler.NewCounter(ctx, &Descriptor{
+		DisplayName: handlerName + " Signature Check Failed",
+		ServiceName: serviceName,
+		ID:          handlerID + ".signature_check_failed",
+		Unit:        "errors",
+		Description: "The number of times a " + packetDescription + " failed the signature check to verify the customer's identity.",
 	})
 	if err != nil {
 		return nil, err

--- a/modules/transport/server_init_test.go
+++ b/modules/transport/server_init_test.go
@@ -3,6 +3,7 @@ package transport_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -58,7 +59,7 @@ func TestServerInitHandlerBuyerNotFound(t *testing.T) {
 	assert.Equal(t, metrics.ServerInitMetrics.BuyerNotFound.Value(), 1.0)
 }
 
-func TestServerInitHandlerSDKTooOld(t *testing.T) {
+func TestServerInitHandlerSignatureCheckFailed(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
@@ -73,11 +74,62 @@ func TestServerInitHandlerSDKTooOld(t *testing.T) {
 	responseBuffer := bytes.NewBuffer(nil)
 
 	requestPacket := transport.ServerInitRequestPacket{
-		Version:    transport.SDKVersion{3, 3, 4},
 		CustomerID: 123,
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	handler := transport.ServerInitHandlerFunc(logger, storer, metrics.ServerInitMetrics)
+	handler(responseBuffer, &transport.UDPPacket{
+		Data: requestData,
+	})
+
+	var responsePacket transport.ServerInitResponsePacket
+	err = transport.UnmarshalPacket(&responsePacket, responseBuffer.Bytes()[1+crypto.PacketHashSize:])
+	assert.NoError(t, err)
+
+	assert.Equal(t, requestPacket.RequestID, responsePacket.RequestID)
+	assert.Equal(t, uint32(transport.InitResponseSignatureCheckFailed), responsePacket.Response)
+
+	assert.Equal(t, metrics.ServerInitMetrics.SignatureCheckFailed.Value(), 1.0)
+}
+
+func TestServerInitHandlerSDKTooOld(t *testing.T) {
+	logger := log.NewNopLogger()
+	storer := &storage.InMemory{}
+
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
+	})
+	assert.NoError(t, err)
+
+	metricsHandler := metrics.LocalHandler{}
+	metrics, err := metrics.NewServerBackendMetrics(context.Background(), &metricsHandler)
+	assert.NoError(t, err)
+	responseBuffer := bytes.NewBuffer(nil)
+
+	requestPacket := transport.ServerInitRequestPacket{
+		Version:    transport.SDKVersion{3, 3, 4},
+		CustomerID: customerID,
+	}
+	requestData, err := transport.MarshalPacket(&requestPacket)
+	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	handler := transport.ServerInitHandlerFunc(logger, storer, metrics.ServerInitMetrics)
 	handler(responseBuffer, &transport.UDPPacket{
@@ -98,13 +150,21 @@ func TestServerInitHandlerMisconfiguredDatacenterAlias(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
-	err := storer.AddBuyer(context.Background(), routing.Buyer{
-		ID: 123,
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
 	})
 	assert.NoError(t, err)
 
 	err = storer.AddDatacenterMap(context.Background(), routing.DatacenterMap{
-		BuyerID:      123,
+		BuyerID:      customerID,
 		DatacenterID: crypto.HashID("datacenter.name"),
 		Alias:        "datacenter.alias",
 	})
@@ -117,12 +177,20 @@ func TestServerInitHandlerMisconfiguredDatacenterAlias(t *testing.T) {
 
 	requestPacket := transport.ServerInitRequestPacket{
 		Version:        transport.SDKVersion{4, 0, 0},
-		CustomerID:     123,
+		CustomerID:     customerID,
 		DatacenterID:   crypto.HashID("datacenter.alias"),
 		DatacenterName: "datacenter.alias",
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	handler := transport.ServerInitHandlerFunc(logger, storer, metrics.ServerInitMetrics)
 	handler(responseBuffer, &transport.UDPPacket{
@@ -143,8 +211,16 @@ func TestServerInitHandlerDatacenterNotFound(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
-	err := storer.AddBuyer(context.Background(), routing.Buyer{
-		ID: 123,
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
 	})
 	assert.NoError(t, err)
 
@@ -155,12 +231,20 @@ func TestServerInitHandlerDatacenterNotFound(t *testing.T) {
 
 	requestPacket := transport.ServerInitRequestPacket{
 		Version:        transport.SDKVersion{4, 0, 0},
-		CustomerID:     123,
+		CustomerID:     customerID,
 		DatacenterID:   crypto.HashID("datacenter.alias"),
 		DatacenterName: "datacenter.alias",
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	handler := transport.ServerInitHandlerFunc(logger, storer, metrics.ServerInitMetrics)
 	handler(responseBuffer, &transport.UDPPacket{
@@ -181,8 +265,16 @@ func TestServerInitHandlerDatacenterNotAllowed(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
-	err := storer.AddBuyer(context.Background(), routing.Buyer{
-		ID: 123,
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
 	})
 	assert.NoError(t, err)
 
@@ -198,12 +290,20 @@ func TestServerInitHandlerDatacenterNotAllowed(t *testing.T) {
 
 	requestPacket := transport.ServerInitRequestPacket{
 		Version:        transport.SDKVersion{4, 0, 0},
-		CustomerID:     123,
+		CustomerID:     customerID,
 		DatacenterID:   crypto.HashID("datacenter.name"),
 		DatacenterName: "datacenter.name",
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	handler := transport.ServerInitHandlerFunc(logger, storer, metrics.ServerInitMetrics)
 	handler(responseBuffer, &transport.UDPPacket{
@@ -224,8 +324,16 @@ func TestServerInitHandlerSuccess(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
-	err := storer.AddBuyer(context.Background(), routing.Buyer{
-		ID: 123,
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
 	})
 	assert.NoError(t, err)
 
@@ -236,7 +344,7 @@ func TestServerInitHandlerSuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = storer.AddDatacenterMap(context.Background(), routing.DatacenterMap{
-		BuyerID:      123,
+		BuyerID:      customerID,
 		DatacenterID: crypto.HashID("datacenter.name"),
 	})
 	assert.NoError(t, err)
@@ -249,12 +357,20 @@ func TestServerInitHandlerSuccess(t *testing.T) {
 
 	requestPacket := transport.ServerInitRequestPacket{
 		Version:        transport.SDKVersion{4, 0, 0},
-		CustomerID:     123,
+		CustomerID:     customerID,
 		DatacenterID:   crypto.HashID("datacenter.name"),
 		DatacenterName: "datacenter.name",
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	handler := transport.ServerInitHandlerFunc(logger, storer, metrics.ServerInitMetrics)
 	handler(responseBuffer, &transport.UDPPacket{
@@ -275,8 +391,16 @@ func TestServerInitHandlerSuccessDatacenterAliasFound(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
-	err := storer.AddBuyer(context.Background(), routing.Buyer{
-		ID: 123,
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
 	})
 	assert.NoError(t, err)
 
@@ -287,7 +411,7 @@ func TestServerInitHandlerSuccessDatacenterAliasFound(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = storer.AddDatacenterMap(context.Background(), routing.DatacenterMap{
-		BuyerID:      123,
+		BuyerID:      customerID,
 		DatacenterID: crypto.HashID("datacenter.name"),
 		Alias:        "datacenter.alias",
 	})
@@ -301,12 +425,20 @@ func TestServerInitHandlerSuccessDatacenterAliasFound(t *testing.T) {
 
 	requestPacket := transport.ServerInitRequestPacket{
 		Version:        transport.SDKVersion{4, 0, 0},
-		CustomerID:     123,
+		CustomerID:     customerID,
 		DatacenterID:   crypto.HashID("datacenter.alias"),
 		DatacenterName: "datacenter.alias",
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	handler := transport.ServerInitHandlerFunc(logger, storer, metrics.ServerInitMetrics)
 	handler(responseBuffer, &transport.UDPPacket{

--- a/modules/transport/server_update_test.go
+++ b/modules/transport/server_update_test.go
@@ -3,6 +3,7 @@ package transport_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -53,7 +54,7 @@ func TestServerUpdateHandlerBuyerNotFound(t *testing.T) {
 	assert.Equal(t, metrics.ServerUpdateMetrics.BuyerNotFound.Value(), 1.0)
 }
 
-func TestServerUpdateHandlerSDKTooOld(t *testing.T) {
+func TestServerUpdateHandlerSignatureCheckFailed(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
@@ -68,11 +69,56 @@ func TestServerUpdateHandlerSDKTooOld(t *testing.T) {
 	responseBuffer := bytes.NewBuffer(nil)
 
 	requestPacket := transport.ServerUpdatePacket{
-		Version:    transport.SDKVersion{3, 3, 4},
 		CustomerID: 123,
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	postSessionHandler := transport.NewPostSessionHandler(0, 0, nil, 0, nil, 0, false, nil, logger, metrics.PostSessionMetrics)
+	handler := transport.ServerUpdateHandlerFunc(logger, storer, postSessionHandler, metrics.ServerUpdateMetrics)
+	handler(responseBuffer, &transport.UDPPacket{
+		Data: requestData,
+	})
+
+	assert.Equal(t, metrics.ServerUpdateMetrics.SignatureCheckFailed.Value(), 1.0)
+}
+
+func TestServerUpdateHandlerSDKTooOld(t *testing.T) {
+	logger := log.NewNopLogger()
+	storer := &storage.InMemory{}
+
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
+	})
+	assert.NoError(t, err)
+
+	metricsHandler := metrics.LocalHandler{}
+	metrics, err := metrics.NewServerBackendMetrics(context.Background(), &metricsHandler)
+	assert.NoError(t, err)
+	responseBuffer := bytes.NewBuffer(nil)
+
+	requestPacket := transport.ServerUpdatePacket{
+		Version:    transport.SDKVersion{3, 3, 4},
+		CustomerID: customerID,
+	}
+	requestData, err := transport.MarshalPacket(&requestPacket)
+	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	postSessionHandler := transport.NewPostSessionHandler(0, 0, nil, 0, nil, 0, false, nil, logger, metrics.PostSessionMetrics)
 	handler := transport.ServerUpdateHandlerFunc(logger, storer, postSessionHandler, metrics.ServerUpdateMetrics)
@@ -87,13 +133,21 @@ func TestServerUpdateHandlerMisconfiguredDatacenterAlias(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
-	err := storer.AddBuyer(context.Background(), routing.Buyer{
-		ID: 123,
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
 	})
 	assert.NoError(t, err)
 
 	err = storer.AddDatacenterMap(context.Background(), routing.DatacenterMap{
-		BuyerID:      123,
+		BuyerID:      customerID,
 		DatacenterID: crypto.HashID("datacenter.name"),
 		Alias:        "datacenter.alias",
 	})
@@ -106,11 +160,19 @@ func TestServerUpdateHandlerMisconfiguredDatacenterAlias(t *testing.T) {
 
 	requestPacket := transport.ServerUpdatePacket{
 		Version:      transport.SDKVersion{4, 0, 0},
-		CustomerID:   123,
+		CustomerID:   customerID,
 		DatacenterID: crypto.HashID("datacenter.alias"),
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	postSessionHandler := transport.NewPostSessionHandler(0, 0, nil, 0, nil, 0, false, nil, logger, metrics.PostSessionMetrics)
 	handler := transport.ServerUpdateHandlerFunc(logger, storer, postSessionHandler, metrics.ServerUpdateMetrics)
@@ -125,8 +187,16 @@ func TestServerUpdateHandlerDatacenterNotFound(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
-	err := storer.AddBuyer(context.Background(), routing.Buyer{
-		ID: 123,
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
 	})
 	assert.NoError(t, err)
 
@@ -137,11 +207,19 @@ func TestServerUpdateHandlerDatacenterNotFound(t *testing.T) {
 
 	requestPacket := transport.ServerUpdatePacket{
 		Version:      transport.SDKVersion{4, 0, 0},
-		CustomerID:   123,
+		CustomerID:   customerID,
 		DatacenterID: crypto.HashID("datacenter.alias"),
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	postSessionHandler := transport.NewPostSessionHandler(0, 0, nil, 0, nil, 0, false, nil, logger, metrics.PostSessionMetrics)
 	handler := transport.ServerUpdateHandlerFunc(logger, storer, postSessionHandler, metrics.ServerUpdateMetrics)
@@ -156,8 +234,16 @@ func TestServerUpdateHandlerDatacenterNotAllowed(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
-	err := storer.AddBuyer(context.Background(), routing.Buyer{
-		ID: 123,
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
 	})
 	assert.NoError(t, err)
 
@@ -173,11 +259,19 @@ func TestServerUpdateHandlerDatacenterNotAllowed(t *testing.T) {
 
 	requestPacket := transport.ServerUpdatePacket{
 		Version:      transport.SDKVersion{4, 0, 0},
-		CustomerID:   123,
+		CustomerID:   customerID,
 		DatacenterID: crypto.HashID("datacenter.name"),
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	postSessionHandler := transport.NewPostSessionHandler(0, 0, nil, 0, nil, 0, false, nil, logger, metrics.PostSessionMetrics)
 	handler := transport.ServerUpdateHandlerFunc(logger, storer, postSessionHandler, metrics.ServerUpdateMetrics)
@@ -192,8 +286,16 @@ func TestServerUpdateHandlerSuccess(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
-	err := storer.AddBuyer(context.Background(), routing.Buyer{
-		ID: 123,
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
 	})
 	assert.NoError(t, err)
 
@@ -204,7 +306,7 @@ func TestServerUpdateHandlerSuccess(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = storer.AddDatacenterMap(context.Background(), routing.DatacenterMap{
-		BuyerID:      123,
+		BuyerID:      customerID,
 		DatacenterID: crypto.HashID("datacenter.name"),
 	})
 	assert.NoError(t, err)
@@ -217,11 +319,19 @@ func TestServerUpdateHandlerSuccess(t *testing.T) {
 
 	requestPacket := transport.ServerUpdatePacket{
 		Version:      transport.SDKVersion{4, 0, 0},
-		CustomerID:   123,
+		CustomerID:   customerID,
 		DatacenterID: crypto.HashID("datacenter.name"),
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	postSessionHandler := transport.NewPostSessionHandler(0, 0, nil, 0, nil, 0, false, nil, logger, metrics.PostSessionMetrics)
 	handler := transport.ServerUpdateHandlerFunc(logger, storer, postSessionHandler, metrics.ServerUpdateMetrics)
@@ -236,8 +346,16 @@ func TestServerUpdateHandlerSuccessDatacenterAliasFound(t *testing.T) {
 	logger := log.NewNopLogger()
 	storer := &storage.InMemory{}
 
-	err := storer.AddBuyer(context.Background(), routing.Buyer{
-		ID: 123,
+	publicKey, privateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
+
+	customerID := binary.LittleEndian.Uint64(privateKey[:8])
+	publicKey = publicKey[8:]
+	privateKey = privateKey[8:]
+
+	err = storer.AddBuyer(context.Background(), routing.Buyer{
+		ID:        customerID,
+		PublicKey: publicKey,
 	})
 	assert.NoError(t, err)
 
@@ -248,7 +366,7 @@ func TestServerUpdateHandlerSuccessDatacenterAliasFound(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = storer.AddDatacenterMap(context.Background(), routing.DatacenterMap{
-		BuyerID:      123,
+		BuyerID:      customerID,
 		DatacenterID: crypto.HashID("datacenter.name"),
 		Alias:        "datacenter.alias",
 	})
@@ -262,11 +380,19 @@ func TestServerUpdateHandlerSuccessDatacenterAliasFound(t *testing.T) {
 
 	requestPacket := transport.ServerUpdatePacket{
 		Version:      transport.SDKVersion{4, 0, 0},
-		CustomerID:   123,
+		CustomerID:   customerID,
 		DatacenterID: crypto.HashID("datacenter.alias"),
 	}
 	requestData, err := transport.MarshalPacket(&requestPacket)
 	assert.NoError(t, err)
+
+	// We need to add the packet header (packet type + 8 hash bytes) in order to get the correct signature
+	requestDataHeader := append([]byte{transport.PacketTypeServerInitRequest}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+	requestData = crypto.SignPacket(privateKey, requestData)
+
+	// Once we have the signature, we need to take off the header before passing to the handler
+	requestData = requestData[1+crypto.PacketHashSize:]
 
 	postSessionHandler := transport.NewPostSessionHandler(0, 0, nil, 0, nil, 0, false, nil, logger, metrics.PostSessionMetrics)
 	handler := transport.ServerUpdateHandlerFunc(logger, storer, postSessionHandler, metrics.ServerUpdateMetrics)

--- a/modules/transport/session_update_test.go
+++ b/modules/transport/session_update_test.go
@@ -649,6 +649,7 @@ type sessionUpdateBackendConfig struct {
 	buyer                *routing.Buyer
 	datacenters          []routing.Datacenter
 	datacenterMaps       []routing.DatacenterMap
+	failSignatureCheck   bool
 }
 
 func NewSessionUpdateBackendConfig(t *testing.T) *sessionUpdateBackendConfig {
@@ -659,6 +660,7 @@ func NewSessionUpdateBackendConfig(t *testing.T) *sessionUpdateBackendConfig {
 		buyer:                nil,
 		datacenters:          nil,
 		datacenterMaps:       nil,
+		failSignatureCheck:   false,
 	}
 }
 
@@ -687,25 +689,13 @@ func NewSessionUpdateResponseConfig(t *testing.T) *sessionUpdateResponseConfig {
 }
 
 func runSessionUpdateTest(t *testing.T, request *sessionUpdateRequestConfig, backend *sessionUpdateBackendConfig, response *sessionUpdateResponseConfig, expectedMetrics *metrics.SessionUpdateMetrics) {
+	customerPublicKey, customerPrivateKey, err := crypto.GenerateCustomerKeyPair()
+	assert.NoError(t, err)
 
-	// Set up request packet
+	customerPublicKey = customerPublicKey[8:]
+	customerPrivateKey = customerPrivateKey[8:]
 
-	var nearRelays relayGroup
-	if request.desyncedNearRelays {
-		nearRelays = getRelays(t, 0, noRTT)
-	} else {
-		nearRelays = getRelays(t, request.numNearRelays, request.nearRelayRTTType)
-		if request.badNearRelay {
-			if nearRelays.Count > 1 {
-				nearRelays.RTTs[1] = 255
-			}
-		}
-	}
-
-	sessionVersion := uint32(1)
-	if request.prevRouteType == routing.RouteTypeDirect {
-		sessionVersion = 0
-	}
+	// Set up route matrix
 
 	relays := getRelays(t, backend.numRouteMatrixRelays, goodRTT)
 
@@ -759,6 +749,25 @@ func runSessionUpdateTest(t *testing.T, request *sessionUpdateRequestConfig, bac
 
 	routeMatrixFunc := func() *routing.RouteMatrix {
 		return &routeMatrix
+	}
+
+	// Set up request packet
+
+	var nearRelays relayGroup
+	if request.desyncedNearRelays {
+		nearRelays = getRelays(t, 0, noRTT)
+	} else {
+		nearRelays = getRelays(t, request.numNearRelays, request.nearRelayRTTType)
+		if request.badNearRelay {
+			if nearRelays.Count > 1 {
+				nearRelays.RTTs[1] = 255
+			}
+		}
+	}
+
+	sessionVersion := uint32(1)
+	if request.prevRouteType == routing.RouteTypeDirect {
+		sessionVersion = 0
 	}
 
 	var destRelay uint64
@@ -816,7 +825,6 @@ func runSessionUpdateTest(t *testing.T, request *sessionUpdateRequestConfig, bac
 	initialSessionData := getInitialSessionData(t, request, prevRouteInfo, response, initialCommitted, commitCounter, routeShader.Multipath, mispredictCounter)
 
 	var sessionDataSlice []byte
-	var err error
 	if initialSessionData != nil {
 		sessionDataSlice, err = transport.MarshalSessionData(initialSessionData)
 		assert.NoError(t, err)
@@ -887,12 +895,26 @@ func runSessionUpdateTest(t *testing.T, request *sessionUpdateRequestConfig, bac
 		initialSessionData = &transport.SessionData{}
 	}
 
+	// Add the packet type byte and hash bytes to the request data so we can sign it properly
+	requestDataHeader := append([]byte{transport.PacketTypeSessionUpdate}, make([]byte, crypto.PacketHashSize)...)
+	requestData = append(requestDataHeader, requestData...)
+
+	// Sign the packet
+	requestData = crypto.SignPacket(customerPrivateKey, requestData)
+
+	// Once the packet is signed, we need to remove the header before passing to the session update handler
+	requestData = requestData[1+crypto.PacketHashSize:]
+
 	// Set up backend
 
 	ctx := context.Background()
 	storer := &storage.InMemory{}
 
 	if backend.buyer != nil {
+		backend.buyer.PublicKey = nil
+		if !backend.failSignatureCheck {
+			backend.buyer.PublicKey = customerPublicKey
+		}
 		err := storer.AddBuyer(ctx, *backend.buyer)
 		assert.NoError(t, err)
 	}
@@ -1228,6 +1250,23 @@ func TestSessionUpdateHandlerBuyerNotFound(t *testing.T) {
 	expectedMetrics := getBlankSessionUpdateMetrics(t)
 	expectedMetrics.DirectSlices.Add(1)
 	expectedMetrics.BuyerNotFound.Add(1)
+
+	runSessionUpdateTest(t, request, backend, response, expectedMetrics)
+}
+
+func TestSessionUpdateHandlerSignatureCheckFailed(t *testing.T) {
+	request := NewSessionUpdateRequestConfig(t)
+
+	backend := NewSessionUpdateBackendConfig(t)
+	backend.buyer = &routing.Buyer{ID: request.buyerID, Live: true}
+	backend.failSignatureCheck = true
+
+	response := NewSessionUpdateResponseConfig(t)
+	response.unchangedSessionData = true
+
+	expectedMetrics := getBlankSessionUpdateMetrics(t)
+	expectedMetrics.DirectSlices.Add(1)
+	expectedMetrics.SignatureCheckFailed.Add(1)
 
 	runSessionUpdateTest(t, request, backend, response, expectedMetrics)
 }


### PR DESCRIPTION
During a discussion last week with @Omortis I noticed that the buyer's public key isn't actually being used in the server backend anywhere, which seemed wrong. So I looked back through and realized that the server backend isn't actually verifying the signature at the end of the incoming packet to check and make sure that the server is who they say they are.

The server SDK will sign request packets to the server backend with the customer's private key. The server backend needs to verify this signature with the customer's public key so that we know we're actually communicating with that customer's server, and not someone trying to spoof them. I've added this verification check in each of the server backend endpoints and associated metrics. I also removed some older sign/verify functions we're not using anymore to avoid confusion. Once #2695 gets merged in, these new metrics should be added to the server backend dashboard JSON as well.