### PR TITLE
Move IP lookup to Pre session handler

### DIFF
--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -616,13 +616,15 @@ func SessionPre(state *SessionHandlerState) bool {
 		return true
 	}
 
-	state.Output.Location, err = state.IpLocator.LocateIP(state.Packet.ClientAddress.IP)
+	if state.Input.Initial {
+		state.Output.Location, err = state.IpLocator.LocateIP(state.Packet.ClientAddress.IP)
 
-	if err != nil || state.Output.Location == routing.LocationNullIsland {
-		core.Debug("location veto")
-		state.Metrics.ClientLocateFailure.Add(1)
-		state.Output.RouteState.LocationVeto = true
-		return true
+		if err != nil || state.Output.Location == routing.LocationNullIsland {
+			core.Debug("location veto")
+			state.Metrics.ClientLocateFailure.Add(1)
+			state.Output.RouteState.LocationVeto = true
+			return true
+		}
 	}
 
 	if !datacenterExists(state.Database, state.Packet.DatacenterID) {

--- a/modules/transport/server_handlers_test.go
+++ b/modules/transport/server_handlers_test.go
@@ -732,6 +732,8 @@ func TestSessionUpdateHandlerFunc_Pre_LocationVeto(t *testing.T) {
 	requestData := env.GenerateEmptySessionUpdatePacket(privateKey)
 	state.PacketData = requestData
 
+	state.Input.Initial = true
+
 	state.IpLocator = &errLocator{}
 
 	transport.SessionPre(&state)


### PR DESCRIPTION
This PR moves the client IP lookup to the pre session handler so that we are still able to get the client's location even if there is an issue with the server's datacenter.