### PR TITLE
Clean up API Service

### DIFF
--- a/cmd/analytics/analytics.go
+++ b/cmd/analytics/analytics.go
@@ -196,8 +196,8 @@ func mainReturnWithCode() int {
 	// Setup the status handler info
 	type AnalyticsStatus struct {
 		// Service Information
-		ServiceName string `json:"serviceName"`
-		GitHash     string `json:"gitHash"`
+		ServiceName string `json:"service_name"`
+		GitHash     string `json:"git_hash"`
 		Started     string `json:"started"`
 		Uptime      string `json:"uptime"`
 

--- a/cmd/analytics_pusher/analytics_pusher.go
+++ b/cmd/analytics_pusher/analytics_pusher.go
@@ -183,8 +183,8 @@ func mainReturnWithCode() int {
 	// Setup the status handler info
 	type AnalyticsPusherStatus struct {
 		// Service Information
-		ServiceName string `json:"serviceName"`
-		GitHash     string `json:"gitHash"`
+		ServiceName string `json:"service_name"`
+		GitHash     string `json:"git_hash"`
 		Started     string `json:"started"`
 		Uptime      string `json:"uptime"`
 

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -268,8 +268,8 @@ func mainReturnWithCode() int {
 	// Setup the status handler info
 	type APIStatus struct {
 		// Service Information
-		ServiceName string `json:"serviceName"`
-		GitHash     string `json:"gitHash"`
+		ServiceName string `json:"service_name"`
+		GitHash     string `json:"git_hash"`
 		Started     string `json:"started"`
 		Uptime      string `json:"uptime"`
 


### PR DESCRIPTION
This PR cleans up the API service.

We need to still remove the gokit logger from vanity metrics service, so once that's done, we can completely get rid of it from the API service.

Closes #3424 