### PR TITLE
Small fixes

### DIFF
--- a/modules/routing/relay_map.go
+++ b/modules/routing/relay_map.go
@@ -259,7 +259,7 @@ func (relayMap *RelayMap) TimeoutLoop(ctx context.Context, timeoutSeconds int64,
 				    return relayStats[i].name < relayStats[j].name
 				})
 				sort.SliceStable(relayStats, func(i, j int) bool {
-				    return relayStats[i].sessionCount < relayStats[j].sessionCount
+				    return relayStats[i].sessionCount > relayStats[j].sessionCount
 				})
 				fmt.Printf("\n-----------------------------------------\n")
 				fmt.Printf("\n%d active relays:\n\n", len(relayStats))


### PR DESCRIPTION
* Sort relay session counts in descending order (was ascending order, accidentally)
* Add "error: " in front of errors debug logs, so we can filter journalctl logs for errors only