### PR TITLE
add 4 new fields to next session dump

### DIFF
--- a/cmd/next/bigquery_data.go
+++ b/cmd/next/bigquery_data.go
@@ -82,6 +82,10 @@ type BigQueryBillingEntry struct {
 	UserFlags                       bigquery.NullInt64
 	UserHash                        bigquery.NullInt64
 	Vetoed                          bigquery.NullBool
+	UnknownDatacenter               bigquery.NullBool
+	DatacenterNotEnabled            bigquery.NullBool
+	BuyerNotLive                    bigquery.NullBool
+	StaleRouteMatrix                bigquery.NullBool
 }
 
 // BigQueryRelayPingsEntry contains 1 row of the BQ relay_pings table

--- a/cmd/next/session_dump.go
+++ b/cmd/next/session_dump.go
@@ -146,6 +146,10 @@ func dumpSession(rpcClient jsonrpc.RPCClient, env Environment, sessionID uint64)
 		"Debug String",
 		"ClientToServerPacketsSent",
 		"ServerToClientPacketsSent",
+		"UnknownDatacenter",
+		"DatacenterNotEnabled",
+		"BuyerNotLive",
+		"StaleRouteMatrix",
 	})
 
 	for _, billingEntry := range newRows {
@@ -481,6 +485,30 @@ func dumpSession(rpcClient jsonrpc.RPCClient, env Environment, sessionID uint64)
 			routeDiversity = fmt.Sprintf("%d", billingEntry.RouteDiversity.Int64)
 		}
 
+		// UnknownDatacenter
+		unknownDatacenter := ""
+		if billingEntry.UnknownDatacenter.Valid {
+			unknownDatacenter = fmt.Sprintf("%t", billingEntry.UnknownDatacenter.Bool)
+		}
+
+		// DatacenterNotEnabled
+		datacenterNotEnabled := ""
+		if billingEntry.DatacenterNotEnabled.Valid {
+			datacenterNotEnabled = fmt.Sprintf("%t", billingEntry.DatacenterNotEnabled.Bool)
+		}
+
+		// BuyerNotLive
+		buyerNotLive := ""
+		if billingEntry.BuyerNotLive.Valid {
+			buyerNotLive = fmt.Sprintf("%t", billingEntry.BuyerNotLive.Bool)
+		}
+
+		// StaleRouteMatrix
+		staleRouteMatrix := ""
+		if billingEntry.StaleRouteMatrix.Valid {
+			staleRouteMatrix = fmt.Sprintf("%t", billingEntry.StaleRouteMatrix.Bool)
+		}
+
 		bqBillingDataEntryCSV = append(bqBillingDataEntryCSV, []string{
 			sliceNumber,
 			timeStamp,
@@ -548,6 +576,10 @@ func dumpSession(rpcClient jsonrpc.RPCClient, env Environment, sessionID uint64)
 			debug,
 			clientToServerPacketsSent,
 			serverToClientPacketsSent,
+			unknownDatacenter,
+			datacenterNotEnabled,
+			buyerNotLive,
+			staleRouteMatrix,
 		})
 	}
 
@@ -648,7 +680,11 @@ func GetAllSessionBillingInfo(sessionID int64, env Environment) ([]BigQueryBilli
 	lackOfDiversity,
 	packetLoss,
 	pro,
-	routeDiversity
+	routeDiversity,
+	unknownDatacenter,
+	datacenterNotEnabled,
+	buyerNotLive,
+	staleRouteMatrix
     from `))
 
 	if env.Name != "prod" && env.Name != "dev" && env.Name != "staging" {


### PR DESCRIPTION
Added 4 new _bigquery.NullBool_ fields to `./next session dump`:

* UnknownDatacenter
* DatacenterNotEnabled
* BuyerNotLive
* StaleRouteMatrix