### PR TITLE
Fix Status Format

### DIFF
--- a/modules/transport/jsonrpc/relay_fleet.go
+++ b/modules/transport/jsonrpc/relay_fleet.go
@@ -253,7 +253,7 @@ func (rfs *RelayFleetService) GetServiceURI(serviceName string) (string, error) 
 		}
 		serviceURI = fmt.Sprintf("http://%s/status", instanceInternalIP)
 	case "AnalyticsPusher":
-		serviceURI = rfs.AnalyticsPusherURI + "/status"
+		serviceURI = fmt.Sprintf("http://%s/status", rfs.AnalyticsPusherURI)
 	case "Api":
 		serviceURI = fmt.Sprintf("https://%s/status", rfs.ApiURI)
 	case "Billing":


### PR DESCRIPTION
Need to use `%v` instead of `%s` to account for all types when formatting the string.