### PR TITLE
dev hotfix

### DIFF
--- a/cmd/next/relays_bin.go
+++ b/cmd/next/relays_bin.go
@@ -200,11 +200,11 @@ func commitRelaysBin(env Environment) {
 
 	switch env.Name {
 	case "dev":
-		bucketName += "development_artifacts"
+		bucketName += "dev_database_bin"
 	case "prod":
-		bucketName += "prod_artifacts"
+		bucketName += "prod_database_bin"
 	case "staging":
-		bucketName += "staging_artifacts"
+		bucketName += "staging_database_bin"
 	case "local":
 		fmt.Println("No need to commit relays.bin for the happy path.")
 		os.Exit(0)


### PR DESCRIPTION
This simple PR does 2 things - it  prevents the next tool from blocking if for some strange reason the remote relays.bin file doesn't exist and it changes the bucket the relays.bin file is copied to.

I created a new bucket in each env and set the retention policy to 60 seconds, meaning when we copy a bin file to the bucket it will be cached for 1 minute. The 3 buckets are:

* dev_database_bin
* prod_database_bin
* staging_database_bin