### PR TITLE
Auth0 users table data collection

### DIFF
--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -687,7 +687,7 @@ func main() {
 					"Email", "Company Code", "Buyer ID", "Is Owner?", "Time Created"})
 
 				for _, entry := range reply.Entries {
-					fmt.Printf("Email: %s - Company Code: %s - Is Owner: %s - Time Created: %s\n\n", entry.Email, entry.CompanyCode, strconv.FormatBool(entry.IsOwner), entry.CreationTime)
+					fmt.Printf("Email: %s - Company Code: %s - Buyer ID: %s - Is Owner: %s - Time Created: %s\n\n", entry.Email, entry.CompanyCode, entry.BuyerID, strconv.FormatBool(entry.IsOwner), entry.CreationTime)
 					usersCSV = append(usersCSV, []string{
 						entry.Email,
 						entry.CompanyCode,

--- a/modules/transport/jsonrpc/auth.go
+++ b/modules/transport/jsonrpc/auth.go
@@ -498,7 +498,6 @@ func (s *AuthService) UserDatabase(r *http.Request, args *UserDatabaseArgs, repl
 		page++
 	}
 
-	fmt.Println(len(totalUsers))
 	for _, account := range totalUsers {
 		var companyCode string
 		companyCode, ok := account.AppMetadata["company_code"].(string)


### PR DESCRIPTION
This PR adds a next tool command and an endpoint to the auth service that pulls down the emails associated to a company account. It gives us an idea of who is the owners of new accounts and whether or not they have setup a buyer account yet (more likely to be ready to integrate the SDK).