### PR TITLE
On auth failure, re auth and try again automatically

### DIFF
--- a/cmd/next/buyers.go
+++ b/cmd/next/buyers.go
@@ -12,14 +12,13 @@ import (
 	"github.com/modood/table"
 	"github.com/networknext/backend/modules/routing"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 )
 
-func buyers(rpcClient jsonrpc.RPCClient, env Environment, signed bool) {
+func buyers(env Environment, signed bool) {
 	args := localjsonrpc.BuyersArgs{}
 
 	var reply localjsonrpc.BuyersReply
-	if err := rpcClient.CallFor(&reply, "OpsService.Buyers", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.Buyers", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -58,13 +57,13 @@ func buyers(rpcClient jsonrpc.RPCClient, env Environment, signed bool) {
 	table.Output(buyers)
 }
 
-func removeBuyer(rpcClient jsonrpc.RPCClient, env Environment, id string) {
+func removeBuyer(env Environment, id string) {
 	args := localjsonrpc.RemoveBuyerArgs{
 		ID: id,
 	}
 
 	var reply localjsonrpc.RemoveBuyerReply
-	if err := rpcClient.CallFor(&reply, "OpsService.RemoveBuyer", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.RemoveBuyer", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -72,11 +71,11 @@ func removeBuyer(rpcClient jsonrpc.RPCClient, env Environment, id string) {
 	fmt.Printf("Buyer with ID \"%s\" removed from storage.\n", id)
 }
 
-func routingRulesSettingsByID(rpcClient jsonrpc.RPCClient, env Environment, buyerID string) {
+func routingRulesSettingsByID(env Environment, buyerID string) {
 
 	buyerArgs := localjsonrpc.BuyersArgs{}
 	var buyers localjsonrpc.BuyersReply
-	if err := rpcClient.CallFor(&buyers, "OpsService.Buyers", buyerArgs); err != nil {
+	if err := makeRPCCall(env, &buyers, "OpsService.Buyers", buyerArgs); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -96,7 +95,7 @@ func routingRulesSettingsByID(rpcClient jsonrpc.RPCClient, env Environment, buye
 			}
 
 			var reply localjsonrpc.RoutingRulesSettingsReply
-			if err := rpcClient.CallFor(&reply, "OpsService.RoutingRulesSettings", args); err != nil {
+			if err := makeRPCCall(env, &reply, "OpsService.RoutingRulesSettings", args); err != nil {
 				handleJSONRPCError(env, err)
 				return
 			}
@@ -123,11 +122,11 @@ func routingRulesSettingsByID(rpcClient jsonrpc.RPCClient, env Environment, buye
 
 }
 
-func routingRulesSettings(rpcClient jsonrpc.RPCClient, env Environment, buyerName string) {
+func routingRulesSettings(env Environment, buyerName string) {
 
 	buyerArgs := localjsonrpc.BuyersArgs{}
 	var buyers localjsonrpc.BuyersReply
-	if err := rpcClient.CallFor(&buyers, "OpsService.Buyers", buyerArgs); err != nil {
+	if err := makeRPCCall(env, &buyers, "OpsService.Buyers", buyerArgs); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -166,7 +165,7 @@ func routingRulesSettings(rpcClient jsonrpc.RPCClient, env Environment, buyerNam
 	}
 
 	var reply localjsonrpc.RoutingRulesSettingsReply
-	if err := rpcClient.CallFor(&reply, "OpsService.RoutingRulesSettings", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.RoutingRulesSettings", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -189,7 +188,6 @@ func routingRulesSettings(rpcClient jsonrpc.RPCClient, env Environment, buyerNam
 }
 
 func datacenterMapsForBuyer(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyer string,
 	csvOutput bool,
@@ -202,7 +200,7 @@ func datacenterMapsForBuyer(
 			DatacenterID: 0,
 		}
 
-		if err := rpcClient.CallFor(&reply, "OpsService.ListDatacenterMaps", arg); err != nil {
+		if err := makeRPCCall(env, &reply, "OpsService.ListDatacenterMaps", arg); err != nil {
 			fmt.Printf("rpc error: %v\n", err)
 			handleJSONRPCError(env, err)
 			return
@@ -267,7 +265,7 @@ func datacenterMapsForBuyer(
 
 		buyerArgs := localjsonrpc.BuyersArgs{}
 		var buyersReply localjsonrpc.BuyersReply
-		if err = rpcClient.CallFor(&buyersReply, "OpsService.Buyers", buyerArgs); err != nil {
+		if err = makeRPCCall(env, &buyersReply, "OpsService.Buyers", buyerArgs); err != nil {
 			handleJSONRPCError(env, err)
 			return
 		}
@@ -281,7 +279,7 @@ func datacenterMapsForBuyer(
 		if buyerID == 0 {
 			fmt.Printf("No match for provided buyer ID: %v\n\n", buyer)
 			fmt.Println("Here is a current list of buyers in the system:")
-			buyers(rpcClient, env, false)
+			buyers(env, false)
 			return
 		}
 
@@ -290,7 +288,7 @@ func datacenterMapsForBuyer(
 		}
 
 		var reply localjsonrpc.DatacenterMapsReply
-		if err := rpcClient.CallFor(&reply, "BuyersService.DatacenterMapsForBuyer", args); err != nil {
+		if err := makeRPCCall(env, &reply, "BuyersService.DatacenterMapsForBuyer", args); err != nil {
 			fmt.Printf("rpc error: %v\n", err)
 			handleJSONRPCError(env, err)
 			return
@@ -355,7 +353,7 @@ func datacenterMapsForBuyer(
 
 }
 
-func addDatacenterMap(rpcClient jsonrpc.RPCClient, env Environment, dcm dcMapStrings) error {
+func addDatacenterMap(env Environment, dcm dcMapStrings) error {
 
 	var err error
 	var buyerID uint64
@@ -363,7 +361,7 @@ func addDatacenterMap(rpcClient jsonrpc.RPCClient, env Environment, dcm dcMapStr
 
 	buyerArgs := localjsonrpc.BuyersArgs{}
 	var buyers localjsonrpc.BuyersReply
-	if err = rpcClient.CallFor(&buyers, "OpsService.Buyers", buyerArgs); err != nil {
+	if err = makeRPCCall(env, &buyers, "OpsService.Buyers", buyerArgs); err != nil {
 		handleRunTimeError(fmt.Sprintln("Unable to retrive buyer list."), 1)
 	}
 	r := regexp.MustCompile("(?i)" + dcm.BuyerID) // case-insensitive regex
@@ -378,7 +376,7 @@ func addDatacenterMap(rpcClient jsonrpc.RPCClient, env Environment, dcm dcMapStr
 
 	dcArgs := localjsonrpc.DatacentersArgs{}
 	var dcReply localjsonrpc.DatacentersReply
-	if err = rpcClient.CallFor(&dcReply, "OpsService.Datacenters", dcArgs); err != nil {
+	if err = makeRPCCall(env, &dcReply, "OpsService.Datacenters", dcArgs); err != nil {
 		handleRunTimeError(fmt.Sprintln("Unable to retrive datacenter list."), 1)
 	}
 	r = regexp.MustCompile("(?i)" + dcm.Datacenter) // case-insensitive regex
@@ -400,7 +398,7 @@ func addDatacenterMap(rpcClient jsonrpc.RPCClient, env Environment, dcm dcMapStr
 	}
 
 	var reply localjsonrpc.AddDatacenterMapReply
-	if err := rpcClient.CallFor(&reply, "BuyersService.AddDatacenterMap", arg); err != nil {
+	if err := makeRPCCall(env, &reply, "BuyersService.AddDatacenterMap", arg); err != nil {
 		handleJSONRPCError(env, err)
 		return nil
 	}
@@ -409,7 +407,7 @@ func addDatacenterMap(rpcClient jsonrpc.RPCClient, env Environment, dcm dcMapStr
 
 }
 
-func removeDatacenterMap(rpcClient jsonrpc.RPCClient, env Environment, dcm dcMapStrings) error {
+func removeDatacenterMap(env Environment, dcm dcMapStrings) error {
 
 	var err error
 	var buyerID uint64
@@ -417,7 +415,7 @@ func removeDatacenterMap(rpcClient jsonrpc.RPCClient, env Environment, dcm dcMap
 
 	buyerArgs := localjsonrpc.BuyersArgs{}
 	var buyers localjsonrpc.BuyersReply
-	if err = rpcClient.CallFor(&buyers, "OpsService.Buyers", buyerArgs); err != nil {
+	if err = makeRPCCall(env, &buyers, "OpsService.Buyers", buyerArgs); err != nil {
 		handleRunTimeError(fmt.Sprintln("Unable to retrive buyer list."), 1)
 	}
 	r := regexp.MustCompile("(?i)" + dcm.BuyerID) // case-insensitive regex
@@ -432,7 +430,7 @@ func removeDatacenterMap(rpcClient jsonrpc.RPCClient, env Environment, dcm dcMap
 
 	dcArgs := localjsonrpc.DatacentersArgs{}
 	var dcReply localjsonrpc.DatacentersReply
-	if err = rpcClient.CallFor(&dcReply, "OpsService.Datacenters", dcArgs); err != nil {
+	if err = makeRPCCall(env, &dcReply, "OpsService.Datacenters", dcArgs); err != nil {
 		handleRunTimeError(fmt.Sprintln("Unable to retrive datacenter list."), 1)
 	}
 	r = regexp.MustCompile("(?i)" + dcm.Datacenter) // case-insensitive regex
@@ -454,7 +452,7 @@ func removeDatacenterMap(rpcClient jsonrpc.RPCClient, env Environment, dcm dcMap
 	}
 
 	var reply localjsonrpc.RemoveDatacenterMapReply
-	if err := rpcClient.CallFor(&reply, "BuyersService.RemoveDatacenterMap", arg); err != nil {
+	if err := makeRPCCall(env, &reply, "BuyersService.RemoveDatacenterMap", arg); err != nil {
 		handleJSONRPCError(env, err)
 		return nil
 	}
@@ -464,14 +462,13 @@ func removeDatacenterMap(rpcClient jsonrpc.RPCClient, env Environment, dcm dcMap
 }
 
 func buyerIDFromName(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 ) (string, uint64) {
 
 	buyerArgs := localjsonrpc.BuyersArgs{}
 	var buyers localjsonrpc.BuyersReply
-	if err := rpcClient.CallFor(&buyers, "OpsService.Buyers", buyerArgs); err != nil {
+	if err := makeRPCCall(env, &buyers, "OpsService.Buyers", buyerArgs); err != nil {
 		handleJSONRPCError(env, err)
 	}
 
@@ -502,13 +499,12 @@ func buyerIDFromName(
 }
 
 func getInternalConfig(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 ) error {
 	var reply localjsonrpc.InternalConfigReply
 
-	buyerName, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	buyerName, buyerID := buyerIDFromName(env, buyerRegex)
 
 	buyerIDHex := fmt.Sprintf("%016x", buyerID)
 
@@ -516,7 +512,7 @@ func getInternalConfig(
 		BuyerID: buyerIDHex,
 	}
 
-	if err := rpcClient.CallFor(&reply, "BuyersService.InternalConfig", arg); err != nil {
+	if err := makeRPCCall(env, &reply, "BuyersService.InternalConfig", arg); err != nil {
 		handleJSONRPCError(env, err)
 	}
 
@@ -543,20 +539,19 @@ func getInternalConfig(
 }
 
 func getRouteShader(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 ) error {
 	var reply localjsonrpc.RouteShaderReply
 
-	buyerName, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	buyerName, buyerID := buyerIDFromName(env, buyerRegex)
 
 	buyerIDHex := fmt.Sprintf("%016x", buyerID)
 
 	arg := localjsonrpc.RouteShaderArg{
 		BuyerID: buyerIDHex,
 	}
-	if err := rpcClient.CallFor(&reply, "BuyersService.RouteShader", arg); err != nil {
+	if err := makeRPCCall(env, &reply, "BuyersService.RouteShader", arg); err != nil {
 		fmt.Println("No RouteShader stored for this buyer (they use the defaults).")
 		return nil
 	}
@@ -580,7 +575,6 @@ func getRouteShader(
 }
 
 func addInternalConfig(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerID uint64,
 	ic localjsonrpc.JSInternalConfig,
@@ -593,7 +587,7 @@ func addInternalConfig(
 		InternalConfig: ic,
 	}
 	// Storer method checks BuyerID validity
-	if err := rpcClient.CallFor(&emptyReply, "BuyersService.JSAddInternalConfig", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "BuyersService.JSAddInternalConfig", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}
@@ -603,12 +597,11 @@ func addInternalConfig(
 }
 
 func removeInternalConfig(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 ) error {
 
-	buyerName, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	buyerName, buyerID := buyerIDFromName(env, buyerRegex)
 
 	emptyReply := localjsonrpc.RemoveInternalConfigReply{}
 
@@ -616,7 +609,7 @@ func removeInternalConfig(
 		BuyerID: fmt.Sprintf("%016x", buyerID),
 	}
 	// Storer method checks BuyerID validity
-	if err := rpcClient.CallFor(&emptyReply, "BuyersService.RemoveInternalConfig", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "BuyersService.RemoveInternalConfig", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}
@@ -626,14 +619,13 @@ func removeInternalConfig(
 }
 
 func updateInternalConfig(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 	field string,
 	value string,
 ) error {
 
-	buyerName, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	buyerName, buyerID := buyerIDFromName(env, buyerRegex)
 
 	emptyReply := localjsonrpc.UpdateInternalConfigReply{}
 
@@ -642,7 +634,7 @@ func updateInternalConfig(
 		Field:   field,
 		Value:   value,
 	}
-	if err := rpcClient.CallFor(&emptyReply, "BuyersService.UpdateInternalConfig", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "BuyersService.UpdateInternalConfig", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}
@@ -652,7 +644,6 @@ func updateInternalConfig(
 }
 
 func addRouteShader(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerID uint64,
 	rs localjsonrpc.JSRouteShader,
@@ -664,7 +655,7 @@ func addRouteShader(
 		BuyerID:     fmt.Sprintf("%016x", buyerID),
 		RouteShader: rs,
 	}
-	if err := rpcClient.CallFor(&emptyReply, "BuyersService.JSAddRouteShader", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "BuyersService.JSAddRouteShader", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}
@@ -674,19 +665,18 @@ func addRouteShader(
 }
 
 func removeRouteShader(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 ) error {
 
-	buyerName, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	buyerName, buyerID := buyerIDFromName(env, buyerRegex)
 
 	emptyReply := localjsonrpc.RemoveRouteShaderReply{}
 
 	args := localjsonrpc.RemoveRouteShaderArg{
 		BuyerID: fmt.Sprintf("%016x", buyerID),
 	}
-	if err := rpcClient.CallFor(&emptyReply, "BuyersService.RemoveRouteShader", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "BuyersService.RemoveRouteShader", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}
@@ -696,14 +686,13 @@ func removeRouteShader(
 }
 
 func updateRouteShader(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 	field string,
 	value string,
 ) error {
 
-	buyerName, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	buyerName, buyerID := buyerIDFromName(env, buyerRegex)
 
 	emptyReply := localjsonrpc.UpdateRouteShaderReply{}
 
@@ -712,7 +701,7 @@ func updateRouteShader(
 		Field:   field,
 		Value:   value,
 	}
-	if err := rpcClient.CallFor(&emptyReply, "BuyersService.UpdateRouteShader", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "BuyersService.UpdateRouteShader", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}
@@ -722,19 +711,18 @@ func updateRouteShader(
 }
 
 func getBannedUsers(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 ) error {
 
-	buyerName, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	buyerName, buyerID := buyerIDFromName(env, buyerRegex)
 
 	reply := localjsonrpc.GetBannedUserReply{}
 
 	args := localjsonrpc.GetBannedUserArg{
 		BuyerID: buyerID,
 	}
-	if err := rpcClient.CallFor(&reply, "BuyersService.GetBannedUsers", args); err != nil {
+	if err := makeRPCCall(env, &reply, "BuyersService.GetBannedUsers", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}
@@ -747,13 +735,12 @@ func getBannedUsers(
 }
 
 func addBannedUser(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 	userID uint64,
 ) error {
 
-	buyerName, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	buyerName, buyerID := buyerIDFromName(env, buyerRegex)
 
 	emptyReply := localjsonrpc.BannedUserReply{}
 
@@ -761,7 +748,7 @@ func addBannedUser(
 		BuyerID: buyerID,
 		UserID:  userID,
 	}
-	if err := rpcClient.CallFor(&emptyReply, "BuyersService.AddBannedUser", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "BuyersService.AddBannedUser", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}
@@ -771,13 +758,12 @@ func addBannedUser(
 }
 
 func removeBannedUser(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 	userID uint64,
 ) error {
 
-	buyerName, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	buyerName, buyerID := buyerIDFromName(env, buyerRegex)
 
 	emptyReply := localjsonrpc.BannedUserReply{}
 
@@ -785,7 +771,7 @@ func removeBannedUser(
 		BuyerID: buyerID,
 		UserID:  userID,
 	}
-	if err := rpcClient.CallFor(&emptyReply, "BuyersService.RemoveBannedUser", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "BuyersService.RemoveBannedUser", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}
@@ -794,16 +780,16 @@ func removeBannedUser(
 	return nil
 }
 
-func getBuyerInfo(rpcClient jsonrpc.RPCClient, env Environment, buyerRegex string) {
+func getBuyerInfo(env Environment, buyerRegex string) {
 
-	_, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	_, buyerID := buyerIDFromName(env, buyerRegex)
 
 	arg := localjsonrpc.BuyerArg{
 		BuyerID: buyerID,
 	}
 
 	var reply localjsonrpc.BuyerReply
-	if err := rpcClient.CallFor(&reply, "BuyersService.Buyer", arg); err != nil {
+	if err := makeRPCCall(env, &reply, "BuyersService.Buyer", arg); err != nil {
 		handleJSONRPCError(env, err)
 	}
 
@@ -821,14 +807,13 @@ func getBuyerInfo(rpcClient jsonrpc.RPCClient, env Environment, buyerRegex strin
 }
 
 func updateBuyer(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	buyerRegex string,
 	field string,
 	value string,
 ) error {
 
-	buyerName, buyerID := buyerIDFromName(rpcClient, env, buyerRegex)
+	buyerName, buyerID := buyerIDFromName(env, buyerRegex)
 
 	emptyReply := localjsonrpc.UpdateBuyerReply{}
 
@@ -837,7 +822,7 @@ func updateBuyer(
 		Field:   field,
 		Value:   value,
 	}
-	if err := rpcClient.CallFor(&emptyReply, "BuyersService.UpdateBuyer", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "BuyersService.UpdateBuyer", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}

--- a/cmd/next/customers.go
+++ b/cmd/next/customers.go
@@ -8,14 +8,13 @@ import (
 	"github.com/modood/table"
 	"github.com/networknext/backend/modules/routing"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 )
 
-func customers(rpcClient jsonrpc.RPCClient, env Environment) {
+func customers(env Environment) {
 	args := localjsonrpc.BuyersArgs{}
 
 	var reply localjsonrpc.CustomersReply
-	if err := rpcClient.CallFor(&reply, "OpsService.Customers", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.Customers", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -27,14 +26,14 @@ func customers(rpcClient jsonrpc.RPCClient, env Environment) {
 	table.Output(reply.Customers)
 }
 
-func addCustomer(rpcClient jsonrpc.RPCClient, env Environment, c routing.Customer) {
+func addCustomer(env Environment, c routing.Customer) {
 
 	arg := localjsonrpc.AddCustomerArgs{
 		Customer: c,
 	}
 
 	var reply localjsonrpc.AddCustomerReply
-	if err := rpcClient.CallFor(&reply, "OpsService.AddCustomer", arg); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.AddCustomer", arg); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -43,14 +42,14 @@ func addCustomer(rpcClient jsonrpc.RPCClient, env Environment, c routing.Custome
 
 }
 
-func getCustomerInfo(rpcClient jsonrpc.RPCClient, env Environment, id string) {
+func getCustomerInfo(env Environment, id string) {
 
 	arg := localjsonrpc.CustomerArg{
 		CustomerID: id,
 	}
 
 	var reply localjsonrpc.CustomerReply
-	if err := rpcClient.CallFor(&reply, "OpsService.Customer", arg); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.Customer", arg); err != nil {
 		handleJSONRPCError(env, err)
 	}
 
@@ -70,7 +69,6 @@ func getCustomerInfo(rpcClient jsonrpc.RPCClient, env Environment, id string) {
 }
 
 func updateCustomer(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	customerCode string,
 	field string,
@@ -84,7 +82,7 @@ func updateCustomer(
 		Field:      field,
 		Value:      value,
 	}
-	if err := rpcClient.CallFor(&emptyReply, "OpsService.UpdateCustomer", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "OpsService.UpdateCustomer", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}
@@ -94,7 +92,6 @@ func updateCustomer(
 }
 
 func removeCustomer(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	customerCode string,
 ) error {
@@ -104,7 +101,7 @@ func removeCustomer(
 	args := localjsonrpc.RemoveCustomerArgs{
 		CustomerCode: customerCode,
 	}
-	if err := rpcClient.CallFor(&emptyReply, "OpsService.RemoveCustomer", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "OpsService.RemoveCustomer", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}

--- a/cmd/next/datacenters.go
+++ b/cmd/next/datacenters.go
@@ -10,7 +10,6 @@ import (
 	"github.com/networknext/backend/modules/crypto"
 	"github.com/networknext/backend/modules/routing"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 )
 
 type datacenterReply struct {
@@ -21,7 +20,6 @@ type datacenterReply struct {
 }
 
 func datacenters(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	filter string,
 	signed bool,
@@ -38,7 +36,7 @@ func datacenters(
 	})
 
 	var reply localjsonrpc.DatacentersReply
-	if err := rpcClient.CallFor(&reply, "OpsService.Datacenters", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.Datacenters", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -105,13 +103,13 @@ func datacenters(
 
 }
 
-func addDatacenter(rpcClient jsonrpc.RPCClient, env Environment, dc datacenter) {
+func addDatacenter(env Environment, dc datacenter) {
 
 	var sellerReply localjsonrpc.SellerReply
 	var sellerArg localjsonrpc.SellerArg
 
 	sellerArg.ID = dc.SellerID
-	if err := rpcClient.CallFor(&sellerReply, "OpsService.Seller", sellerArg); err != nil {
+	if err := makeRPCCall(env, &sellerReply, "OpsService.Seller", sellerArg); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -132,7 +130,7 @@ func addDatacenter(rpcClient jsonrpc.RPCClient, env Environment, dc datacenter) 
 	}
 
 	var reply localjsonrpc.AddDatacenterReply
-	if err := rpcClient.CallFor(&reply, "OpsService.AddDatacenter", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.AddDatacenter", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -140,13 +138,13 @@ func addDatacenter(rpcClient jsonrpc.RPCClient, env Environment, dc datacenter) 
 	fmt.Printf("Datacenter \"%s\" added to storage.\n", datacenter.Name)
 }
 
-func removeDatacenter(rpcClient jsonrpc.RPCClient, env Environment, name string) {
+func removeDatacenter(env Environment, name string) {
 	args := localjsonrpc.RemoveDatacenterArgs{
 		Name: name,
 	}
 
 	var reply localjsonrpc.RemoveDatacenterReply
-	if err := rpcClient.CallFor(&reply, "OpsService.RemoveDatacenter", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.RemoveDatacenter", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -154,7 +152,7 @@ func removeDatacenter(rpcClient jsonrpc.RPCClient, env Environment, name string)
 	fmt.Printf("Datacenter \"%x\" removed from storage.\n", name)
 }
 
-func listDatacenterMaps(rpcClient jsonrpc.RPCClient, env Environment, datacenter string) {
+func listDatacenterMaps(env Environment, datacenter string) {
 
 	var dcIDs []uint64
 	var err error
@@ -162,7 +160,7 @@ func listDatacenterMaps(rpcClient jsonrpc.RPCClient, env Environment, datacenter
 	// get list of datacenters matching the given id/name/substring
 	datacentersArgs := localjsonrpc.DatacentersArgs{}
 	var datacenters localjsonrpc.DatacentersReply
-	if err = rpcClient.CallFor(&datacenters, "OpsService.Datacenters", datacentersArgs); err != nil {
+	if err = makeRPCCall(env, &datacenters, "OpsService.Datacenters", datacentersArgs); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -187,7 +185,7 @@ func listDatacenterMaps(rpcClient jsonrpc.RPCClient, env Environment, datacenter
 			DatacenterID: id,
 		}
 
-		if err := rpcClient.CallFor(&reply, "OpsService.ListDatacenterMaps", arg); err != nil {
+		if err := makeRPCCall(env, &reply, "OpsService.ListDatacenterMaps", arg); err != nil {
 			fmt.Printf("rpc error: %v\n", err)
 			handleJSONRPCError(env, err)
 			return

--- a/cmd/next/next.go
+++ b/cmd/next/next.go
@@ -314,6 +314,88 @@ func handleJSONRPCErrorCustom(env Environment, err error, msg string) {
 
 }
 
+func refreshAuth(env Environment) error {
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"https://networknext.auth0.com/oauth/token",
+		strings.NewReader(`{
+				"client_id":"6W6PCgPc6yj6tzO9PtW6IopmZAWmltgb",
+				"client_secret":"EPZEHccNbjqh_Zwlc5cSFxvxFQHXZ990yjo6RlADjYWBz47XZMf-_JjVxcMW-XDj",
+				"audience":"https://portal.networknext.com",
+				"grant_type":"client_credentials"
+			}`),
+	)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	env.AuthToken = gjson.ParseBytes(body).Get("access_token").String()
+	env.Write()
+
+	fmt.Print("Successfully authorized\n")
+	return nil
+}
+
+func makeRPCCall(env Environment, reply interface{}, method string, params interface{}) error {
+	protocol := "https"
+	if env.PortalHostname() == PortalHostnameLocal {
+		protocol = "http"
+	}
+
+	rpcClient := jsonrpc.NewClientWithOpts(protocol+"://"+env.PortalHostname()+"/rpc", &jsonrpc.RPCClientOpts{
+		CustomHeaders: map[string]string{
+			"Authorization": fmt.Sprintf("Bearer %s", env.AuthToken),
+		},
+	})
+
+	if err := rpcClient.CallFor(&reply, method, params); err != nil {
+		switch e := err.(type) {
+		case *jsonrpc.HTTPError:
+			switch e.Code {
+			case http.StatusUnauthorized:
+				// Refresh token and try again
+				if err := refreshAuth(env); err != nil {
+					handleRunTimeError(err.Error(), 1)
+				}
+				env.Read()
+
+				rpcClient := jsonrpc.NewClientWithOpts(protocol+"://"+env.PortalHostname()+"/rpc", &jsonrpc.RPCClientOpts{
+					CustomHeaders: map[string]string{
+						"Authorization": fmt.Sprintf("Bearer %s", env.AuthToken),
+					},
+				})
+
+				if err := rpcClient.CallFor(&reply, method, params); err != nil {
+					return err
+				}
+			default:
+				return err
+			}
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
 type internalConfig struct {
 	RouteSelectThreshold           int32
 	RouteSwitchThreshold           int32
@@ -423,16 +505,12 @@ func main() {
 	}
 	env.Read()
 
-	protocol := "https"
-	if env.PortalHostname() == PortalHostnameLocal || env.PortalHostname() == PortalHostnameNRB {
-		protocol = "http"
+	if env.AuthToken == "" {
+		if err := refreshAuth(env); err != nil {
+			handleRunTimeError(err.Error(), 1)
+		}
+		env.Read()
 	}
-
-	rpcClient := jsonrpc.NewClientWithOpts(protocol+"://"+env.PortalHostname()+"/rpc", &jsonrpc.RPCClientOpts{
-		CustomHeaders: map[string]string{
-			"Authorization": fmt.Sprintf("Bearer %s", env.AuthToken),
-		},
-	})
 
 	var srcRelays arrayFlags
 	var destRelays arrayFlags
@@ -562,43 +640,7 @@ func main() {
 		ShortUsage: "next auth",
 		ShortHelp:  "Authorize the operator tool to interact with the Portal API",
 		Exec: func(_ context.Context, args []string) error {
-			req, err := http.NewRequest(
-				http.MethodPost,
-				"https://networknext.auth0.com/oauth/token",
-				strings.NewReader(`{
-						"client_id":"6W6PCgPc6yj6tzO9PtW6IopmZAWmltgb",
-						"client_secret":"EPZEHccNbjqh_Zwlc5cSFxvxFQHXZ990yjo6RlADjYWBz47XZMf-_JjVxcMW-XDj",
-						"audience":"https://portal.networknext.com",
-						"grant_type":"client_credentials"
-					}`),
-			)
-			if err != nil {
-				return err
-			}
-
-			req.Header.Add("Content-Type", "application/json")
-
-			res, err := http.DefaultClient.Do(req)
-			if err != nil {
-				return err
-			}
-			defer res.Body.Close()
-
-			if res.StatusCode != http.StatusOK {
-				return fmt.Errorf("auth0 returned code %d", res.StatusCode)
-			}
-
-			body, err := ioutil.ReadAll(res.Body)
-			if err != nil {
-				return err
-			}
-			defer res.Body.Close()
-
-			env.AuthToken = gjson.ParseBytes(body).Get("access_token").String()
-			env.Write()
-
-			fmt.Print("Successfully authorized\n")
-
+			refreshAuth(env)
 			return nil
 		},
 	}
@@ -668,8 +710,8 @@ func main() {
 
 			env.RemoteRelease = "Unknown"
 			env.RemoteBuildTime = "Unknown"
-			var reply localjsonrpc.CurrentReleaseReply
-			if err := rpcClient.CallFor(&reply, "OpsService.CurrentRelease", localjsonrpc.CurrentReleaseArgs{}); err == nil {
+			var reply localjsonrpc.CurrentReleaseReply = localjsonrpc.CurrentReleaseReply{}
+			if err := makeRPCCall(env, &reply, "OpsService.CurrentRelease", localjsonrpc.CurrentReleaseArgs{}); err == nil {
 				env.RemoteRelease = reply.Release
 				env.RemoteBuildTime = reply.BuildTime
 			}
@@ -689,7 +731,7 @@ func main() {
 			reply := localjsonrpc.UserDatabaseReply{}
 			fmt.Println("Looking up all accounts associated to a company/buyer account")
 			fmt.Println("")
-			if err := rpcClient.CallFor(&reply, "AuthService.UserDatabase", localjsonrpc.UserDatabaseArgs{}); err == nil {
+			if err := makeRPCCall(env, &reply, "AuthService.UserDatabase", localjsonrpc.UserDatabaseArgs{}); err == nil {
 				usersCSV := [][]string{{}}
 
 				usersCSV = append(usersCSV, []string{
@@ -804,10 +846,10 @@ func main() {
 		FlagSet:    sessionsfs,
 		Exec: func(_ context.Context, args []string) error {
 			if len(args) > 0 {
-				sessions(rpcClient, env, args[0], sessionCount)
+				sessions(env, args[0], sessionCount)
 				return nil
 			}
-			sessionsByBuyer(rpcClient, env, buyerName, sessionCount)
+			sessionsByBuyer(env, buyerName, sessionCount)
 			return nil
 		},
 		Subcommands: []*ffcli.Command{
@@ -816,7 +858,7 @@ func main() {
 				ShortUsage: "next sessions flush",
 				ShortHelp:  "Flush all sessions in Redis in the Portal",
 				Exec: func(ctx context.Context, args []string) error {
-					flushsessions(rpcClient, env)
+					flushsessions(env)
 					fmt.Println("All sessions flushed.")
 					return nil
 				},
@@ -832,7 +874,7 @@ func main() {
 			if len(args) != 1 {
 				fmt.Printf("A session ID must be provided (see ./next sessions).")
 			}
-			sessions(rpcClient, env, args[0], sessionCount)
+			sessions(env, args[0], sessionCount)
 			return nil
 		},
 		Subcommands: []*ffcli.Command{
@@ -861,7 +903,7 @@ func main() {
 						}
 					}
 
-					dumpSession(rpcClient, env, sessionID)
+					dumpSession(env, sessionID)
 
 					return nil
 				},
@@ -942,7 +984,7 @@ func main() {
 				regexName = args[0]
 			}
 
-			getFleetRelays(rpcClient, env, relaysCount, relaysAlphaSort, regexName)
+			getFleetRelays(env, relaysCount, relaysAlphaSort, regexName)
 
 			return nil
 		},
@@ -983,7 +1025,6 @@ func main() {
 
 					if relayOpsOutput {
 						opsRelays(
-							rpcClient,
 							env,
 							arg,
 							relaysStateShowFlags,
@@ -997,7 +1038,6 @@ func main() {
 						)
 					} else {
 						relays(
-							rpcClient,
 							env,
 							arg,
 							relaysStateShowFlags,
@@ -1020,11 +1060,11 @@ func main() {
 				ShortHelp:  "Return the number of relays in each state",
 				Exec: func(ctx context.Context, args []string) error {
 					if len(args) > 0 {
-						countRelays(rpcClient, env, args[0])
+						countRelays(env, args[0])
 						return nil
 					}
 
-					countRelays(rpcClient, env, "")
+					countRelays(env, "")
 					return nil
 				},
 			},
@@ -1056,11 +1096,11 @@ func main() {
 						relaysStateHideFlags[routing.RelayStateOffline] = false
 					}
 					if len(args) == 0 {
-						validate(rpcClient, env, relaysStateShowFlags, relaysStateHideFlags, "optimize.bin")
+						validate(env, relaysStateShowFlags, relaysStateHideFlags, "optimize.bin")
 						return nil
 					}
 
-					validate(rpcClient, env, relaysStateShowFlags, relaysStateHideFlags, args[0])
+					validate(env, relaysStateShowFlags, relaysStateHideFlags, args[0])
 					return nil
 				},
 			},
@@ -1086,7 +1126,7 @@ func main() {
 						handleRunTimeError(fmt.Sprintln("you must supply at least one argument"), 0)
 					}
 
-					relayLogs(rpcClient, env, loglines, args)
+					relayLogs(env, loglines, args)
 
 					return nil
 				},
@@ -1121,7 +1161,7 @@ func main() {
 						regex = args[0]
 					}
 
-					checkRelays(rpcClient, env, regex, relaysStateShowFlags, relaysStateHideFlags, relaysDownFlag, csvOutputFlag)
+					checkRelays(env, regex, relaysStateShowFlags, relaysStateHideFlags, relaysDownFlag, csvOutputFlag)
 					return nil
 				},
 			},
@@ -1130,7 +1170,7 @@ func main() {
 				ShortUsage: "next relay keys <relay name>",
 				ShortHelp:  "Show the public keys for the relay",
 				Exec: func(ctx context.Context, args []string) error {
-					relays := getRelayInfo(rpcClient, env, args[0])
+					relays := getRelayInfo(env, args[0])
 
 					if len(relays) == 0 {
 						handleRunTimeError(fmt.Sprintf("no relays matched the name '%s'\n", args[0]), 0)
@@ -1154,7 +1194,7 @@ func main() {
 						regexes = args
 					}
 
-					updateRelays(env, rpcClient, regexes, updateOpts)
+					updateRelays(env, regexes, updateOpts)
 
 					return nil
 				},
@@ -1169,7 +1209,7 @@ func main() {
 						regexes = args
 					}
 
-					revertRelays(env, rpcClient, regexes)
+					revertRelays(env, regexes)
 
 					return nil
 				},
@@ -1184,7 +1224,7 @@ func main() {
 						regexes = args
 					}
 
-					enableRelays(env, rpcClient, regexes)
+					enableRelays(env, regexes)
 
 					return nil
 				},
@@ -1200,7 +1240,7 @@ func main() {
 						regexes = args
 					}
 
-					disableRelays(env, rpcClient, regexes, hardDisable, false)
+					disableRelays(env, regexes, hardDisable, false)
 
 					return nil
 				},
@@ -1216,7 +1256,7 @@ func main() {
 						regexes = args
 					}
 
-					disableRelays(env, rpcClient, regexes, hardDisable, true)
+					disableRelays(env, regexes, hardDisable, true)
 
 					return nil
 				},
@@ -1234,7 +1274,7 @@ func main() {
 						handleRunTimeError(fmt.Sprintln("You need to supply a new name for the relay as well"), 0)
 					}
 
-					updateRelayName(rpcClient, env, args[0], args[1])
+					updateRelayName(env, args[0], args[1])
 
 					return nil
 				},
@@ -1254,7 +1294,7 @@ func main() {
 					}
 
 					// Add the Relay to storage
-					addRelayJS(rpcClient, env, relay)
+					addRelayJS(env, relay)
 					return nil
 				},
 			},
@@ -1267,7 +1307,7 @@ func main() {
 						handleRunTimeError(fmt.Sprintln("Provide the relay name of the relay you wish to remove\nFor a list of relay, use next relay"), 0)
 					}
 
-					removeRelay(rpcClient, env, args[0])
+					removeRelay(env, args[0])
 					return nil
 				},
 			},
@@ -1280,7 +1320,7 @@ func main() {
 						handleRunTimeError(fmt.Sprintln("Must provide a relay name"), 0)
 					}
 
-					getDetailedRelayInfo(rpcClient, env, args[0])
+					getDetailedRelayInfo(env, args[0])
 					return nil
 				},
 			},
@@ -1294,7 +1334,7 @@ func main() {
 						handleRunTimeError(fmt.Sprintln("Must provide a relay name, field name and a value."), 0)
 					}
 
-					modifyRelayField(rpcClient, env, args[0], args[1], args[2])
+					modifyRelayField(env, args[0], args[1], args[2])
 					return nil
 				},
 			},
@@ -1308,7 +1348,7 @@ func main() {
 						handleRunTimeError(fmt.Sprintln("Must provide a relay name for the generated heatmap."), 0)
 					}
 
-					relayHeatmap(rpcClient, env, args[0])
+					relayHeatmap(env, args[0])
 					return nil
 				},
 			},
@@ -1322,11 +1362,11 @@ func main() {
 		Exec: func(_ context.Context, args []string) error {
 
 			if len(args) == 0 {
-				routes(rpcClient, env, []string{}, []string{}, 0, 0)
+				routes(env, []string{}, []string{}, 0, 0)
 				return nil
 			}
 
-			routes(rpcClient, env, []string{args[0]}, []string{args[1]}, 0, 0)
+			routes(env, []string{args[0]}, []string{args[1]}, 0, 0)
 			return nil
 		},
 		Subcommands: []*ffcli.Command{
@@ -1336,7 +1376,7 @@ func main() {
 				ShortHelp:  "Select routes between sets of relays",
 				FlagSet:    routesfs,
 				Exec: func(ctx context.Context, args []string) error {
-					routes(rpcClient, env, srcRelays, destRelays, routeRTT, routeHash)
+					routes(env, srcRelays, destRelays, routeRTT, routeHash)
 
 					return nil
 				},
@@ -1351,10 +1391,10 @@ func main() {
 		FlagSet:    datacentersfs,
 		Exec: func(_ context.Context, args []string) error {
 			if len(args) > 0 {
-				datacenters(rpcClient, env, args[0], datacenterIdSigned, datacentersCSV)
+				datacenters(env, args[0], datacenterIdSigned, datacentersCSV)
 				return nil
 			}
-			datacenters(rpcClient, env, "", datacenterIdSigned, datacentersCSV)
+			datacenters(env, "", datacenterIdSigned, datacentersCSV)
 			return nil
 		},
 	}
@@ -1364,7 +1404,7 @@ func main() {
 		ShortUsage: "next customers",
 		ShortHelp:  "List customers",
 		Exec: func(_ context.Context, args []string) error {
-			customers(rpcClient, env)
+			customers(env)
 			return nil
 		},
 	}
@@ -1374,7 +1414,7 @@ func main() {
 		ShortUsage: "next sellers",
 		ShortHelp:  "List sellers",
 		Exec: func(_ context.Context, args []string) error {
-			sellers(rpcClient, env)
+			sellers(env)
 			return nil
 		},
 	}
@@ -1402,7 +1442,7 @@ func main() {
 					}
 
 					// Add the Datacenter to storage
-					addDatacenter(rpcClient, env, dc)
+					addDatacenter(env, dc)
 					return nil
 				},
 			},
@@ -1416,7 +1456,7 @@ func main() {
 						return err
 					}
 
-					removeDatacenter(rpcClient, env, args[0])
+					removeDatacenter(env, args[0])
 					return nil
 				},
 			},
@@ -1431,7 +1471,7 @@ func main() {
 						handleRunTimeError(fmt.Sprintln("Exactly zero or one datacenter ID or name must be provided."), 0)
 					}
 
-					listDatacenterMaps(rpcClient, env, args[0])
+					listDatacenterMaps(env, args[0])
 					return nil
 				},
 			},
@@ -1447,7 +1487,7 @@ func main() {
 			if len(args) != 0 {
 				fmt.Println("No arguments necessary, everything after 'buyers' is ignored.\n\nA list of all current buyers:")
 			}
-			buyers(rpcClient, env, buyersIdSigned)
+			buyers(env, buyersIdSigned)
 			return nil
 		},
 	}
@@ -1466,7 +1506,7 @@ func main() {
 				ShortUsage: "next buyer list",
 				ShortHelp:  "Return a list of all current buyers",
 				Exec: func(_ context.Context, args []string) error {
-					buyers(rpcClient, env, buyersIdSigned)
+					buyers(env, buyersIdSigned)
 					return nil
 				},
 			},
@@ -1479,7 +1519,7 @@ func main() {
 						handleRunTimeError(fmt.Sprintln("Please provide the seller ID in hex, only."), 0)
 					}
 
-					getBuyerInfo(rpcClient, env, args[0])
+					getBuyerInfo(env, args[0])
 					return nil
 				},
 			},
@@ -1493,7 +1533,7 @@ func main() {
 						handleRunTimeError(fmt.Sprintln("Please provide the buyer name, field and value."), 0)
 					}
 
-					updateBuyer(rpcClient, env, args[0], args[1], args[2])
+					updateBuyer(env, args[0], args[1], args[2])
 					return nil
 				},
 			},
@@ -1529,7 +1569,7 @@ func main() {
 					}
 
 					var reply localjsonrpc.JSAddBuyerReply
-					if err := rpcClient.CallFor(&reply, "OpsService.JSAddBuyer", buyerArgs); err != nil {
+					if err := makeRPCCall(env, &reply, "OpsService.JSAddBuyer", buyerArgs); err != nil {
 						handleJSONRPCError(env, err)
 					}
 
@@ -1546,7 +1586,7 @@ func main() {
 						handleRunTimeError(fmt.Sprintln("Provide the buyer ID of the buyer you wish to remove\nFor a list of buyers, use next buyers"), 0)
 					}
 
-					removeBuyer(rpcClient, env, args[0])
+					removeBuyer(env, args[0])
 					return nil
 				},
 			},
@@ -1557,11 +1597,11 @@ func main() {
 				FlagSet:    buyerfs,
 				Exec: func(_ context.Context, args []string) error {
 					if len(args) != 1 {
-						datacenterMapsForBuyer(rpcClient, env, "", csvOutput, signedIDs)
+						datacenterMapsForBuyer(env, "", csvOutput, signedIDs)
 						return nil
 					}
 
-					datacenterMapsForBuyer(rpcClient, env, args[0], csvOutput, signedIDs)
+					datacenterMapsForBuyer(env, args[0], csvOutput, signedIDs)
 					return nil
 				},
 			},
@@ -1581,11 +1621,11 @@ func main() {
 						LongHelp:   "A buyer ID or name must be supplied. If the name includes spaces it must be enclosed in quotations marks.",
 						Exec: func(_ context.Context, args []string) error {
 							if len(args) != 1 {
-								datacenterMapsForBuyer(rpcClient, env, "", csvOutput, signedIDs)
+								datacenterMapsForBuyer(env, "", csvOutput, signedIDs)
 								return nil
 							}
 
-							datacenterMapsForBuyer(rpcClient, env, args[0], csvOutput, signedIDs)
+							datacenterMapsForBuyer(env, args[0], csvOutput, signedIDs)
 							return nil
 						},
 					},
@@ -1623,7 +1663,7 @@ The buyer and datacenter must exist. Hex IDs are required for now.
 								handleRunTimeError(fmt.Sprintf("Could not unmarshal datacenter map: %v\n", err), 1)
 							}
 
-							err = addDatacenterMap(rpcClient, env, dcmStrings)
+							err = addDatacenterMap(env, dcmStrings)
 
 							if err != nil {
 								// error handled in sender
@@ -1670,7 +1710,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 								handleRunTimeError(fmt.Sprintf("Could not unmarshal datacenter map: %v\n", err), 1)
 							}
 
-							err = removeDatacenterMap(rpcClient, env, dcmStrings)
+							err = removeDatacenterMap(env, dcmStrings)
 
 							if err != nil {
 								return err
@@ -1694,7 +1734,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						handleRunTimeError(fmt.Sprintln("Please provide only the buyer name or a substring"), 0)
 					}
 
-					getInternalConfig(rpcClient, env, args[0])
+					getInternalConfig(env, args[0])
 					return nil
 				},
 				Subcommands: []*ffcli.Command{
@@ -1717,7 +1757,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 								handleRunTimeError(fmt.Sprintf("Could not parse hexadecimal ID %s into a uint64: %v", ic.BuyerID, err), 0)
 							}
 
-							addInternalConfig(rpcClient, env, buyerID, localjsonrpc.JSInternalConfig{
+							addInternalConfig(env, buyerID, localjsonrpc.JSInternalConfig{
 								RouteSelectThreshold:           int64(ic.RouteSelectThreshold),
 								RouteSwitchThreshold:           int64(ic.RouteSwitchThreshold),
 								MaxLatencyTradeOff:             int64(ic.MaxLatencyTradeOff),
@@ -1745,7 +1785,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						ShortHelp:  "Remove the internal config for the specified buyer.",
 						Exec: func(_ context.Context, args []string) error {
 
-							removeInternalConfig(rpcClient, env, args[0])
+							removeInternalConfig(env, args[0])
 							return nil
 						},
 					},
@@ -1759,7 +1799,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 								handleRunTimeError(fmt.Sprintln("Please provide the buyer name or a substring, field name and value."), 0)
 							}
 
-							updateInternalConfig(rpcClient, env, args[0], args[1], args[2])
+							updateInternalConfig(env, args[0], args[1], args[2])
 							return nil
 						},
 					}},
@@ -1775,7 +1815,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						handleRunTimeError(fmt.Sprintln("Please provide only the buyer name or a substring"), 0)
 					}
 
-					getRouteShader(rpcClient, env, args[0])
+					getRouteShader(env, args[0])
 					return nil
 				},
 				Subcommands: []*ffcli.Command{
@@ -1798,7 +1838,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 								handleRunTimeError(fmt.Sprintf("Could not parse hexadecimal ID %s into a uint64: %v", rs.BuyerID, err), 0)
 							}
 
-							addRouteShader(rpcClient, env, buyerID, localjsonrpc.JSRouteShader{
+							addRouteShader(env, buyerID, localjsonrpc.JSRouteShader{
 								DisableNetworkNext:        rs.DisableNetworkNext,
 								SelectionPercent:          int64(rs.SelectionPercent),
 								ABTest:                    rs.ABTest,
@@ -1823,7 +1863,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						ShortHelp:  "Remove the route shader for the specified buyer.",
 						Exec: func(_ context.Context, args []string) error {
 
-							removeRouteShader(rpcClient, env, args[0])
+							removeRouteShader(env, args[0])
 							return nil
 						},
 					},
@@ -1837,7 +1877,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 								handleRunTimeError(fmt.Sprintln("Please provide the buyer name or a substring, field name and value."), 0)
 							}
 
-							updateRouteShader(rpcClient, env, args[0], args[1], args[2])
+							updateRouteShader(env, args[0], args[1], args[2])
 							return nil
 						},
 					},
@@ -1854,7 +1894,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						handleRunTimeError(fmt.Sprintln("Please provide only the buyer name or a substring"), 0)
 					}
 
-					getBannedUsers(rpcClient, env, args[0])
+					getBannedUsers(env, args[0])
 					return nil
 				},
 				Subcommands: []*ffcli.Command{
@@ -1872,7 +1912,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 								handleRunTimeError(fmt.Sprintf("Could not parse hexadecimal user ID %s into a uint64: %v", args[1], err), 0)
 							}
 
-							addBannedUser(rpcClient, env, args[0], userID)
+							addBannedUser(env, args[0], userID)
 							return nil
 						},
 					},
@@ -1893,7 +1933,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 								handleRunTimeError(fmt.Sprintf("Could not parse hexadecimal user ID %s into a uint64: %v", args[1], err), 0)
 							}
 
-							removeBannedUser(rpcClient, env, args[0], userID)
+							removeBannedUser(env, args[0], userID)
 							return nil
 						},
 					},
@@ -1981,7 +2021,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 					}
 
 					// Add the Seller to storage
-					addSeller(rpcClient, env, routing.Seller{
+					addSeller(env, routing.Seller{
 						ID:                        s.Name,
 						Name:                      s.Name,
 						ShortName:                 s.ShortName,
@@ -2001,7 +2041,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						handleRunTimeError(fmt.Sprintln("Provide the seller ID of the seller you wish to remove\nFor a list of sellers, use next sellers"), 0)
 					}
 
-					removeSeller(rpcClient, env, args[0])
+					removeSeller(env, args[0])
 					return nil
 				},
 			},
@@ -2014,7 +2054,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						handleRunTimeError(fmt.Sprintln("Please provide the seller ID in hex, only."), 0)
 					}
 
-					getSellerInfo(rpcClient, env, args[0])
+					getSellerInfo(env, args[0])
 					return nil
 				},
 			},
@@ -2028,7 +2068,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						handleRunTimeError(fmt.Sprintln("Please provide the seller id, field and value."), 0)
 					}
 
-					updateSeller(rpcClient, env, args[0], args[1], args[2])
+					updateSeller(env, args[0], args[1], args[2])
 					return nil
 				},
 			},
@@ -2074,7 +2114,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						SellerRef:              nil,
 					}
 
-					addCustomer(rpcClient, env, c)
+					addCustomer(env, c)
 
 					return nil
 				},
@@ -2088,7 +2128,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						handleRunTimeError(fmt.Sprintln("Please provide the customer code, only."), 0)
 					}
 
-					getCustomerInfo(rpcClient, env, args[0])
+					getCustomerInfo(env, args[0])
 					return nil
 				},
 			},
@@ -2102,7 +2142,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						handleRunTimeError(fmt.Sprintln("Please provide the customer code, field and value."), 0)
 					}
 
-					updateCustomer(rpcClient, env, args[0], args[1], args[2])
+					updateCustomer(env, args[0], args[1], args[2])
 					return nil
 				},
 			},
@@ -2115,7 +2155,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 						handleRunTimeError(fmt.Sprintln("Please provide the customer code, only."), 0)
 					}
 
-					removeCustomer(rpcClient, env, args[0])
+					removeCustomer(env, args[0])
 					return nil
 				},
 			},
@@ -2131,7 +2171,7 @@ The alias is uniquely defined by all three entries, so they must be provided. He
 				handleRunTimeError(fmt.Sprintln("You need to supply a device identifer"), 0)
 			}
 
-			SSHInto(env, rpcClient, args[0])
+			SSHInto(env, args[0])
 
 			return nil
 		},

--- a/cmd/next/ops.go
+++ b/cmd/next/ops.go
@@ -5,16 +5,15 @@ import (
 
 	"github.com/networknext/backend/modules/routing"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 )
 
-func getDetailedRelayInfo(rpcClient jsonrpc.RPCClient,
+func getDetailedRelayInfo(
 	env Environment,
 	relayRegex string,
 ) {
 	var relayID uint64
 	var ok bool
-	if relayID, ok = checkForRelay(rpcClient, env, relayRegex); !ok {
+	if relayID, ok = checkForRelay(env, relayRegex); !ok {
 		// error msg printed by called function
 		return
 	}
@@ -24,7 +23,7 @@ func getDetailedRelayInfo(rpcClient jsonrpc.RPCClient,
 	}
 
 	var reply localjsonrpc.GetRelayReply
-	if err := rpcClient.CallFor(&reply, "OpsService.GetRelay", args); !ok {
+	if err := makeRPCCall(env, &reply, "OpsService.GetRelay", args); !ok {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -93,13 +92,13 @@ func getDetailedRelayInfo(rpcClient jsonrpc.RPCClient,
 
 }
 
-func checkForRelay(rpcClient jsonrpc.RPCClient, env Environment, regex string) (uint64, bool) {
+func checkForRelay(env Environment, regex string) (uint64, bool) {
 	args := localjsonrpc.RelaysArgs{
 		Regex: regex,
 	}
 
 	var reply localjsonrpc.RelaysReply
-	err := rpcClient.CallFor(&reply, "OpsService.Relays", args)
+	err := makeRPCCall(env, &reply, "OpsService.Relays", args)
 	if err != nil {
 		handleJSONRPCError(env, err)
 		return 0, false

--- a/cmd/next/relay_fleet.go
+++ b/cmd/next/relay_fleet.go
@@ -9,11 +9,9 @@ import (
 
 	"github.com/modood/table"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 )
 
 func getFleetRelays(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	relayCount int64,
 	alphaSort bool,
@@ -21,10 +19,10 @@ func getFleetRelays(
 
 ) {
 
-	var reply localjsonrpc.RelayFleetReply
-	var args localjsonrpc.RelayFleetArgs
+	var reply localjsonrpc.RelayFleetReply = localjsonrpc.RelayFleetReply{}
+	var args = localjsonrpc.RelayFleetArgs{}
 
-	if err := rpcClient.CallFor(&reply, "RelayFleetService.RelayFleet", args); err != nil {
+	if err := makeRPCCall(env, &reply, "RelayFleetService.RelayFleet", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}

--- a/cmd/next/relays.go
+++ b/cmd/next/relays.go
@@ -11,11 +11,9 @@ import (
 	"github.com/modood/table"
 	"github.com/networknext/backend/modules/routing"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 )
 
 func opsRelays(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	regex string,
 	relaysStateShowFlags [6]bool,
@@ -35,7 +33,7 @@ func opsRelays(
 	// os.Exit(0)
 
 	var reply localjsonrpc.RelaysReply
-	if err := rpcClient.CallFor(&reply, "OpsService.Relays", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.Relays", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -246,7 +244,6 @@ func opsRelays(
 }
 
 func relays(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	regex string,
 	relaysStateShowFlags [6]bool,
@@ -266,7 +263,7 @@ func relays(
 	// os.Exit(0)
 
 	var reply localjsonrpc.RelaysReply
-	if err := rpcClient.CallFor(&reply, "OpsService.Relays", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.Relays", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -415,7 +412,7 @@ func relays(
 
 }
 
-func addRelayJS(rpcClient jsonrpc.RPCClient, env Environment, r relay) {
+func addRelayJS(env Environment, r relay) {
 
 	bwRule, err := routing.ParseBandwidthRule(r.BWRule)
 	if err != nil {
@@ -454,7 +451,7 @@ func addRelayJS(rpcClient jsonrpc.RPCClient, env Environment, r relay) {
 	}
 
 	var reply localjsonrpc.JSAddRelayReply
-	if err := rpcClient.CallFor(&reply, "OpsService.JSAddRelay", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.JSAddRelay", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -463,8 +460,8 @@ func addRelayJS(rpcClient jsonrpc.RPCClient, env Environment, r relay) {
 
 }
 
-func removeRelay(rpcClient jsonrpc.RPCClient, env Environment, name string) {
-	relays := getRelayInfo(rpcClient, env, name)
+func removeRelay(env Environment, name string) {
+	relays := getRelayInfo(env, name)
 
 	if len(relays) == 0 {
 		handleRunTimeError(fmt.Sprintf("no relays matched the name '%s'\n", name), 0)
@@ -487,7 +484,7 @@ func removeRelay(rpcClient jsonrpc.RPCClient, env Environment, name string) {
 	}
 
 	var reply localjsonrpc.RemoveRelayReply
-	if err := rpcClient.CallFor(&reply, "OpsService.RemoveRelay", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.RemoveRelay", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -495,13 +492,13 @@ func removeRelay(rpcClient jsonrpc.RPCClient, env Environment, name string) {
 	fmt.Printf("Relay \"%s\" removed.\n", info.name)
 }
 
-func countRelays(rpcClient jsonrpc.RPCClient, env Environment, regex string) {
+func countRelays(env Environment, regex string) {
 	args := localjsonrpc.RelaysArgs{
 		Regex: regex,
 	}
 
 	var reply localjsonrpc.RelaysReply
-	if err := rpcClient.CallFor(&reply, "OpsService.Relays", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.Relays", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -549,7 +546,6 @@ func countRelays(rpcClient jsonrpc.RPCClient, env Environment, regex string) {
 }
 
 func modifyRelayField(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	relayRegex string,
 	field string,
@@ -561,7 +557,7 @@ func modifyRelayField(
 	}
 
 	var reply localjsonrpc.RelaysReply
-	if err := rpcClient.CallFor(&reply, "OpsService.Relays", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.Relays", args); err != nil {
 		handleJSONRPCError(env, err)
 		return nil
 	}
@@ -585,7 +581,7 @@ func modifyRelayField(
 		Field:   field,
 		Value:   value,
 	}
-	if err := rpcClient.CallFor(&emptyReply, "OpsService.ModifyRelayField", modifyArgs); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "OpsService.ModifyRelayField", modifyArgs); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}

--- a/cmd/next/routes.go
+++ b/cmd/next/routes.go
@@ -8,10 +8,9 @@ import (
 	"github.com/modood/table"
 	"github.com/networknext/backend/modules/routing"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 )
 
-func routes(rpcClient jsonrpc.RPCClient, env Environment, srcrelays []string, destrelays []string, rtt float64, routehash uint64) {
+func routes(env Environment, srcrelays []string, destrelays []string, rtt float64, routehash uint64) {
 	args := localjsonrpc.RouteSelectionArgs{
 		SourceRelays:      srcrelays,
 		DestinationRelays: destrelays,
@@ -20,7 +19,7 @@ func routes(rpcClient jsonrpc.RPCClient, env Environment, srcrelays []string, de
 	}
 
 	var reply localjsonrpc.RouteSelectionReply
-	if err := rpcClient.CallFor(&reply, "OpsService.RouteSelection", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.RouteSelection", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}

--- a/cmd/next/sellers.go
+++ b/cmd/next/sellers.go
@@ -8,14 +8,13 @@ import (
 	"github.com/modood/table"
 	"github.com/networknext/backend/modules/routing"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 )
 
-func sellers(rpcClient jsonrpc.RPCClient, env Environment) {
+func sellers(env Environment) {
 	args := localjsonrpc.SellersArgs{}
 
 	var reply localjsonrpc.SellersReply
-	if err := rpcClient.CallFor(&reply, "OpsService.Sellers", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.Sellers", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -48,13 +47,13 @@ func sellers(rpcClient jsonrpc.RPCClient, env Environment) {
 	table.Output(sellers)
 }
 
-func addSeller(rpcClient jsonrpc.RPCClient, env Environment, seller routing.Seller) {
+func addSeller(env Environment, seller routing.Seller) {
 	args := localjsonrpc.AddSellerArgs{
 		Seller: seller,
 	}
 
 	var reply localjsonrpc.AddSellerReply
-	if err := rpcClient.CallFor(&reply, "OpsService.AddSeller", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.AddSeller", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -62,13 +61,13 @@ func addSeller(rpcClient jsonrpc.RPCClient, env Environment, seller routing.Sell
 	fmt.Printf("Seller \"%s\" added to storage.\n", seller.Name)
 }
 
-func removeSeller(rpcClient jsonrpc.RPCClient, env Environment, id string) {
+func removeSeller(env Environment, id string) {
 	args := localjsonrpc.RemoveSellerArgs{
 		ID: id,
 	}
 
 	var reply localjsonrpc.RemoveSellerReply
-	if err := rpcClient.CallFor(&reply, "OpsService.RemoveSeller", args); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.RemoveSeller", args); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -76,14 +75,14 @@ func removeSeller(rpcClient jsonrpc.RPCClient, env Environment, id string) {
 	fmt.Printf("Seller with ID \"%s\" removed from storage.\n", id)
 }
 
-func getSellerInfo(rpcClient jsonrpc.RPCClient, env Environment, id string) {
+func getSellerInfo(env Environment, id string) {
 
 	arg := localjsonrpc.SellerArg{
 		ID: id,
 	}
 
 	var reply localjsonrpc.SellerReply
-	if err := rpcClient.CallFor(&reply, "OpsService.Seller", arg); err != nil {
+	if err := makeRPCCall(env, &reply, "OpsService.Seller", arg); err != nil {
 		handleJSONRPCError(env, err)
 	}
 
@@ -101,7 +100,6 @@ func getSellerInfo(rpcClient jsonrpc.RPCClient, env Environment, id string) {
 }
 
 func updateSeller(
-	rpcClient jsonrpc.RPCClient,
 	env Environment,
 	sellerID string,
 	field string,
@@ -115,7 +113,7 @@ func updateSeller(
 		Field:    field,
 		Value:    value,
 	}
-	if err := rpcClient.CallFor(&emptyReply, "OpsService.UpdateSeller", args); err != nil {
+	if err := makeRPCCall(env, &emptyReply, "OpsService.UpdateSeller", args); err != nil {
 		fmt.Printf("%v\n", err)
 		return nil
 	}

--- a/cmd/next/session_dump.go
+++ b/cmd/next/session_dump.go
@@ -11,16 +11,15 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 	"google.golang.org/api/iterator"
 )
 
-func dumpSession(rpcClient jsonrpc.RPCClient, env Environment, sessionID uint64) {
+func dumpSession(env Environment, sessionID uint64) {
 
 	// make a call for all the relays (there is no relay "singular" endpoint)
 	var relaysReply localjsonrpc.RelaysReply
 	relaysArg := localjsonrpc.RelaysArgs{} // empty args returns all relays
-	if err := rpcClient.CallFor(&relaysReply, "OpsService.Relays", relaysArg); err != nil {
+	if err := makeRPCCall(env, &relaysReply, "OpsService.Relays", relaysArg); err != nil {
 		handleJSONRPCError(env, err)
 	}
 
@@ -32,7 +31,7 @@ func dumpSession(rpcClient jsonrpc.RPCClient, env Environment, sessionID uint64)
 	// make a call for the datacenters
 	var dcsReply localjsonrpc.DatacentersReply
 	dcsArgs := localjsonrpc.DatacentersArgs{}
-	if err := rpcClient.CallFor(&dcsReply, "OpsService.Datacenters", dcsArgs); err != nil {
+	if err := makeRPCCall(env, &dcsReply, "OpsService.Datacenters", dcsArgs); err != nil {
 		handleJSONRPCError(env, err)
 	}
 	dcNames := make(map[int64]string)

--- a/cmd/next/sessions.go
+++ b/cmd/next/sessions.go
@@ -10,27 +10,26 @@ import (
 	"github.com/modood/table"
 	"github.com/networknext/backend/modules/routing"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 )
 
-func flushsessions(rpcClient jsonrpc.RPCClient, env Environment) {
+func flushsessions(env Environment) {
 	relaysargs := localjsonrpc.FlushSessionsArgs{}
 
 	var relaysreply localjsonrpc.FlushSessionsReply
-	if err := rpcClient.CallFor(&relaysreply, "BuyersService.FlushSessions", relaysargs); err != nil {
+	if err := makeRPCCall(env, &relaysreply, "BuyersService.FlushSessions", relaysargs); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
 }
 
-func sessions(rpcClient jsonrpc.RPCClient, env Environment, sessionID string, sessionCount int64) {
+func sessions(env Environment, sessionID string, sessionCount int64) {
 	if sessionID != "" {
 		args := localjsonrpc.SessionDetailsArgs{
 			SessionID: sessionID,
 		}
 
 		var reply localjsonrpc.SessionDetailsReply
-		if err := rpcClient.CallFor(&reply, "BuyersService.SessionDetails", args); err != nil {
+		if err := makeRPCCall(env, &reply, "BuyersService.SessionDetails", args); err != nil {
 			handleJSONRPCErrorCustom(env, err, "Session not found")
 			return
 		}
@@ -240,15 +239,15 @@ func sessions(rpcClient jsonrpc.RPCClient, env Environment, sessionID string, se
 
 		return
 	}
-	sessionsByBuyer(rpcClient, env, "", sessionCount)
+	sessionsByBuyer(env, "", sessionCount)
 }
 
-func sessionsByBuyer(rpcClient jsonrpc.RPCClient, env Environment, buyerName string, sessionCount int64) {
+func sessionsByBuyer(env Environment, buyerName string, sessionCount int64) {
 
 	buyerArgs := localjsonrpc.BuyersArgs{}
 
 	var buyersReply localjsonrpc.BuyersReply
-	if err := rpcClient.CallFor(&buyersReply, "OpsService.Buyers", buyerArgs); err != nil {
+	if err := makeRPCCall(env, &buyersReply, "OpsService.Buyers", buyerArgs); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}
@@ -269,7 +268,7 @@ func sessionsByBuyer(rpcClient jsonrpc.RPCClient, env Environment, buyerName str
 	}
 
 	var topSessionsReply localjsonrpc.TopSessionsReply
-	if err := rpcClient.CallFor(&topSessionsReply, "BuyersService.TopSessions", topSessionArgs); err != nil {
+	if err := makeRPCCall(env, &topSessionsReply, "BuyersService.TopSessions", topSessionArgs); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}

--- a/cmd/next/ssh.go
+++ b/cmd/next/ssh.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-
-	"github.com/ybbus/jsonrpc"
 )
 
 func testForSSHKey(env Environment) {
@@ -18,14 +16,14 @@ func testForSSHKey(env Environment) {
 	}
 }
 
-func SSHInto(env Environment, rpcClient jsonrpc.RPCClient, relayName string) {
+func SSHInto(env Environment, relayName string) {
 
 	riot := false
 	if strings.Split(relayName, ".")[0] == "riot" {
 		riot = true
 	}
 
-	relays := getRelayInfo(rpcClient, env, relayName)
+	relays := getRelayInfo(env, relayName)
 	if len(relays) == 0 {
 		handleRunTimeError(fmt.Sprintf("no relays matches the regex '%s'\n", relayName), 0)
 	}

--- a/cmd/next/validate.go
+++ b/cmd/next/validate.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/networknext/backend/modules/routing"
 	localjsonrpc "github.com/networknext/backend/modules/transport/jsonrpc"
-	"github.com/ybbus/jsonrpc"
 )
 
-func validate(rpcClient jsonrpc.RPCClient, env Environment, relaysStateShowFlags [6]bool, relaysStateHideFlags [6]bool, inputFile string) {
+func validate(env Environment, relaysStateShowFlags [6]bool, relaysStateHideFlags [6]bool, inputFile string) {
 	file, err := os.Open(inputFile)
 	if err != nil {
 		handleRunTimeError(fmt.Sprintf("could not open the route matrix file for reading: %v\n", err), 1)
@@ -22,12 +21,12 @@ func validate(rpcClient jsonrpc.RPCClient, env Environment, relaysStateShowFlags
 	}
 
 	var relayReply localjsonrpc.RelaysReply
-	if err := rpcClient.CallFor(&relayReply, "OpsService.Relays", localjsonrpc.RelaysArgs{}); err != nil {
+	if err := makeRPCCall(env, &relayReply, "OpsService.Relays", localjsonrpc.RelaysArgs{}); err != nil {
 		handleJSONRPCError(env, err)
 	}
 
 	var dcReply localjsonrpc.DatacentersReply
-	if err := rpcClient.CallFor(&dcReply, "OpsService.Datacenters", localjsonrpc.DatacentersArgs{}); err != nil {
+	if err := makeRPCCall(env, &dcReply, "OpsService.Datacenters", localjsonrpc.DatacentersArgs{}); err != nil {
 		handleJSONRPCError(env, err)
 		return
 	}


### PR DESCRIPTION
This PR does two main things:

1. On auth failure, refresh the auth token and try the call again
2. Automatically fetch an auth token if one does not exist in the environment

I left `./next auth` in as a "force refresh" of sorts but it can be removed if everyone thinks it is unnecessary.

This change effects ever next tool call so it should be thoroughly tested locally and in dev

Closes #2575 