### PR TITLE
Make the gist release notes headers fully dynamic

### DIFF
--- a/modules/transport/jsonrpc/buyer.go
+++ b/modules/transport/jsonrpc/buyer.go
@@ -2644,7 +2644,7 @@ func (s *BuyersService) FetchReleaseNotes() error {
 		embedHTML = strings.ReplaceAll(embedHTML, "\\", "")
 
 		notification := notifications.NewReleaseNotesNotification()
-		notification.Title = fmt.Sprintf("Service updates for the month of %s", list.GetDescription())
+		notification.Title = list.GetDescription()
 		notification.EmbedHTML = embedHTML
 		notification.CSSURL = cssURL
 


### PR DESCRIPTION
The release notes card headers originally had a hard coded string attached to the gist description which would make it hard to customize the headers in the future. This PR changes it so that the description of the gist is the header for the card giving more range for customization.

Example use case: We want the card header to say something other than "service updates for the month of X". Someone would need to go into the backend and change the hard coded "service updates for the month of " piece which would in turn screw up all the existing card headers.