### PR TITLE
Roadmap issue 73 support

### DIFF
--- a/modules/transport/jsonrpc/buyer.go
+++ b/modules/transport/jsonrpc/buyer.go
@@ -2863,6 +2863,13 @@ func (s *BuyersService) FetchUsageSummaryDashboard(r *http.Request, args *FetchU
 		return &err
 	}
 
+	if args.Origin == "" {
+		err := JSONRPCErrorCodes[int(ERROR_MISSING_FIELD)]
+		err.Data.(*JSONRPCErrorData).MissingField = "Origin"
+		s.Logger.Log("err", fmt.Errorf("FetchUsageSummaryDashboard(): %v: Origin is required", err.Error()))
+		return &err
+	}
+
 	user := r.Context().Value(middleware.Keys.UserKey)
 	if user == nil {
 		err := JSONRPCErrorCodes[int(ERROR_JWT_PARSE_FAILURE)]


### PR DESCRIPTION
This PR adds support for sending a year-month string to the backend to support URLs similar to "portal.networknext.com/explore/usage/2021-09". This idea can be used to tap into the "Billing Period" filter on looker dashboards. It could also be extended to support any filter within Looker by swapping out the filter name in the query string attached the Looker dashboard URI.

https://github.com/networknext/roadmap/issues/73