### PR TITLE
Added next customer remove

### DIFF
--- a/cmd/next/buyers.go
+++ b/cmd/next/buyers.go
@@ -468,6 +468,7 @@ func buyerIDFromName(
 	env Environment,
 	buyerRegex string,
 ) (string, uint64) {
+
 	buyerArgs := localjsonrpc.BuyersArgs{}
 	var buyers localjsonrpc.BuyersReply
 	if err := rpcClient.CallFor(&buyers, "OpsService.Buyers", buyerArgs); err != nil {

--- a/cmd/next/customers.go
+++ b/cmd/next/customers.go
@@ -92,3 +92,23 @@ func updateCustomer(
 	fmt.Printf("Customer %s updated successfully.\n", customerCode)
 	return nil
 }
+
+func removeCustomer(
+	rpcClient jsonrpc.RPCClient,
+	env Environment,
+	customerCode string,
+) error {
+
+	emptyReply := localjsonrpc.RemoveCustomerReply{}
+
+	args := localjsonrpc.RemoveCustomerArgs{
+		CustomerCode: customerCode,
+	}
+	if err := rpcClient.CallFor(&emptyReply, "OpsService.RemoveCustomer", args); err != nil {
+		fmt.Printf("%v\n", err)
+		return nil
+	}
+
+	fmt.Printf("Customer %s updated successfully.\n", customerCode)
+	return nil
+}

--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -1864,7 +1864,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 				ShortHelp:  "Displays detailed info for the specified customer",
 				Exec: func(_ context.Context, args []string) error {
 					if len(args) != 1 {
-						handleRunTimeError(fmt.Sprintln("Please provide the seller ID in hex, only."), 0)
+						handleRunTimeError(fmt.Sprintln("Please provide the customer code, only."), 0)
 					}
 
 					getCustomerInfo(rpcClient, env, args[0])
@@ -1882,6 +1882,19 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 					}
 
 					updateCustomer(rpcClient, env, args[0], args[1], args[2])
+					return nil
+				},
+			},
+			{
+				Name:       "remove",
+				ShortUsage: "next customer remove (code)",
+				ShortHelp:  "Removes a customer from the database",
+				Exec: func(_ context.Context, args []string) error {
+					if len(args) != 1 {
+						handleRunTimeError(fmt.Sprintln("Please provide the customer code, only."), 0)
+					}
+
+					removeCustomer(rpcClient, env, args[0])
 					return nil
 				},
 			},

--- a/modules/transport/jsonrpc/ops.go
+++ b/modules/transport/jsonrpc/ops.go
@@ -199,7 +199,7 @@ func (s *OpsService) Buyers(r *http.Request, args *BuyersArgs, reply *BuyersRepl
 	for _, b := range s.Storage.Buyers() {
 		c, err := s.Storage.Customer(b.CompanyCode)
 		if err != nil {
-			err = fmt.Errorf("Buyers() could not find Customer %s fo %s: %v", b.CompanyCode, b.String(), err)
+			err = fmt.Errorf("Buyers() could not find Customer %s for %s: %v", b.CompanyCode, b.String(), err)
 			s.Logger.Log("err", err)
 			return err
 		}
@@ -1473,6 +1473,19 @@ func (s *OpsService) UpdateCustomer(r *http.Request, args *UpdateCustomerArgs, r
 	}
 
 	return nil
+}
+
+type RemoveCustomerArgs struct {
+	CustomerCode string `json:"customerCode"`
+}
+
+type RemoveCustomerReply struct{}
+
+func (s *OpsService) RemoveCustomer(r *http.Request, args *RemoveCustomerArgs, reply *RemoveCustomerReply) error {
+	ctx, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
+	defer cancelFunc()
+
+	return s.Storage.RemoveCustomer(ctx, args.CustomerCode)
 }
 
 type UpdateSellerArgs struct {


### PR DESCRIPTION
Added `./next customer remove`, paralleling the other entities. There are no Storer changes (RemoveCustomer() already exists and is tested), just changes to the cli and the Ops endpoint.