### PR TITLE
Refresh bin_version Handler on database.bin Reload

### DIFF
--- a/cmd/relay_backend/relay_backend.go
+++ b/cmd/relay_backend/relay_backend.go
@@ -805,7 +805,7 @@ func mainReturnWithCode() int {
 
 	router.HandleFunc("/health", transport.HealthHandlerFunc())
 	router.HandleFunc("/version", transport.VersionHandlerFunc(buildtime, sha, tag, commitMessage, []string{}))
-	router.HandleFunc("/bin_version", transport.RelaysBinVersionFunc(binCreator, binCreationTime, env))
+	router.HandleFunc("/bin_version", transport.RelaysBinVersionFunc(&binCreator, &binCreationTime, &env))
 	router.HandleFunc("/relay_init", transport.RelayInitHandlerFunc()).Methods("POST")
 	router.HandleFunc("/relay_update", transport.RelayUpdateHandlerFunc(&commonUpdateParams)).Methods("POST")
 	router.HandleFunc("/cost_matrix", serveCostMatrixFunc).Methods("GET")

--- a/modules/transport/relay_handlers.go
+++ b/modules/transport/relay_handlers.go
@@ -382,14 +382,14 @@ func RelayDashboardHandlerFunc(relayMap *routing.RelayMap, GetRouteMatrix func()
 	}
 }
 
-func RelaysBinVersionFunc(creator string, creationTime string, env string) func(w http.ResponseWriter, r *http.Request) {
-	binInfo := map[string]string{
-		"creator":      creator,
-		"creationTime": creationTime,
-		"env":          env,
-	}
-
+func RelaysBinVersionFunc(creator *string, creationTime *string, env *string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		binInfo := map[string]string{
+			"creator":      *creator,
+			"creationTime": *creationTime,
+			"env":          *env,
+		}
+
 		w.WriteHeader(http.StatusOK)
 		if err := json.NewEncoder(w).Encode(binInfo); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
The `bin_version` handler wasn't updating the creation time and creator fields upon the handler updating.
This is because 1) pointers to the variables weren't used and 2) the mapping that was converted to json was not done inside the handler's return func.