### PR TITLE
Add logic to scale next counts when filtering on ghost army

### DIFF
--- a/modules/transport/jsonrpc/buyer.go
+++ b/modules/transport/jsonrpc/buyer.go
@@ -445,6 +445,8 @@ func (s *BuyersService) TotalSessions(r *http.Request, args *TotalSessionsArgs, 
 		reply.Direct = totalCount - reply.Next
 
 	default:
+		var ghostArmyNextCount int
+
 		buyer, err := s.Storage.BuyerWithCompanyCode(args.CompanyCode)
 		if err != nil {
 			err = fmt.Errorf("TotalSessions() failed getting company with code: %v", err)
@@ -476,6 +478,16 @@ func (s *BuyersService) TotalSessions(r *http.Request, args *TotalSessionsArgs, 
 			err = fmt.Errorf("TotalSessions() failed getting buyer session next counts: %v", err)
 			level.Error(s.Logger).Log("err", err)
 			return err
+		}
+
+		if buyer.ID == ghostArmyBuyerID {
+			if firstNextCount > secondNextCount {
+				ghostArmyNextCount = firstNextCount * int(ghostArmyNextScaler)
+			} else {
+				ghostArmyNextCount = secondNextCount * int(ghostArmyNextScaler)
+			}
+			firstNextCount += ghostArmyNextCount
+			secondNextCount += ghostArmyNextCount
 		}
 
 		reply.Next = firstNextCount

--- a/modules/transport/jsonrpc/buyer_test.go
+++ b/modules/transport/jsonrpc/buyer_test.go
@@ -698,8 +698,8 @@ func TestTotalSessionsWithGhostArmy(t *testing.T) {
 		err := svc.TotalSessions(req, &jsonrpc.TotalSessionsArgs{CompanyCode: "local"}, &reply)
 		assert.NoError(t, err)
 
-		assert.Equal(t, 1, reply.Next)
-		assert.Equal(t, 50, reply.Direct)
+		assert.Equal(t, 6, reply.Next)
+		assert.Equal(t, 300, reply.Direct)
 	})
 }
 


### PR DESCRIPTION
Ghost army sessions are lower than they should be because next session counts aren't being scaled when filtered.

Closes #2849 