### PR TITLE
removed/replaced LastInsertID go sql method call

### DIFF
--- a/modules/storage/sql.go
+++ b/modules/storage/sql.go
@@ -390,17 +390,13 @@ func (db *SQL) AddBuyer(ctx context.Context, b routing.Buyer) error {
 		return err
 	}
 
-	newDatabaseID, err := result.LastInsertId()
-	if err != nil {
-		level.Error(db.Logger).Log("during", "Exec result does not contain new database ID", "err", err)
-		return err
-	}
-
-	// get the DatabaseID loaded
 	db.syncBuyers(ctx)
 
+	// get the DatabaseID loaded
+	dbBuyerID := uint64(db.buyerIDs[buyer.ID])
+
 	db.buyerMutex.RLock()
-	newBuyer := db.buyers[uint64(newDatabaseID)]
+	newBuyer := db.buyers[dbBuyerID]
 	db.buyerMutex.RUnlock()
 
 	newBuyer.HexID = fmt.Sprintf("%016x", buyer.ID)
@@ -409,7 +405,7 @@ func (db *SQL) AddBuyer(ctx context.Context, b routing.Buyer) error {
 
 	// update local fields
 	db.buyerMutex.Lock()
-	db.buyers[uint64(newDatabaseID)] = newBuyer
+	db.buyers[dbBuyerID] = newBuyer
 	db.buyerMutex.Unlock()
 
 	db.customerMutex.Lock()


### PR DESCRIPTION
As it happens, CloudSQL w/ PostgreSQL does _not_ support the _LastInsertID()_ method. This PR makes a programmatic change in how the database ID is retrieved after the user is inserted into the database in the _AddBbuyer()_ method . No functional changes.

The _AddBuyer()_ method was unique in using this call, as a convenience. Now that same method retrieves the database ID the same way all the other methods do, using the `buyerIDs` Storer map.