### PR TITLE
Remove duplicate addition from total sessions calculations

### DIFF
--- a/modules/transport/jsonrpc/buyer_test.go
+++ b/modules/transport/jsonrpc/buyer_test.go
@@ -704,7 +704,7 @@ func TestTotalSessionsWithGhostArmy(t *testing.T) {
 		err := svc.TotalSessions(req, &jsonrpc.TotalSessionsArgs{}, &reply)
 		assert.NoError(t, err)
 
-		assert.Equal(t, 8, reply.Next)
+		assert.Equal(t, 7, reply.Next)
 		assert.Equal(t, 250, reply.Direct)
 	})
 
@@ -714,8 +714,8 @@ func TestTotalSessionsWithGhostArmy(t *testing.T) {
 		err := svc.TotalSessions(req, &jsonrpc.TotalSessionsArgs{CompanyCode: "local"}, &reply)
 		assert.NoError(t, err)
 
-		assert.Equal(t, 6, reply.Next)
-		assert.Equal(t, 300, reply.Direct)
+		assert.Equal(t, 5, reply.Next)
+		assert.Equal(t, 250, reply.Direct)
 	})
 }
 


### PR DESCRIPTION
In the total sessions calculations, ghost army numbers were being added unscaled, scaled and then added again. This PR removes that extra addition to make debugging the difference between filtered and unfiltered numbers easier. This will lower overall numbers so the scaling factor may need to be increased to compensate for the reduction. I will know more when this goes to dev.