### PR TITLE
Add Client IP Address to First and Summary Slice

### DIFF
--- a/modules/billing/billing_entry_test.go
+++ b/modules/billing/billing_entry_test.go
@@ -85,6 +85,7 @@ func getTestBillingEntry2() *billing.BillingEntry2 {
 		EnvelopeBytesUp:                 rand.Uint64(),
 		Latitude:                        rand.Float32(),
 		Longitude:                       rand.Float32(),
+		ClientAddress:                   generateRandomStringSequence(billing.BillingEntryMaxAddressLength - 1),
 		ISP:                             generateRandomStringSequence(billing.BillingEntryMaxISPLength - 1),
 		ConnectionType:                  int32(rand.Intn(3)),
 		PlatformType:                    int32(rand.Intn(10)),
@@ -807,6 +808,20 @@ func TestSerializeBillingEntry2_Clamp(t *testing.T) {
 	})
 
 	t.Run("test first slice", func(t *testing.T) {
+
+		t.Run("client IP address length", func(t *testing.T) {
+			entry = getTestBillingEntry2()
+			entry.SliceNumber = 0
+			clientAddrStr := generateRandomStringSequence(billing.BillingEntryMaxAddressLength + 1)
+			assert.Equal(t, billing.BillingEntryMaxAddressLength+1, len(clientAddrStr))
+			entry.ClientAddress = clientAddrStr
+
+			data, readEntry, err = writeReadClampBillingEntry2(entry)
+			assert.NotEmpty(t, data)
+			assert.NoError(t, err)
+			assert.NotEqual(t, entry, readEntry)
+			assert.Equal(t, clientAddrStr[:billing.BillingEntryMaxAddressLength-1], readEntry.ClientAddress)
+		})
 
 		t.Run("isp length", func(t *testing.T) {
 			entry = getTestBillingEntry2()

--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -1743,6 +1743,7 @@ func BuildBillingEntry2(state *SessionHandlerState, sliceDuration uint64, nextEn
 		EnvelopeBytesUp:                 nextEnvelopeBytesUp,
 		Latitude:                        float32(state.Input.Location.Latitude),
 		Longitude:                       float32(state.Input.Location.Longitude),
+		ClientAddress:                   state.Packet.ClientAddress.String(),
 		ISP:                             state.Input.Location.ISP,
 		ConnectionType:                  int32(state.Packet.ConnectionType),
 		PlatformType:                    int32(state.Packet.PlatformType),


### PR DESCRIPTION
Request from @alexander-pan and @gafferongames to add the client IP address to the first and summary slice.

The client IP address is anonymized by the server before it is sent to the server backend, so there aren't any privacy issues.

TODO:
Add "clientAddress" as a string to billing2 schema across all envs.