### PR TITLE
Use local maximind DB files (hotfix)

### DIFF
--- a/cmd/server_backend/prod.env
+++ b/cmd/server_backend/prod.env
@@ -9,8 +9,8 @@ ENABLE_STACKDRIVER_PROFILER=true
 ENABLE_STACKDRIVER_METRICS=true
 GOOGLE_STACKDRIVER_METRICS_WRITE_INTERVAL=1m
 GOOGLE_FIRESTORE_SYNC_INTERVAL=10s
-MAXMIND_CITY_DB_URI=https://download.maxmind.com/app/geoip_download?edition_id=GeoIP2-City&license_key=FdAbKslwkXe2Lxu9&suffix=tar.gz
-MAXMIND_ISP_DB_URI=https://download.maxmind.com/app/geoip_download?edition_id=GeoIP2-ISP&license_key=FdAbKslwkXe2Lxu9&suffix=tar.gz
+MAXMIND_CITY_DB_URI=/app/GeoIP2-City.mmdb
+MAXMIND_ISP_DB_URI=/app/GeoIP2-ISP.mmdb
 MAXMIND_SYNC_DB_INTERVAL=24h
 ROUTE_MATRIX_URI=http://10.128.0.25/route_matrix
 ROUTE_MATRIX_SYNC_INTERVAL=1s


### PR DESCRIPTION
NOTE: Only merge this hotfix if we need to spin up more server backends (at this time, we are at 4 instances)

We hit the Maximind DB file limit for today, so we need to read from local files instead. I have a backup from 3/23/21 that I uploaded to `gs://prod_artifacts/GeoIP2-City.mmdb` and `gs://prod_artifacts/GeoIP2-ISP.mmdb`, which is what prod is currently using.

The prod server backend's startup script was modified to pull these db copies to `/app`, and with these env var changes, the files will be read from `/app/GeoIP2-City.mmdb` and `/app/GeoIP2-ISP.mmdb`.

 