### PR TITLE
Clamp jitter to 1000 on billing side

### DIFF
--- a/modules/billing/googlebigquery.go
+++ b/modules/billing/googlebigquery.go
@@ -211,13 +211,23 @@ func (entry *BillingEntry) Validate() bool {
 	}
 
 	if !(entry.JitterClientToServer >= 0.0 && entry.JitterClientToServer <= 1000.0) {
-		fmt.Printf("invalid jitter client to server\n")
-		return false
+		if entry.JitterClientToServer > 1000.0 {
+			fmt.Printf("JitterClientToServer %v > 1000.0. Clamping to 1000.0\n%+v\n", entry.JitterClientToServer, entry)
+			entry.JitterClientToServer = 1000.0
+		} else {
+			fmt.Printf("invalid jitter client to server\n")
+			return false
+		}
 	}
 
 	if !(entry.JitterServerToClient >= 0.0 && entry.JitterServerToClient <= 1000.0) {
-		fmt.Printf("invalid jitter server to client\n")
-		return false
+		if entry.JitterServerToClient > 1000.0 {
+			fmt.Printf("JitterServerToClient %v > 1000.0. Clamping to 1000.0.\n%+v\n", entry.JitterServerToClient, entry)
+			entry.JitterServerToClient = 1000.0
+		} else {
+			fmt.Printf("invalid jitter server to client\n")
+			return false
+		}
 	}
 
 	if entry.NumTags < 0 || entry.NumTags > 8 {


### PR DESCRIPTION
Hotfix from earlier today #2893 did not work, and the billing pubsub queue is clogged again.
This hotfix should force any jitter between the client and server to be 1000 if the value is > 1000 directly on the billing side.

Solely requires a rolling replace of the billing mig.