### PR TITLE
Issue 2552 - Fortify portal from redis crashes

### DIFF
--- a/modules/transport/jsonrpc/buyer.go
+++ b/modules/transport/jsonrpc/buyer.go
@@ -557,12 +557,12 @@ type TopSessionsReply struct {
 // TopSessions generates the top sessions sorted by improved RTT
 func (s *BuyersService) TopSessions(r *http.Request, args *TopSessionsArgs, reply *TopSessionsReply) error {
 	sessions, err := s.FetchCurrentTopSessions(r, args.CompanyCode)
-	reply.Sessions = sessions
-	if err != nil && len(sessions) == 0 {
+	if err != nil {
 		err = fmt.Errorf("TopSessions() failed to fetch top sessions: %v", err)
 		level.Error(s.Logger).Log("err", err)
 		return err
 	}
+	reply.Sessions = sessions
 	return nil
 }
 


### PR DESCRIPTION
This primarily effects the map points generator but I updated error codes for some of the endpoints to avoid leaking the redis instance IPs to the portal error console.

Goes along with this portal PR: https://github.com/networknext/portal/pull/105
Closes #2552 