### PR TITLE
relaxed relayMap timeout and relayMap read locking

### DIFF
--- a/cmd/relay_backend/relay_backend.go
+++ b/cmd/relay_backend/relay_backend.go
@@ -290,7 +290,15 @@ func mainReturnWithCode() int {
 			syncTimer := helpers.NewSyncTimer(publishInterval)
 			for {
 				syncTimer.Run()
-				allRelayData := relayMap.GetAllRelayData()
+				allRelayAddrs := relayMap.GetAllRelayAddresses()
+				allRelayData := make([]routing.RelayData, len(allRelayAddrs))
+				index := 0
+				for _, addr := range allRelayAddrs {
+					relayMap.RLock()
+					relayData := relayMap.GetRelayData(addr)
+					relayMap.RUnlock()
+					allRelayData[index] = *relayData
+				}
 				entries := make([]analytics.RelayStatsEntry, len(allRelayData))
 
 				count := 0

--- a/modules/routing/relay.go
+++ b/modules/routing/relay.go
@@ -17,7 +17,7 @@ const (
 	// EncryptedRelayTokenSize ...
 	EncryptedRelayTokenSize = crypto.KeySize + crypto.MACSize
 
-	RelayTimeout = 30 * time.Second
+	RelayTimeout = 60 * time.Second
 
 	// MaxRelayAddressLength ...
 	MaxRelayAddressLength = 256

--- a/modules/routing/relay_map.go
+++ b/modules/routing/relay_map.go
@@ -210,6 +210,20 @@ func (relayMap *RelayMap) GetAllRelayIDs(excludeList []string) []uint64 {
 	return relayIDs
 }
 
+func (relayMap *RelayMap) GetAllRelayAddresses() []string {
+	relayMap.RLock()
+	defer relayMap.RUnlock()
+	numRelays := len(relayMap.relays)
+	relayAddrs := make([]string, numRelays)
+
+	index := 0
+	for _, relayData := range relayMap.relays {
+		relayAddrs[index] = relayData.Addr.String()
+		index++
+	}
+	return relayAddrs
+}
+
 func (relayMap *RelayMap) RemoveRelayData(relayAddress string) {
 	if relay, ok := relayMap.relays[relayAddress]; ok {
 		relayMap.cleanupCallback(relay)

--- a/modules/routing/relay_map_test.go
+++ b/modules/routing/relay_map_test.go
@@ -120,6 +120,20 @@ func TestRelayMapGetAllRelayIDs(t *testing.T) {
 	}
 }
 
+func TestRelayMapGetAllRelayAddrs(t *testing.T) {
+	rmap := routing.NewRelayMap(func(relay *routing.RelayData) error { return nil })
+	for i := 0; i < 6; i++ {
+		relay := newRelay()
+		relay.ID = uint64(i)
+		addr, _ := net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", 10000+i))
+		relay.Addr = *addr
+		rmap.AddRelayDataEntry(relay.Addr.String(), relay)
+	}
+
+	relayAddresses := rmap.GetAllRelayAddresses()
+	assert.Equal(t, 6, len(relayAddresses))
+}
+
 func TestRelayMapRemoveRelay(t *testing.T) {
 	removedRelays := new(int)
 	rmap := routing.NewRelayMap(func(relay *routing.RelayData) error {


### PR DESCRIPTION
increases the relayMap timeout to 60 seconds
read relays individually rather than all at once, this should help let writes through.