### PR TITLE
add remote port forwarding for riot.* relays

### DIFF
--- a/cmd/next/ssh.go
+++ b/cmd/next/ssh.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/ybbus/jsonrpc"
 )
@@ -18,6 +19,12 @@ func testForSSHKey(env Environment) {
 }
 
 func SSHInto(env Environment, rpcClient jsonrpc.RPCClient, relayName string) {
+
+	riot := false
+	if strings.Split(relayName, ".")[0] == "riot" {
+		riot = true
+	}
+
 	relays := getRelayInfo(rpcClient, env, relayName)
 	if len(relays) == 0 {
 		handleRunTimeError(fmt.Sprintf("no relays matches the regex '%s'\n", relayName), 0)
@@ -26,7 +33,7 @@ func SSHInto(env Environment, rpcClient jsonrpc.RPCClient, relayName string) {
 	testForSSHKey(env)
 	con := NewSSHConn(info.user, info.sshAddr, info.sshPort, env.SSHKeyFilePath)
 	fmt.Printf("Connecting to %s\n", relayName)
-	con.Connect()
+	con.Connect(riot)
 }
 
 type SSHConn struct {
@@ -56,8 +63,12 @@ func (con SSHConn) commonSSHCommands() []string {
 	return args
 }
 
-func (con SSHConn) Connect() {
+func (con SSHConn) Connect(isRiotRelay bool) {
 	args := con.commonSSHCommands()
+	if isRiotRelay {
+		args = append(args, "-R 9000")
+	}
+	fmt.Printf("isRiotRelay: %t\n", isRiotRelay)
 	args = append(args, "-tt", con.user+"@"+con.address)
 	if !runCommandEnv("ssh", args, nil) {
 		handleRunTimeError(fmt.Sprintln("could not start ssh session"), 1)


### PR DESCRIPTION
Added `-R 9000` to the args for `next ssh` when the target is a riot relay.