### PR TITLE
Hotfix ClearRelayData func 

### DIFF
--- a/modules/routing/relay_map.go
+++ b/modules/routing/relay_map.go
@@ -171,7 +171,7 @@ func (relayMap *RelayMap) GetAllRelayData() []RelayData {
 
 func (relayMap *RelayMap) ClearRelayData(relayAddress string) {
 	//entry is being writen to so a write lock is used before checking it
-	//if a read lock was used furst it could be changed in between the read and write locks.
+	//if a read lock was used first it could be changed in between the read and write locks.
 	relayMap.Lock()
 	defer relayMap.Unlock()
 


### PR DESCRIPTION
ClearRelayData func cause 2 crashes Thursday afternoon at ~5 pm est and 10:30 pm est. This is do to the assumption that the relay still exist. 

this fix adds the map ok check as well as a write mutex 
the ok is to verify the relay exist 
the mutex is to protect data integratory 
