### PR TITLE
Bring in increased route matrix buffer & core debug message changes

### DIFF
--- a/modules/billing/googlebigquery.go
+++ b/modules/billing/googlebigquery.go
@@ -211,13 +211,23 @@ func (entry *BillingEntry) Validate() bool {
 	}
 
 	if !(entry.JitterClientToServer >= 0.0 && entry.JitterClientToServer <= 1000.0) {
-		fmt.Printf("invalid jitter client to server\n")
-		return false
+		if entry.JitterClientToServer > 1000.0 {
+			fmt.Printf("JitterClientToServer %v > 1000.0. Clamping to 1000.0\n%+v\n", entry.JitterClientToServer, entry)
+			entry.JitterClientToServer = 1000.0
+		} else {
+			fmt.Printf("invalid jitter client to server\n")
+			return false
+		}
 	}
 
 	if !(entry.JitterServerToClient >= 0.0 && entry.JitterServerToClient <= 1000.0) {
-		fmt.Printf("invalid jitter server to client\n")
-		return false
+		if entry.JitterServerToClient > 1000.0 {
+			fmt.Printf("JitterServerToClient %v > 1000.0. Clamping to 1000.0.\n%+v\n", entry.JitterServerToClient, entry)
+			entry.JitterServerToClient = 1000.0
+		} else {
+			fmt.Printf("invalid jitter server to client\n")
+			return false
+		}
 	}
 
 	if entry.NumTags < 0 || entry.NumTags > 8 {

--- a/modules/core/core.go
+++ b/modules/core/core.go
@@ -11,10 +11,10 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"os"
 	"strconv"
 	"sync"
 	"unsafe"
-	"os"
 )
 
 const NEXT_EXPERIMENTAL = false
@@ -44,7 +44,7 @@ func init() {
 
 func Debug(s string, params ...interface{}) {
 	if debugLogs {
-		fmt.Printf(s + "\n", params...)
+		fmt.Printf(s+"\n", params...)
 	}
 }
 
@@ -1133,7 +1133,7 @@ func GetRandomBestRoute(routeMatrix []RouteEntry, sourceRelays []int32, sourceRe
 	GetBestRoutes(routeMatrix, sourceRelays, sourceRelayCost, destRelays, bestRouteCost+threshold, bestRoutes, &numBestRoutes, &routeDiversity)
 	if numBestRoutes == 0 {
 		if debug != nil {
-			*debug += "could not find any next routes. this should never happen\n"
+			*debug += "could not find any next routes\n"
 		}
 		return
 	}


### PR DESCRIPTION
We hotfixed the route matrix buffer from 100 MB to 256 MB in #2910 
We also removed a part of the core debug message in #2904 