### PR TITLE
Change err in pubsub forwarder to check against nil

### DIFF
--- a/modules/beacon/pubsub_forwarder.go
+++ b/modules/beacon/pubsub_forwarder.go
@@ -98,7 +98,7 @@ func (psf *PubSubForwarder) Forward(ctx context.Context, wg *sync.WaitGroup) {
 		}
 	})
 
-	if err != nil || err != context.Canceled {
+	if err != nil && err != context.Canceled {
 		// If the Receive function returns for any reason besides shutdown, we want to immediately exit and restart the service
 		level.Error(psf.Logger).Log("msg", "stopped receive loop", "err", err)
 		os.Exit(1)

--- a/modules/billing/pubsub_forwarder.go
+++ b/modules/billing/pubsub_forwarder.go
@@ -106,7 +106,7 @@ func (psf *PubSubForwarder) Forward(ctx context.Context, wg *sync.WaitGroup) {
 	})
 	fmt.Printf("Outside receive, err: %v\n", err)
 
-	if err != nil || err != context.Canceled {
+	if err != nil && err != context.Canceled {
 		// If the Receive function returns for any reason besides shutdown, we want to immediately exit and restart the service
 		level.Error(psf.Logger).Log("msg", "stopped receive loop", "err", err)
 		os.Exit(1)


### PR DESCRIPTION
I was only checking for `err != context.Canceled` based on the example given in the docs, but the error returned can also be nil. This change reflects that in the billing and beacon inserter.