### PR TITLE
Hotfix - Log Route Relay Names When Take Next

### DIFF
--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -1169,6 +1169,18 @@ func SessionMakeRouteDecision(state *SessionHandlerState) {
 
 		if core.MakeRouteDecision_TakeNetworkNext(state.RouteMatrix.RouteEntries, state.RouteMatrix.FullRelayIndicesSet, &state.Buyer.RouteShader, &state.Output.RouteState, multipathVetoMap, &state.Buyer.InternalConfig, int32(state.Packet.DirectMinRTT), state.RealPacketLoss, state.NearRelayIndices[:], state.NearRelayRTTs[:], state.DestRelays, &routeCost, &routeNumRelays, routeRelays[:], &state.RouteDiversity, state.Debug, sliceNumber) {
 			BuildNextTokens(&state.Output, state.Database, &state.Buyer, &state.Packet, routeNumRelays, routeRelays[:routeNumRelays], state.RouteMatrix.RelayIDs, state.RouterPrivateKey, &state.Response)
+
+			if state.Debug != nil {
+				*state.Debug += "route relays: "
+
+				for i, routeRelay := range routeRelays[:routeNumRelays] {
+					if i != int(routeNumRelays-1) {
+						*state.Debug += fmt.Sprintf("%s - ", state.RouteMatrix.RelayNames[routeRelay])
+					} else {
+						*state.Debug += fmt.Sprintf("%s\n", state.RouteMatrix.RelayNames[routeRelay])
+					}
+				}
+			}
 		}
 
 	} else {


### PR DESCRIPTION
This is only when debug is enabled. We already record route relay names when we switch routes.