### PR TITLE
Small bug fix for user sessions look up

### DIFF
--- a/modules/transport/jsonrpc/buyer.go
+++ b/modules/transport/jsonrpc/buyer.go
@@ -317,6 +317,9 @@ func (s *BuyersService) UserSessions(r *http.Request, args *UserSessionsArgs, re
 				return err
 			}
 		}
+	} else {
+		// This is only for situations where Bigtable isn't being used (local dev)
+		reply.Page = MaxBigTableDays
 	}
 
 	// Sort the sessions by timestamp


### PR DESCRIPTION
Calling `FetchCurrentTopSessions` would anonymize the session meta data which would cause errors when looking up the session buyer information using an anonymized buyer ID in the `UserSessions` "live sessions" loop.

This adds a flag to the `FetchCurrentTopSessions` to allow for it to be used normally with the `TopSessions` endpoint but also to be used in the `UserSessions` endpoint without running into hard errors.