### PR TITLE
next relays updates

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -537,6 +537,9 @@ func main() {
 	var relayBWSort bool
 	relaysfs.BoolVar(&relayBWSort, "bw", false, "Sort -ops output by IncludedBandwidthGB, descending (ignored w/o -ops)")
 
+	var relaysAlphaSort bool
+	relaysfs.BoolVar(&relaysAlphaSort, "alpha", false, "Sort relays by name, not by sessions carried")
+
 	// accept session ID as a signed int (next session dump)
 	sessionDumpfs := flag.NewFlagSet("session dump", flag.ExitOnError)
 	var sessionDumpSignedInt bool
@@ -792,7 +795,7 @@ func main() {
 		FlagSet:    relaysfs,
 		Exec: func(_ context.Context, args []string) error {
 
-			queryRelayBackend(env, relaysCount)
+			queryRelayBackend(env, relaysCount, relaysAlphaSort)
 
 			// if relaysfs.NFlag() == 0 ||
 			// 	((relaysfs.NFlag() == 1) && relayOpsOutput) ||

--- a/cmd/next/relays_bin.go
+++ b/cmd/next/relays_bin.go
@@ -251,7 +251,7 @@ func commitRelaysBin(env Environment) {
 
 }
 
-func queryRelayBackend(env Environment, relayCount int64) {
+func queryRelayBackend(env Environment, relayCount int64, alphaSort bool) {
 
 	relayBackendURI, err := env.RelayBackendHostname()
 	if err != nil {
@@ -320,9 +320,15 @@ func queryRelayBackend(env Environment, relayCount int64) {
 		})
 	}
 
-	sort.SliceStable(relays, func(i, j int) bool {
-		return relays[i].Sessions > relays[j].Sessions
-	})
+	if alphaSort {
+		sort.SliceStable(relays, func(i, j int) bool {
+			return relays[i].Name < relays[j].Name
+		})
+	} else {
+		sort.SliceStable(relays, func(i, j int) bool {
+			return relays[i].Sessions > relays[j].Sessions
+		})
+	}
 
 	outputRelays := []struct {
 		Name     string


### PR DESCRIPTION
Sorted by sessions carried and display limited with the -n switch as before. Relays with a blank sessions field have sessions set to -1 to point it out.