### PR TITLE
added signed and unsigned funcs to the next tool

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -640,6 +640,59 @@ func main() {
 		},
 	}
 
+	var signedCommand = &ffcli.Command{
+		Name:       "signed",
+		ShortUsage: "next signed (uint64 in hex)",
+		ShortHelp:  "Provide the signed int64 representation of the provided hex uint64 value",
+		Exec: func(_ context.Context, args []string) error {
+			if len(args) != 1 {
+				handleRunTimeError(fmt.Sprintf("Please provided an unsigned uint64 in hexadecimal format"), 0)
+			}
+
+			hexString := args[0]
+
+			unsigned, err := strconv.ParseUint(hexString, 16, 64)
+			if err != nil {
+				handleRunTimeError(fmt.Sprintf("Error: %v\n", err), 1)
+			}
+			signed := int64(unsigned)
+
+			fmt.Printf("Hex   : %s\nuint64: %d\nint64 : %d\n", hexString, unsigned, signed)
+
+			return nil
+		},
+	}
+
+	var unsignedCommand = &ffcli.Command{
+		Name:       "unsigned",
+		ShortUsage: "next unsigned (int64) // omit negative sign",
+		ShortHelp:  "Provide the signed int64 representation of the provided hex uint64 value (omit negative sign)",
+		Exec: func(_ context.Context, args []string) error {
+			if len(args) != 1 {
+				handleRunTimeError(fmt.Sprintf("Please provided a signed int64 (omit negative sign)"), 0)
+			}
+
+			signedString := os.Args[2]
+
+			signed, err := strconv.ParseInt(signedString, 10, 64)
+			if err != nil {
+				handleRunTimeError(fmt.Sprintf("Error: %v\n", err), 1)
+			}
+			unsigned := uint64(signed)
+
+			fmt.Println("Positive value:")
+			fmt.Printf("\tint64 : %d\n\tHex   : %016x\n\tuint64: %d\n\n", signed, unsigned, unsigned)
+
+			signed *= -1
+			unsigned = uint64(signed)
+
+			fmt.Println("Negative value:")
+			fmt.Printf("\tint64 : %d\n\tHex   : %016x\n\tuint64: %d\n\n", signed, unsigned, unsigned)
+
+			return nil
+		},
+	}
+
 	var sessionsCommand = &ffcli.Command{
 		Name:       "sessions",
 		ShortUsage: "next sessions",
@@ -2107,6 +2160,8 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 		debugCommand,
 		viewCommand,
 		stagingCommand,
+		signedCommand,
+		unsignedCommand,
 	}
 
 	root := &ffcli.Command{


### PR DESCRIPTION
I added `-signed` and `-unsigned` top-level functions to the `next` tool. Note that the args library intercepts every line argument that starts with a '-', hence the postive/negative swizzle in `./next unsigned`:

```

12:35 $ ./next unsigned -h

USAGE
  next unsigned (int64) // omit negative sign
12:36 $ ./next unsigned 3306152254123665193

Positive value:
        int64 : 3306152254123665193
        Hex   : 2de1cff55865e729
        uint64: 3306152254123665193

Negative value:
        int64 : -3306152254123665193
        Hex   : d21e300aa79a18d7
        uint64: 15140591819585886423

12:36 $ ./next signed 2de1cff55865e729

Hex   : 2de1cff55865e729
uint64: 3306152254123665193
int64 : 3306152254123665193

12:36 $ ./next signed d21e300aa79a18d7

Hex   : d21e300aa79a18d7
uint64: 15140591819585886423
int64 : -3306152254123665193
```