### PR TITLE
Add endpoint to get relays with egress price override per seller

### DIFF
--- a/modules/transport/jsonrpc/ops.go
+++ b/modules/transport/jsonrpc/ops.go
@@ -756,10 +756,7 @@ func (s *OpsService) RelaysWithEgressPriceOverride(r *http.Request, args *RelayE
 
 	for _, r := range s.Storage.Relays(r.Context()) {
 
-		if r.Seller.ShortName != args.SellerShortName {
-			continue
-		}
-		if r.EgressPriceOverride <= 0 {
+		if !(r.Seller.ShortName == args.SellerShortName && r.EgressPriceOverride > 0) {
 			continue
 		}
 


### PR DESCRIPTION
Adds an endpoint to the ops service to return a list of relays with an egress price override for the provided seller.