### PR TITLE
fixed update methods to increment sync counter

### DIFF
--- a/modules/storage/sql.go
+++ b/modules/storage/sql.go
@@ -1761,6 +1761,8 @@ func (db *SQL) UpdateDatacenterMap(ctx context.Context, ephemeralBuyerID uint64,
 		return err
 	}
 
+	db.IncrementSequenceNumber(ctx)
+
 	return nil
 }
 
@@ -1935,20 +1937,6 @@ func (db *SQL) IncrementSequenceNumber(ctx context.Context) error {
 	if err != nil {
 		level.Error(db.Logger).Log("during", "error setting sequence number", "err", err)
 	}
-
-	// SQLite3 does not like this check but it is necessary...
-	// TODO: fix/research
-	// result, err := stmt.Exec(sequenceNumber)
-	// if err != nil {
-	// 	level.Error(db.Logger).Log("during", "error setting sequence number", "err", err)
-	// }
-	// rows, err := result.RowsAffected()
-	// if err != nil {
-	// 	level.Error(db.Logger).Log("during", "RowsAffected returned an error", "err", err)
-	// }
-	// if rows != 1 {
-	// 	level.Error(db.Logger).Log("during", "RowsAffected <> 1", "err", err)
-	// }
 
 	return nil
 }
@@ -2387,6 +2375,8 @@ func (db *SQL) UpdateInternalConfig(ctx context.Context, ephemeralBuyerID uint64
 	db.internalConfigs[buyerID] = ic
 	db.internalConfigMutex.Unlock()
 
+	db.IncrementSequenceNumber(ctx)
+
 	return nil
 }
 
@@ -2642,6 +2632,8 @@ func (db *SQL) UpdateRouteShader(ctx context.Context, ephemeralBuyerID uint64, f
 	db.routeShaderMutex.Lock()
 	db.routeShaders[buyerID] = rs
 	db.routeShaderMutex.Unlock()
+
+	db.IncrementSequenceNumber(ctx)
 
 	return nil
 
@@ -2991,6 +2983,8 @@ func (db *SQL) UpdateBuyer(ctx context.Context, ephemeralBuyerID uint64, field s
 	db.buyers[buyerID] = buyer
 	db.buyerMutex.Unlock()
 
+	db.IncrementSequenceNumber(ctx)
+
 	return nil
 }
 
@@ -3053,6 +3047,8 @@ func (db *SQL) UpdateCustomer(ctx context.Context, customerID string, field stri
 	db.customerMutex.Lock()
 	db.customers[customerID] = customer
 	db.customerMutex.Unlock()
+
+	db.IncrementSequenceNumber(ctx)
 
 	return nil
 }
@@ -3135,6 +3131,8 @@ func (db *SQL) UpdateSeller(ctx context.Context, sellerID string, field string, 
 	db.sellers[sellerID] = seller
 	db.sellerMutex.Unlock()
 
+	db.IncrementSequenceNumber(ctx)
+
 	return nil
 }
 
@@ -3196,6 +3194,8 @@ func (db *SQL) UpdateDatacenter(ctx context.Context, datacenterID uint64, field 
 	db.datacenterMutex.Lock()
 	db.datacenters[datacenterID] = datacenter
 	db.datacenterMutex.Unlock()
+
+	db.IncrementSequenceNumber(ctx)
 
 	return nil
 }


### PR DESCRIPTION
Through a repeated copy/paste error none of the Storer _Update_ methods got an IncrementSequenceNumber()_ call after doing their work. While this only affects the `next` tool and the  admin UI it does mean that changes made via an update method may not be "visible" for a while. The update was made, but the sync number has not been incremented. This omission did not manifest any problems in the Happy Path or unit testing because all changes are instantaneous (not UPDATE network lag) and there's only one storer.