### PR TITLE
added the next hash subcommand

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -649,11 +649,9 @@ func main() {
 				handleRunTimeError(fmt.Sprintf("Please provided a string"), 0)
 			}
 
-			srcString := args[0]
-
-			hashValue := crypto.HashID(srcString)
-
+			hashValue := crypto.HashID(args[0])
 			hexStr := fmt.Sprintf("%016x\n", hashValue)
+
 			fmt.Printf("unsigned: %d\n", hashValue)
 			fmt.Printf("signed  : %d\n", int64(hashValue))
 			fmt.Printf("hex     : 0x%s\n", strings.ToUpper(hexStr))


### PR DESCRIPTION
Added the `hash` subcommand to the `next` tool:

```
15:55 $ ./next hash amazon.virginia.4

unsigned: 5931818384509222312
signed  : 5931818384509222312
hex     : 0x52520D6480CDBDA8

15:56 $ ./next hash "frank burns eats worms"

unsigned: 14259476086087137336
signed  : -4187267987622414280
hex     : 0xC5E3D5F34A66B838
```