### PR TITLE
Comment out Relay Stats and Route Matrix Stats

### DIFF
--- a/cmd/analytics/analytics.go
+++ b/cmd/analytics/analytics.go
@@ -215,6 +215,7 @@ func main() {
 		}
 	}
 
+	/*
 	var relayStatsWriter analytics.RelayStatsWriter = &analytics.NoOpRelayStatsWriter{}
 	{
 		// BigQuery
@@ -311,6 +312,7 @@ func main() {
 			go pubsubForwarder.Forward(ctx)
 		}
 	}
+	*/
 
 	// Setup the stats print routine
 	{


### PR DESCRIPTION
When I updated ping stats in analytics, I noticed that relay stats and route matrix stats are no longer working, which caused analytics to go into a crash loop. Since we aren't using them, I commented them out.

On a related note, analytics is very old and fragile, and needs to be refactored at some point.