### PR TITLE
Add UserFlags to billing2

### DIFF
--- a/modules/billing/billing_entry_test.go
+++ b/modules/billing/billing_entry_test.go
@@ -64,6 +64,7 @@ func getTestBillingEntry2() *billing.BillingEntry2 {
 		UseDebug:                        false,
 		Debug:                           backend.GenerateRandomStringSequence(billing.BillingEntryMaxDebugLength - 1),
 		RouteDiversity:                  int32(rand.Intn(32)),
+		UserFlags:                       rand.Uint64(),
 		DatacenterID:                    rand.Uint64(),
 		BuyerID:                         rand.Uint64(),
 		UserHash:                        rand.Uint64(),

--- a/modules/transport/server_handlers.go
+++ b/modules/transport/server_handlers.go
@@ -1689,6 +1689,7 @@ func BuildBillingEntry2(state *SessionHandlerState, sliceDuration uint64, nextEn
 		UseDebug:                        state.Buyer.Debug,
 		Debug:                           debugString,
 		RouteDiversity:                  int32(state.RouteDiversity),
+		UserFlags:                       state.Packet.UserFlags,
 		DatacenterID:                    state.Packet.DatacenterID,
 		BuyerID:                         state.Packet.BuyerID,
 		UserHash:                        state.Packet.UserHash,


### PR DESCRIPTION
This PR adds `UserFlags` to billing2. User flags are events set by the game server. We can include up to 64 in 1 slice.

Note: Update billing2 BigQuery schema with `userFlags` across all envs before merging.