### PR TITLE
Hotfix - Fix everOnNext Flag for Billing2

### DIFF
--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -1222,10 +1222,20 @@ func SessionPost(state *SessionHandlerState) {
 	if state.Response.RouteType != routing.RouteTypeDirect {
 		core.Debug("session takes network next")
 		state.Metrics.NextSlices.Add(1)
-		state.Output.EverOnNext = true
 	} else {
 		core.Debug("session goes direct")
 		state.Metrics.DirectSlices.Add(1)
+	}
+
+	/*
+		Decide if the session was ever on next.
+
+		We avoid using route type to verify if a session was ever on next
+		in case the route decision to take next was made on the final slice.
+	*/
+
+	if state.Packet.Next {
+		state.Output.EverOnNext = true
 	}
 
 	/*
@@ -1252,7 +1262,7 @@ func SessionPost(state *SessionHandlerState) {
 	/*
 		Build route relay data (for portal, billing etc...).
 
-		This is done here to get the post route relay sellers egress price override for 
+		This is done here to get the post route relay sellers egress price override for
 		calculating total price and route relay price when building the billing entry.
 	*/
 


### PR DESCRIPTION
@alexander-pan noticed that the `everOnNext` flag was true for sessions that never had a slice on next.

Turns out the flag could be set to true if the backend decided the session should take next on the final slice of the session. Despite the client ping timing out, the session would still have been marked as having been on next.

We can fix this by setting the flag to true if the previous slice for the session was on next. That way we can for sure say the session was on next at some point.

We did not notice this before because the early out from the client ping timing out would not send billing and portal data entries, but with the summary slice in billing2, it is possible for this edge case to occur.