### PR TITLE
Potential fix for relay backend crashing

### DIFF
--- a/modules/routing/stats_database.go
+++ b/modules/routing/stats_database.go
@@ -94,19 +94,19 @@ func NewStatsEntryRelay() *StatsEntryRelay {
 	return entry
 }
 
-func (sdb *StatsDatabase) ExtractPingStats(maxJitter float32, maxPacketLoss float32, instanceID string, isDebug bool) []analytics.PingStatsEntry {
-	sdb.mu.Lock()
-	length := TriMatrixLength(len(sdb.Entries))
+func (database *StatsDatabase) ExtractPingStats(maxJitter float32, maxPacketLoss float32, instanceID string, isDebug bool) []analytics.PingStatsEntry {
+	database.mu.Lock()
+	length := TriMatrixLength(len(database.Entries))
 	entries := make([]analytics.PingStatsEntry, length)
 
-	ids := make([]uint64, len(sdb.Entries))
+	ids := make([]uint64, len(database.Entries))
 
 	idx := 0
-	for k := range sdb.Entries {
+	for k := range database.Entries {
 		ids[idx] = k
 		idx++
 	}
-	sdb.mu.Unlock()
+	database.mu.Unlock()
 
 	if length == 0 {
 		return entries
@@ -117,7 +117,7 @@ func (sdb *StatsDatabase) ExtractPingStats(maxJitter float32, maxPacketLoss floa
 			idA := ids[i]
 			idB := ids[j]
 
-			rtt, jitter, pl := sdb.GetSample(idA, idB)
+			rtt, jitter, pl := database.GetSample(idA, idB)
 			routable := rtt != InvalidRouteValue && jitter != InvalidRouteValue && pl != InvalidRouteValue
 
 			if jitter > maxJitter {

--- a/modules/routing/stats_database_test.go
+++ b/modules/routing/stats_database_test.go
@@ -5,12 +5,11 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/networknext/backend/modules/crypto"
 	"github.com/networknext/backend/modules/routing"
 	"github.com/stretchr/testify/assert"
 )
 
-// todo: not today
-/*
 func TestHistory(t *testing.T) {
 	t.Run("HistoryMax()", func(t *testing.T) {
 		t.Run("returns the max value in the array", func(t *testing.T) {
@@ -29,13 +28,6 @@ func TestHistory(t *testing.T) {
 		})
 	})
 
-	t.Run("HistoryMean()", func(t *testing.T) {
-		t.Run("returns a float32 that is the average of the input", func(t *testing.T) {
-			history := []float32{1, 2, 3, 4, 5, 4, 3, 2, 1}
-			assert.Equal(t, float32(25.0/9.0), routing.HistoryMean(history))
-		})
-	})
-
 	t.Run("Old tests", func(t *testing.T) {
 		t.Run("TestHistoryMax()", func(t *testing.T) {
 
@@ -50,21 +42,6 @@ func TestHistory(t *testing.T) {
 			history[2] = 100.0
 
 			assert.Equal(t, float32(100.0), routing.HistoryMax(history[:]))
-		})
-
-		t.Run("TestHistoryMean", func(t *testing.T) {
-
-			t.Parallel()
-
-			history := routing.HistoryNotSet()
-
-			assert.Equal(t, float32(0.0), routing.HistoryMean(history[:]))
-
-			history[0] = 5.0
-			history[1] = 3.0
-			history[2] = 100.0
-
-			assert.Equal(t, float32(36.0), routing.HistoryMean(history[:]))
 		})
 	})
 }
@@ -145,7 +122,7 @@ func TestStatsDatabase(t *testing.T) {
 			entry := routing.NewStatsEntry()
 			statsEntry1 := makeBasicStats()
 			entry.Relays[relay1ID] = statsEntry1
-			statsdb.Entries[update.ID] = *entry
+			statsdb.Entries[update.ID] = entry
 
 			statsdb.ProcessStats(&update)
 
@@ -162,7 +139,7 @@ func TestStatsDatabase(t *testing.T) {
 			entry := routing.NewStatsEntry()
 			statsEntry1 := makeBasicStats()
 			entry.Relays[relay1ID] = statsEntry1
-			statsdb.Entries[sourceID] = *entry
+			statsdb.Entries[sourceID] = entry
 
 			cpy := statsdb.MakeCopy()
 
@@ -182,7 +159,7 @@ func TestStatsDatabase(t *testing.T) {
 		t.Run("entry exists but stats for the internal entry does not", func(t *testing.T) {
 			statsdb := routing.NewStatsDatabase()
 			entry := routing.NewStatsEntry()
-			statsdb.Entries[sourceID] = *entry
+			statsdb.Entries[sourceID] = entry
 
 			stats := statsdb.GetEntry(sourceID, relay1ID)
 
@@ -195,7 +172,7 @@ func TestStatsDatabase(t *testing.T) {
 			// this entry makes no sense, test puposes only
 			statsEntry1 := makeBasicStats()
 			entry.Relays[relay1ID] = statsEntry1
-			statsdb.Entries[sourceID] = *entry
+			statsdb.Entries[sourceID] = entry
 
 			stats := statsdb.GetEntry(sourceID, relay1ID)
 
@@ -211,12 +188,12 @@ func TestStatsDatabase(t *testing.T) {
 			statsEntryRelay := routing.NewStatsEntryRelay()
 			entry := routing.NewStatsEntry()
 			entry.Relays[id2] = statsEntryRelay
-			statsdb.Entries[id1] = *entry
+			statsdb.Entries[id1] = entry
 		}
 
 		t.Run("relay 1 -> relay 2 does not exist", func(t *testing.T) {
 			statsdb := routing.NewStatsDatabase()
-			statsdb.Entries[id1] = *routing.NewStatsEntry()
+			statsdb.Entries[id1] = routing.NewStatsEntry()
 			makeBasicConnection(statsdb, id2, id1)
 
 			rtt, jitter, packetLoss := statsdb.GetSample(id1, id2)
@@ -228,7 +205,7 @@ func TestStatsDatabase(t *testing.T) {
 
 		t.Run("relay 2 -> relay 1 does not exist", func(t *testing.T) {
 			statsdb := routing.NewStatsDatabase()
-			statsdb.Entries[id2] = *routing.NewStatsEntry()
+			statsdb.Entries[id2] = routing.NewStatsEntry()
 			makeBasicConnection(statsdb, id1, id2)
 
 			rtt, jitter, packetLoss := statsdb.GetSample(id1, id2)
@@ -256,8 +233,8 @@ func TestStatsDatabase(t *testing.T) {
 			entryForID1.Relays[id2] = statsForID2
 			entryForID2.Relays[id1] = statsForID1
 
-			statsdb.Entries[id1] = *entryForID1
-			statsdb.Entries[id2] = *entryForID2
+			statsdb.Entries[id1] = entryForID1
+			statsdb.Entries[id2] = entryForID2
 
 			rtt, jitter, packetLoss := statsdb.GetSample(id1, id2)
 
@@ -266,94 +243,199 @@ func TestStatsDatabase(t *testing.T) {
 			assert.Equal(t, float32(989.0), packetLoss)
 		})
 	})
+}
 
-	t.Run("GetCostMatrix()", func(t *testing.T) {
-		t.Run("returns the cost matrix", func(t *testing.T) {
-			statsdb := routing.NewStatsDatabase()
-			relayMap := routing.NewRelayMap(func(relayData routing.RelayData) error {
-				statsdb.DeleteEntry(relayData.ID)
-				return nil
-			})
-			// Setup
+func TestDeleteEntry(t *testing.T) {
+	db := routing.NewStatsDatabase()
+	sourceID := crypto.HashID("127.0.0.1")
+	relay1ID := crypto.HashID("127.9.9.9")
+	relay2ID := crypto.HashID("999.999.9.9")
 
-			fillRelayDatabase(relayMap)
-			fillStatsDatabase(statsdb)
+	update := routing.RelayStatsUpdate{
+		ID: sourceID,
+		PingStats: []routing.RelayStatsPing{
+			{
+				RelayID:    relay1ID,
+				RTT:        0.5,
+				Jitter:     0.7,
+				PacketLoss: 0.9,
+			},
+			{
+				RelayID:    relay2ID,
+				RTT:        0,
+				Jitter:     0,
+				PacketLoss: 0,
+			},
+		},
+	}
 
-			allRelayData := relayMap.GetAllRelayData()
+	t.Run("delete existing entry", func(t *testing.T) {
+		db.ProcessStats(&update)
 
-			i := 0
-			for _, r := range allRelayData {
-				if i == 0 {
-					r.Datacenter.ID = 0
-					relayMap.AddRelayDataEntry(r.Addr.String(), r)
-				} else {
-					r.Datacenter.ID = uint64(i)
-					relayMap.AddRelayDataEntry(r.Addr.String(), r)
-				}
-				i++
-			}
+		entry, ok := db.Entries[update.ID]
+		assert.True(t, ok)
+		assert.NotNil(t, entry.Relays)
 
-			modifyEntry := func(addr1, addr2 string, rtt, jitter, packetloss float32) {
-				entry := statsdb.GetEntry(crypto.HashID(addr1), crypto.HashID(addr2))
-				entry.RTT = rtt
-				entry.Jitter = jitter
-				entry.PacketLoss = packetloss
-			}
+		db.DeleteEntry(update.ID)
 
-			maxJitter := float32(10.0)
-			maxPacketLoss := float32(0.1)
+		entry, ok = db.Entries[update.ID]
+		assert.False(t, ok)
+		assert.Nil(t, entry)
+	})
 
-			// valid
-			modifyEntry("127.0.0.1:40000", "127.0.0.2:40000", 123.00, 1.3, 0.0)
-
-			// invalid - rtt = invalid route value
-			modifyEntry("127.0.0.1:40000", "127.0.0.3:40000", routing.InvalidRouteValue, 0.3, 0.0)
-
-			// invalid - jitter > MaxJitter
-			modifyEntry("127.0.0.1:40000", "127.0.0.4:40000", 1.0, maxJitter+1, 0.0)
-
-			// invalid - packet loss > MaxPacketLoss
-			modifyEntry("127.0.0.1:40000", "127.0.0.5:40000", 1.0, 0.3, maxPacketLoss+1)
-
-			relayIDs := make([]uint64, 0)
-			for _, relayData := range allRelayData {
-				relayIDs = append(relayIDs, relayData.ID)
-			}
-
-			costs := statsdb.GetCosts(relayIDs, maxJitter, maxPacketLoss)
-			assert.NotEmpty(t, costs)
-
-			// Testing
-			// assert that all non-invalid rtt's are within the cost matrix
-			getAddressIndex := func(addr1, addr2 string) int {
-				addr1ID := crypto.HashID(addr1)
-				addr2ID := crypto.HashID(addr2)
-				indxOfI := -1
-				indxOfJ := -1
-
-				for i, id := range relayIDs {
-					if uint64(id) == addr1ID {
-						indxOfI = i
-					} else if uint64(id) == addr2ID {
-						indxOfJ = i
-					}
-
-					if indxOfI != -1 && indxOfJ != -1 {
-						break
-					}
-				}
-
-				return routing.TriMatrixIndex(indxOfI, indxOfJ)
-			}
-
-			assert.Equal(t, int32(123), costs[getAddressIndex("127.0.0.1:40000", "127.0.0.2:40000")])
-			assert.Equal(t, int32(-1), costs[getAddressIndex("127.0.0.1:40000", "127.0.0.3:40000")])
-			assert.Equal(t, int32(-1), costs[getAddressIndex("127.0.0.1:40000", "127.0.0.4:40000")])
-			assert.Equal(t, int32(-1), costs[getAddressIndex("127.0.0.1:40000", "127.0.0.5:40000")])
-		})
+	t.Run("delete non existing entry", func(t *testing.T) {
+		db.DeleteEntry(update.ID)
 	})
 }
-*/
+
+func TestGetCosts(t *testing.T) {
+	db := routing.NewStatsDatabase()
+	sourceID := crypto.HashID("127.0.0.1")
+	relay1ID := crypto.HashID("127.9.9.9")
+	relay2ID := crypto.HashID("999.999.9.9")
+
+	update := routing.RelayStatsUpdate{
+		ID: sourceID,
+		PingStats: []routing.RelayStatsPing{
+			{
+				RelayID:    relay1ID,
+				RTT:        0.5,
+				Jitter:     0.7,
+				PacketLoss: 0.9,
+			},
+			{
+				RelayID:    relay2ID,
+				RTT:        0,
+				Jitter:     0,
+				PacketLoss: 0,
+			},
+		},
+	}
+
+	relayIDs := []uint64{
+		sourceID,
+		relay1ID,
+		relay2ID,
+	}
+
+	db.ProcessStats(&update)
+
+	costs := db.GetCosts(relayIDs, 5, 5)
+
+	expectedCosts := []int32{
+		-1,
+		-1,
+		-1,
+		1,
+	}
+
+	for i := 0; i < len(costs); i++ {
+		assert.Equal(t, expectedCosts[i], costs[i])
+	}
+}
+
+func TestGetCostsLocal(t *testing.T) {
+	db := routing.NewStatsDatabase()
+	sourceID := crypto.HashID("127.0.0.1")
+	relay1ID := crypto.HashID("127.9.9.9")
+	relay2ID := crypto.HashID("999.999.9.9")
+
+	update := routing.RelayStatsUpdate{
+		ID: sourceID,
+		PingStats: []routing.RelayStatsPing{
+			{
+				RelayID:    relay1ID,
+				RTT:        0.5,
+				Jitter:     0.7,
+				PacketLoss: 0.9,
+			},
+			{
+				RelayID:    relay2ID,
+				RTT:        0,
+				Jitter:     0,
+				PacketLoss: 0,
+			},
+		},
+	}
+
+	relayIDs := []uint64{
+		sourceID,
+		relay1ID,
+		relay2ID,
+	}
+
+	db.ProcessStats(&update)
+
+	costs := db.GetCostsLocal(relayIDs, 0, 0)
+
+	for i := 0; i < len(costs); i++ {
+		assert.Equal(t, int32(0), costs[i])
+	}
+}
+
+func TestTriMatrixLength(t *testing.T) {
+	t.Run("size of 0", func(t *testing.T) {
+		length := routing.TriMatrixLength(0)
+		assert.Equal(t, 0, length)
+	})
+
+	t.Run("size of 1", func(t *testing.T) {
+		length := routing.TriMatrixLength(1)
+		assert.Equal(t, 0, length)
+	})
+
+	t.Run("size of 2", func(t *testing.T) {
+		length := routing.TriMatrixLength(2)
+		assert.Equal(t, 1, length)
+	})
+
+	t.Run("size of 5", func(t *testing.T) {
+		length := routing.TriMatrixLength(5)
+		assert.Equal(t, 10, length)
+	})
+
+	t.Run("size of 10", func(t *testing.T) {
+		length := routing.TriMatrixLength(10)
+		assert.Equal(t, 45, length)
+	})
+
+	t.Run("size of 27", func(t *testing.T) {
+		length := routing.TriMatrixLength(27)
+		assert.Equal(t, 351, length)
+	})
+
+	t.Run("size of 138", func(t *testing.T) {
+		length := routing.TriMatrixLength(138)
+		assert.Equal(t, 9453, length)
+	})
+
+	t.Run("size of 2148", func(t *testing.T) {
+		length := routing.TriMatrixLength(2148)
+		assert.Equal(t, 2305878, length)
+	})
+}
+
+func TestTriMatrixIndex(t *testing.T) {
+	t.Run("index at 0,0", func(t *testing.T) {
+		index := routing.TriMatrixIndex(0, 0)
+		assert.Equal(t, 0, index)
+	})
+
+	t.Run("index i > j", func(t *testing.T) {
+		index := routing.TriMatrixIndex(10, 20)
+		assert.Equal(t, 200, index)
+	})
+
+	t.Run("index i < j", func(t *testing.T) {
+		index := routing.TriMatrixIndex(20, 10)
+		assert.Equal(t, 200, index)
+	})
+
+	t.Run("index i == j", func(t *testing.T) {
+		index := routing.TriMatrixIndex(20, 20)
+		assert.Equal(t, 210, index)
+	})
+}
 
 func TestExtractPingStats(t *testing.T) {
 	numRelays := 10


### PR DESCRIPTION
This PR is to fix the issue defined in #3279 

The running theory for this PR is that the size of the stats DB entries can change between the time the length was calculated and the time the IDs were defined causing the "off by one" error we saw crash the relay backend.

The PR addresses the issue by wrapping both the length calculation and the IDs definition in the same mutex to make sure that the same version of the stats DB is being used.

Closes #3279 