### PR TITLE
reduce promotion VMs to smaller instances

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Test
 agent:
   machine:
-    type: e1-standard-8
+    type: e1-standard-2
     os_image: ubuntu1804
 global_job_config:
   secrets:


### PR DESCRIPTION
We are using beefy instances to run deployments which causes slow downs. This PR should reduce the deployments to run on e1-standard-2 instances while builds will still run on e1-standard-8 instances