### PR TITLE
prod hotfix if needed (update relay pks and sync counter increments)

### DIFF
--- a/modules/storage/sql_test.go
+++ b/modules/storage/sql_test.go
@@ -1069,11 +1069,14 @@ func TestUpdateSQL(t *testing.T) {
 		assert.Equal(t, uint32(25000), checkRelay.MaxSessions)
 
 		// relay.PublicKey
-		err = db.UpdateRelay(ctx, rid, "PublicKey", []byte("public key"))
+		err = db.UpdateRelay(ctx, rid, "PublicKey", "1AKtwe4Ear59iQyBOggxutzdtVLLc1YQ2qnArgiiz14=")
 		assert.NoError(t, err)
 		checkRelay, err = db.Relay(rid)
 		assert.NoError(t, err)
-		assert.Equal(t, []byte("public key"), checkRelay.PublicKey)
+
+		newPublicKey, err := base64.StdEncoding.DecodeString("1AKtwe4Ear59iQyBOggxutzdtVLLc1YQ2qnArgiiz14=")
+		assert.NoError(t, err)
+		assert.Equal(t, newPublicKey, checkRelay.PublicKey)
 
 		// relay.Datacenter = only one datacenter available...
 

--- a/modules/transport/jsonrpc/ops.go
+++ b/modules/transport/jsonrpc/ops.go
@@ -1375,6 +1375,15 @@ func (s *OpsService) ModifyRelayField(r *http.Request, args *ModifyRelayFieldArg
 			return err
 		}
 
+	case "PublicKey":
+		newPublicKey := string(args.Value)
+		err := s.Storage.UpdateRelay(context.Background(), args.RelayID, args.Field, newPublicKey)
+		if err != nil {
+			err = fmt.Errorf("UpdateRelay() error updating field for relay %016x: %v", args.RelayID, err)
+			level.Error(s.Logger).Log("err", err)
+			return err
+		}
+
 	// routing.RelayState
 	case "State":
 


### PR DESCRIPTION
This hotfix exposes PublicKey modification via the _Ops.UpdateRelay_ endpoint. It also adds the missing sync counter increments on Update functions in the Storer which can buy us some time w/r/t deploying master. 

_These changes are all portal specific and only effect the `next` cli tool and the admin UI_. No other services use the Storer _Update*_ functions (yet).