### PR TITLE
fix the URI for relays.bin and database.bin

### DIFF
--- a/cmd/next/database_bin.go
+++ b/cmd/next/database_bin.go
@@ -19,7 +19,7 @@ import (
 func getDatabaseBin(env Environment) {
 	var err error
 
-	uri := fmt.Sprintf("%s/database.bin", env.PortalHostname())
+	uri := fmt.Sprintf("https://%s/database.bin", env.PortalHostname())
 
 	// GET doesn't seem to like env.PortalHostname() for local
 	if env.Name == "local" {

--- a/cmd/next/relays_bin.go
+++ b/cmd/next/relays_bin.go
@@ -23,7 +23,7 @@ import (
 func getRelaysBin(env Environment, filename string) {
 	var err error
 
-	uri := fmt.Sprintf("%s/relays.bin", env.PortalHostname())
+	uri := fmt.Sprintf("https://%s/relays.bin", env.PortalHostname())
 
 	// GET doesn't seem to like env.PortalHostname() for local
 	if env.Name == "local" {


### PR DESCRIPTION
I fixed the URI for relays.bin and database.bin. `env.PortalHostname()` does not include the `https://`...