### PR TITLE
Inject session ID into ghost army map point data

### DIFF
--- a/cmd/ghost_army/ghost_army.go
+++ b/cmd/ghost_army/ghost_army.go
@@ -178,7 +178,6 @@ func main() {
 		for {
 			select {
 			case slice := <-publishChan:
-				slice.Point.SessionID = slice.Meta.ID
 				sessionBytes, err := slice.MarshalBinary()
 				if err != nil {
 					fmt.Printf("could not marshal binary for slice session id %d", slice.Meta.ID)

--- a/modules/ghost_army/types.go
+++ b/modules/ghost_army/types.go
@@ -347,5 +347,6 @@ func (self *Entry) Into(data *transport.SessionPortalData, dcmap DatacenterMap, 
 		pt := &data.Point
 		pt.Latitude = self.Latitude
 		pt.Longitude = self.Longitude
+		pt.SessionID = uint64(self.SessionID)
 	}
 }


### PR DESCRIPTION
The ghost army data was generated prior to the map points containing a session ID. This PR grabs the session ID from the session meta and adds it to the map point struct.