### PR TITLE
Relay pusher missing City file fix

### DIFF
--- a/cmd/relay_pusher/relay_pusher.go
+++ b/cmd/relay_pusher/relay_pusher.go
@@ -188,13 +188,13 @@ func mainReturnWithCode() int {
 	}
 
 	ispStorageName := envvar.Get("MAXMIND_ISP_STORAGE_FILE_NAME", "")
-	if ispFileName == "" {
+	if ispStorageName == "" {
 		level.Error(logger).Log("err", "MAXMIND_ISP_STORAGE_FILE_NAME not defined", "err")
 		return 1
 	}
 
 	cityStorageName := envvar.Get("MAXMIND_CITY_STORAGE_FILE_NAME", "")
-	if cityFileName == "" {
+	if cityStorageName == "" {
 		level.Error(logger).Log("err", "MAXMIND_CITY_STORAGE_FILE_NAME not defined", "err")
 		return 1
 	}
@@ -364,15 +364,14 @@ func mainReturnWithCode() int {
 					}
 				}
 
-				if err := gcpStorage.CopyFromBytesToRemote(buf.Bytes(), maxmindInstanceNames, cityFileName); err != nil {
-					level.Error(logger).Log("msg", "failed to copy maxmind city file to server backends", "err", err)
-					relayPusherServiceMetrics.RelayPusherMetrics.ErrorMetrics.MaxmindSCPWriteFailure.Add(1)
-					continue
-				}
-
 				if err := gcpStorage.CopyFromBytesToStorage(ctx, buf.Bytes(), cityStorageName); err != nil {
 					level.Error(logger).Log("msg", "failed to copy maxmind City file to gcp cloud storage", "err", err)
 					relayPusherServiceMetrics.RelayPusherMetrics.ErrorMetrics.MaxmindStorageUploadFailureCity.Add(1)
+				}
+
+				if err := gcpStorage.CopyFromBytesToRemote(buf.Bytes(), maxmindInstanceNames, cityFileName); err != nil {
+					level.Error(logger).Log("msg", "failed to copy maxmind city file to server backends", "err", err)
+					relayPusherServiceMetrics.RelayPusherMetrics.ErrorMetrics.MaxmindSCPWriteFailure.Add(1)
 					continue
 				}
 

--- a/modules/storage/gcp_storage.go
+++ b/modules/storage/gcp_storage.go
@@ -53,6 +53,8 @@ func (g *GCPStorage) CopyFromBytesToStorage(ctx context.Context, inputBytes []by
 	// Create an object writer
 	writer := g.Bucket.Object(outputFileName).NewWriter(ctx)
 
+	writer.ObjectAttrs.ContentType = "application/octet-stream"
+
 	// Write to the file
 	if _, err := writer.Write(inputBytes); err != nil {
 		err = fmt.Errorf("failed to write to bucket object: %v", err)


### PR DESCRIPTION
There was a bug where the maxmind city file wasn't being uploaded and it was due to the call before erroring out when it tried to upload to the debug server backend in dev. This machine is off so the city file would never be uploaded. I changed the flow to always upload to storage no matter what happens with the instance uploads. Also I updated the content type of the upload to be an octet-stream because the GCP client was mislabeling it as an image.