### PR TITLE
update all buyer dcmaps when they update their pub key

### DIFF
--- a/modules/transport/jsonrpc/buyer.go
+++ b/modules/transport/jsonrpc/buyer.go
@@ -1221,6 +1221,16 @@ func (s *BuyersService) UpdateGameConfiguration(r *http.Request, args *GameConfi
 	live := buyer.Live
 	oldBuyerID := buyer.ID
 
+	// Remove all dc Maps
+	dcMaps := s.Storage.GetDatacenterMapsForBuyer(oldBuyerID)
+	for _, dcMap := range dcMaps {
+		if err := s.Storage.RemoveDatacenterMap(ctx, dcMap); err != nil {
+			err = fmt.Errorf("UpdateGameConfiguration() failed to remove old datacenter map: %v, datacenter ID: %016x", err, dcMap.DatacenterID)
+			level.Error(s.Logger).Log("err", err)
+			return err
+		}
+	}
+
 	if err = s.Storage.RemoveBuyer(ctx, oldBuyerID); err != nil {
 		err = fmt.Errorf("UpdateGameConfiguration() failed to remove buyer")
 		level.Error(s.Logger).Log("err", err)
@@ -1233,20 +1243,14 @@ func (s *BuyersService) UpdateGameConfiguration(r *http.Request, args *GameConfi
 		Live:        live,
 		PublicKey:   byteKey[8:],
 	})
-
 	if err != nil {
 		err = fmt.Errorf("UpdateGameConfiguration() buyer update failed: %v", err)
 		level.Error(s.Logger).Log("err", err)
 		return err
 	}
 
-	dcMaps := s.Storage.GetDatacenterMapsForBuyer(oldBuyerID)
+	// Add back dc maps with new buyer ID
 	for _, dcMap := range dcMaps {
-		if err := s.Storage.RemoveDatacenterMap(ctx, dcMap); err != nil {
-			err = fmt.Errorf("UpdateGameConfiguration() failed to remove old datacenter map: %v, datacenter ID: %016x", err, dcMap.DatacenterID)
-			level.Error(s.Logger).Log("err", err)
-			return err
-		}
 		dcMap.BuyerID = buyerID
 		if err := s.Storage.AddDatacenterMap(ctx, dcMap); err != nil {
 			err = fmt.Errorf("UpdateGameConfiguration() failed to add new datacenter map: %v, datacenter ID: %016x, buyer ID: %016x", err, dcMap.DatacenterID, buyerID)


### PR DESCRIPTION
When a buyer updates their public key, it invalidates all of their dc mappings. This PR deletes the old mapping and creates a new one using the old map and the new buyer ID.

Closes #2774 