### PR TITLE
Only log errors from gcloud util

### DIFF
--- a/modules/storage/gcp_storage.go
+++ b/modules/storage/gcp_storage.go
@@ -87,7 +87,7 @@ func (g *GCPStorage) CopyFromBytesToRemote(inputBytes []byte, instanceNames []st
 	var loopError error
 	for _, name := range instanceNames {
 		// Call gsutil to copy the tmp file over to the instance
-		runnable := exec.Command("gcloud", "compute", "scp", "--zone", "us-central1-a", outputFileName, fmt.Sprintf("%s:%s", name, outputFileName))
+		runnable := exec.Command("gcloud", "compute", "scp", "--zone", "us-central1-a", "--verbosity", "error", outputFileName, fmt.Sprintf("%s:%s", name, outputFileName))
 
 		buffer, err := runnable.CombinedOutput()
 		level.Debug(g.Logger).Log("msg", buffer)
@@ -143,7 +143,7 @@ func (g *GCPStorage) CopyFromBucketToRemote(ctx context.Context, artifactName st
 	var loopError error
 	for _, name := range instanceNames {
 		// Call gsutil to copy the tmp file over to the instance
-		runnable := exec.Command("gcloud", "compute", "scp", "--zone", "us-central1-a", outputFileName, fmt.Sprintf("%s:%s", name, outputFileName))
+		runnable := exec.Command("gcloud", "compute", "scp", "--zone", "us-central1-a", "--verbosity", "error", outputFileName, fmt.Sprintf("%s:%s", name, outputFileName))
 
 		buffer, err := runnable.CombinedOutput()
 


### PR DESCRIPTION
Gcloud was crashing the relay pusher VM because it logs every transaction and accumulated 5GB of logs in the last month so this PR disables all logs other than error logs.