### PR TITLE
fix relay notes null handling

### DIFF
--- a/modules/storage/new_sql.go
+++ b/modules/storage/new_sql.go
@@ -522,7 +522,6 @@ func (db *SQL) syncRelays(ctx context.Context) error {
 			BWRule:              bwRule,
 			ContractTerm:        int32(relay.ContractTerm),
 			Type:                machineType,
-			Notes:               relay.Notes,
 			Seller:              seller,
 			DatabaseID:          relay.DatabaseID,
 			Version:             relay.Version,
@@ -570,6 +569,10 @@ func (db *SQL) syncRelays(ctx context.Context) error {
 
 		if relay.EndDate.Valid {
 			r.EndDate = relay.EndDate.Time
+		}
+
+		if relay.Notes.Valid {
+			r.Notes = relay.Notes.String
 		}
 
 		relays[internalID] = r

--- a/modules/storage/sql.go
+++ b/modules/storage/sql.go
@@ -1156,6 +1156,35 @@ func (db *SQL) UpdateRelay(ctx context.Context, relayID uint64, field string, va
 	return nil
 }
 
+//         Column         |          Type          | Nullable
+// -----------------------+------------------------+----------
+//  id                    | integer                | not null
+//  hex_id                | character varying(16)  | not null
+//  contract_term         | integer                | not null
+//  display_name          | character varying      | not null
+//  end_date              | date                   |
+//  included_bandwidth_gb | integer                | not null
+//  internal_ip           | inet                   |
+//  internal_ip_port      | integer                |
+//  management_ip         | character varying      | not null
+//  max_sessions          | integer                | not null
+//  mrc                   | bigint                 | not null
+//  overage               | bigint                 | not null
+//  port_speed            | integer                | not null
+//  public_ip             | inet                   |
+//  public_ip_port        | integer                |
+//  public_key            | bytea                  | not null
+//  ssh_port              | integer                | not null
+//  ssh_user              | character varying      | not null
+//  start_date            | date                   |
+//  bw_billing_rule       | integer                | not null
+//  datacenter            | integer                | not null
+//  machine_type          | integer                | not null
+//  relay_state           | integer                | not null
+//  notes                 | character varying(500) |
+//  billing_supplier      | integer                |
+//  relay_version         | character varying      | not null
+
 type sqlRelay struct {
 	ID                 uint64
 	HexID              string
@@ -1178,7 +1207,7 @@ type sqlRelay struct {
 	Overage            int64
 	BWRule             int64
 	ContractTerm       int64
-	Notes              string
+	Notes              sql.NullString
 	StartDate          sql.NullTime
 	EndDate            sql.NullTime
 	MachineType        int64
@@ -1262,6 +1291,15 @@ func (db *SQL) AddRelay(ctx context.Context, r routing.Relay) error {
 		Int64: publicIPPort,
 	}
 
+	nullableNotes := sql.NullString{
+		Valid: false,
+	}
+
+	if r.Notes != "" {
+		nullableNotes.Valid = true
+		nullableNotes.String = r.Notes
+	}
+
 	// field is not null but we also don't want an empty string
 	if r.Version == "" {
 		return fmt.Errorf("relay version can not be an empty string and must be a valid value (e.g. '2.0.6')")
@@ -1291,7 +1329,7 @@ func (db *SQL) AddRelay(ctx context.Context, r routing.Relay) error {
 		StartDate:          startDate,
 		EndDate:            endDate,
 		MachineType:        int64(r.Type),
-		Notes:              r.Notes,
+		Notes:              nullableNotes,
 		Version:            r.Version,
 	}
 

--- a/modules/storage/sql_test.go
+++ b/modules/storage/sql_test.go
@@ -242,6 +242,7 @@ func TestInsertSQL(t *testing.T) {
 		assert.Equal(t, relay.SSHUser, checkRelay.SSHUser)
 		assert.Equal(t, relay.MaxSessions, checkRelay.MaxSessions)
 		assert.Equal(t, relay.PublicKey, checkRelay.PublicKey)
+		assert.Equal(t, outerSeller.ShortName, relay.BillingSupplier)
 		assert.Equal(t, relay.Datacenter.DatabaseID, checkRelay.Datacenter.DatabaseID)
 		assert.Equal(t, relay.MRC, checkRelay.MRC)
 		assert.Equal(t, relay.Overage, checkRelay.Overage)
@@ -287,7 +288,7 @@ func TestInsertSQL(t *testing.T) {
 		relayMod.State = checkRelay.State
 		relayMod.IncludedBandwidthGB = checkRelay.IncludedBandwidthGB
 		relayMod.NICSpeedMbps = checkRelay.NICSpeedMbps
-		relayMod.Notes = checkRelay.Notes
+		// Notes
 		relayMod.DatabaseID = checkRelay.DatabaseID
 
 		relayMod.Seller = checkRelay.Seller
@@ -327,7 +328,14 @@ func TestInsertSQL(t *testing.T) {
 		assert.Equal(t, routing.Nibblin(10), checkRelayMod.Seller.IngressPriceNibblinsPerGB)
 		assert.Equal(t, routing.Nibblin(20), checkRelayMod.Seller.EgressPriceNibblinsPerGB)
 		assert.Equal(t, outerCustomer.DatabaseID, checkRelayMod.Seller.CustomerID)
-		assert.Equal(t, relayMod.Notes, checkRelayMod.Notes)
+
+		// test nulls
+		assert.Equal(t, "", relayMod.Notes)
+		assert.Equal(t, net.UDPAddr{}, relayMod.Addr)
+		assert.Equal(t, net.UDPAddr{}, relayMod.InternalAddr)
+		assert.True(t, relayMod.EndDate.IsZero())
+		assert.True(t, relayMod.StartDate.IsZero())
+		assert.Equal(t, "", relayMod.BillingSupplier)
 
 		// relay with some null values null values (except dc to trip an error)
 		addr2, err := net.ResolveUDPAddr("udp", "127.0.0.3:40000")


### PR DESCRIPTION
Converted sqlRelay.Notes to an sql.NullString and enhanced the null checks in the unit tests. 

For convenience I pasted the schema for the _relays_ table above the sqlRelay definition. This can be deleted if we prefer.