### PR TITLE
Use Buyer Map in Top Sessions

### DIFF
--- a/modules/transport/jsonrpc/buyer.go
+++ b/modules/transport/jsonrpc/buyer.go
@@ -1431,6 +1431,11 @@ func (s *BuyersService) FetchCurrentTopSessions(r *http.Request, companyCodeFilt
 		return sessionMetasNext[i].DeltaRTT > sessionMetasNext[j].DeltaRTT
 	})
 
+	if len(sessionMetasNext) > TopSessionsSize {
+		sessions = sessionMetasNext[:TopSessionsSize]
+		return sessions, err
+	}
+
 	sort.Slice(sessionMetasDirect, func(i, j int) bool {
 		return sessionMetasDirect[i].DirectRTT > sessionMetasDirect[j].DirectRTT
 	})


### PR DESCRIPTION
I believe repetitive storage calls are causing the Top Sessions page to load slowly.
After loading the Top Sessions Page, I examined the Redis portal database slow log. The only slow calls showing up were for the session count, nothing related to session meta. This makes me believe that the redis calls are fine as is.

Looking into the code in `FetchCurrentTopSessions()`, there is a loop at the end to extract the data from the session meta string and anonymize the data. Within that loop, we make a call to storage for each top session to check if the buyer exists, which applies to every live session, including ghost army. This is likely the cause of the slowdown, and the Cloud SQL CPU utilization spikes whenever someone loads the Top Sessions page (otherwise it's fairly low). 
Top Sessions also started to slow down when we switched from Firestore to Cloud SQL, which likely isn't a coincidence.

To resolve this, we make 1 call to storage to get a list of all buyers before the loop. Then we construct a buyer map of buyer ID to the buyer. This removes the need for multiple storage calls within the loop.

I also added an early-out in case the number of sessions on next is greater than the top session size. This is often the case when we are looking at only ghost army data, so it removes sorting direct sessions.

It's hard to test this in staging because we use SQLite, but we can try testing in dev with ghost army turned on. Regardless, this optimization should be included to limit the number of storage calls.

Reference Issue: networknext/roadmap#78