### PR TITLE
Build Post Route Relay Data before Total Price Calc

### DIFF
--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -1250,6 +1250,15 @@ func SessionPost(state *SessionHandlerState) {
 	}
 
 	/*
+		Build route relay data (for portal, billing etc...).
+
+		This is done here to get the post route relay sellers egress price override for 
+		calculating total price and route relay price when building the billing entry.
+	*/
+
+	BuildPostRouteRelayData(state)
+
+	/*
 		Each slice is 10 seconds long except for the first slice with a given network next route,
 		which is 20 seconds long. Each time we change network next route, we burn the 10 second tail
 		that we pre-bought at the start of the previous route.
@@ -1339,12 +1348,6 @@ func SessionPost(state *SessionHandlerState) {
 			}
 		}
 	*/
-
-	/*
-		Build route relay data (for portal, billing etc...)
-	*/
-
-	BuildPostRouteRelayData(state)
 
 	/*
 		Build post near relay data (for portal, billing etc...)


### PR DESCRIPTION
Relay Egress Price Override wasn't being used when calculating total price because we were creating the `PostRouteRelayEgressPriceOverride` after the total price calculation. Moving it before the total price calculation ensures that egress override price will be used in that calculation. 