### PR TITLE
Clamp PacketLoss to 100.0

### DIFF
--- a/modules/billing/googlebigquery.go
+++ b/modules/billing/googlebigquery.go
@@ -205,7 +205,11 @@ func (entry *BillingEntry) Validate() bool {
 		return false
 	}
 
-	if !(entry.PacketLoss >= 0.0 && entry.PacketLoss <= 500.0) {
+	if !(entry.PacketLoss >= 0.0 && entry.PacketLoss <= 100.0) {
+		if entry.PacketLoss > 100.0 {
+			fmt.Printf("PacketLoss %v > 100.0. Clamping to 100.0\n%+v\n", entry.PacketLoss, entry)
+			entry.PacketLoss = 100.0
+		}
 		fmt.Printf("invalid packet loss\n")
 		return false
 	}


### PR DESCRIPTION
This is for post-Velan beta:

Clamps packet loss in billing to 100.0 if it is > 100.0.
We have noticed values of 115 and 350 in our billing entries thus far. Issue #2916

