### PR TITLE
Hotfix - add logging statement for unread billing entry bytes

### DIFF
--- a/modules/billing/pubsub_forwarder.go
+++ b/modules/billing/pubsub_forwarder.go
@@ -144,6 +144,7 @@ func (psf *PubSubForwarder) Forward2(ctx context.Context, wg *sync.WaitGroup) {
 				m.Ack()
 			} else {
 				level.Error(psf.Logger).Log("msg", "could not read billing entry 2", "err", err)
+				level.Error(psf.Logger).Log("msg", "bytes for unread entry", "bytes", fmt.Sprintf("%+v", entries[i]))
 
 				entryVetoStr := os.Getenv("BILLING_ENTRY_VETO")
 				entryVeto, err := strconv.ParseBool(entryVetoStr)


### PR DESCRIPTION
There is a log that tells me there is a serialization error for some billing2 entries, but I cannot figure out what exactly is wrong with the serialization (write works fine, read does not). This logging statement will let me figure out where the error in the serialization lies (i.e. `MaxBillingEntry2Bytes` is not accurate).