### PR TITLE
Add error check for forming http request

### DIFF
--- a/modules/transport/jsonrpc/relay_fleet.go
+++ b/modules/transport/jsonrpc/relay_fleet.go
@@ -463,7 +463,12 @@ func (rfs *RelayFleetService) AdminFrontPage(r *http.Request, args *AdminFrontPa
 			reply.SelectedService = args.ServiceName
 		} else {
 			client := &http.Client{}
-			req, _ := http.NewRequest("GET", serviceURI, nil)
+			req, err := http.NewRequest("GET", serviceURI, nil)
+			if err != nil {
+				err = fmt.Errorf("AdminFrontPage() error getting status for service: %w", err)
+				core.Error("%v", err)
+				return err
+			}
 			req.Header.Set("Authorization", authHeader)
 
 			response, err := client.Do(req)


### PR DESCRIPTION
We're getting panics when serving the status for instances under MIGs. This error check should help me figure out what's going on.