### PR TITLE
fix next cli relay list filters

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -862,9 +862,9 @@ func main() {
 				FlagSet:    relaysDbFs,
 				Exec: func(ctx context.Context, args []string) error {
 
-					if relaysfs.NFlag() == 0 ||
-						((relaysfs.NFlag() == 1) && relayOpsOutput) ||
-						((relaysfs.NFlag() == 2) && relayOpsOutput && csvOutputFlag) {
+					if relaysDbFs.NFlag() == 0 ||
+						((relaysDbFs.NFlag() == 1) && relayOpsOutput) ||
+						((relaysDbFs.NFlag() == 2) && relayOpsOutput && csvOutputFlag) {
 						// If no flags are given, set the default set of flags
 						relaysStateShowFlags[routing.RelayStateEnabled] = true
 						relaysStateHideFlags[routing.RelayStateEnabled] = false


### PR DESCRIPTION
I fixed a bug that made the filters a union of the "filter" and "enabled" in e.g. `./next relays db -disabled`.