### PR TITLE
Add missing billing fields to session dump

### DIFF
--- a/cmd/next/bigquery_data.go
+++ b/cmd/next/bigquery_data.go
@@ -117,6 +117,7 @@ type BigQueryBilling2Entry struct {
 	EnvelopeBytesDown bigquery.NullInt64
 	Latitude          bigquery.NullFloat64
 	Longitude         bigquery.NullFloat64
+	ClientAddress     bigquery.NullString
 	ISP               bigquery.NullString
 	ConnectionType    bigquery.NullInt64
 	PlatformType      bigquery.NullInt64
@@ -142,6 +143,7 @@ type BigQueryBilling2Entry struct {
 	TotalPriceSum                   bigquery.NullInt64
 	EnvelopeBytesUpSum              bigquery.NullInt64
 	EnvelopeBytesDownSum            bigquery.NullInt64
+	DurationOnNext                  bigquery.NullInt64
 
 	// network next only
 

--- a/cmd/next/session_dump.go
+++ b/cmd/next/session_dump.go
@@ -856,6 +856,7 @@ func dumpSession2(env Environment, sessionID uint64) {
 		"EnvelopeBytesDown",
 		"Latitude",
 		"Longitude",
+		"ClientAddress",
 		"ISP",
 		"ConnectionType",
 		"PlatformType",
@@ -878,6 +879,7 @@ func dumpSession2(env Environment, sessionID uint64) {
 		"TotalPriceSum",
 		"EnvelopeBytesUpSum",
 		"EnvelopeBytesDownSum",
+		"DurationOnNext",
 		"NextRTT",
 		"NextJitter",
 		"NextPacketLoss",
@@ -1245,6 +1247,16 @@ func dumpSession2(env Environment, sessionID uint64) {
 		if billingEntry.EnvelopeBytesDownSum.Valid {
 			envelopeBytesDownSum = fmt.Sprintf("%d", billingEntry.EnvelopeBytesDownSum.Int64)
 		}
+		// DurationOnNext
+		durationOnNext := ""
+		if billingEntry.DurationOnNext.Valid {
+			durationOnNext = fmt.Sprintf("%d", billingEntry.DurationOnNext.Int64)
+		}
+		// ClientAddress
+		clientAddress := ""
+		if billingEntry.ClientAddress.Valid {
+			clientAddress = billingEntry.ClientAddress.StringVal
+		}
 
 		bqBilling2DataEntryCSV = append(bqBilling2DataEntryCSV, []string{
 			timestamp,
@@ -1266,6 +1278,7 @@ func dumpSession2(env Environment, sessionID uint64) {
 			envelopeBytesDown,
 			latitude,
 			longitude,
+			clientAddress,
 			isp,
 			connectionType,
 			platformType,
@@ -1288,6 +1301,7 @@ func dumpSession2(env Environment, sessionID uint64) {
 			totalPriceSum,
 			envelopeBytesUpSum,
 			envelopeBytesDownSum,
+			durationOnNext,
 			nextRTT,
 			nextJitter,
 			nextPacketLoss,
@@ -1417,7 +1431,9 @@ func GetAllSessionBilling2Info(sessionID int64, env Environment) ([]BigQueryBill
 	sessionDuration,
 	totalPriceSum,
 	envelopeBytesUpSum,
-	envelopeBytesDownSum
+	envelopeBytesDownSum,
+	durationOnNext,
+	clientAddress,
     from `))
 
 	if env.Name != "prod" && env.Name != "dev" && env.Name != "staging" {


### PR DESCRIPTION
Forgot to add `ClientAddress` and `DurationOnNext` to `next session dump`.