### PR TITLE
Minor updates to match data

### DIFF
--- a/modules/match_data/match_data_entry.go
+++ b/modules/match_data/match_data_entry.go
@@ -101,15 +101,10 @@ func (entry *MatchDataEntry) Validate() bool {
 		return false
 	}
 
-	// NOTE: we don't validate the DatacenterID and UserHash since that can come in as 0 from the SDK
+	// NOTE: we don't validate the DatacenterID, UserHash, and MatchID since that can come in as 0 from the SDK
 
 	if entry.SessionID == 0 {
 		core.Error("invalid session id")
-		return false
-	}
-
-	if entry.MatchID == 0 {
-		core.Error("invalid match id")
 		return false
 	}
 
@@ -172,7 +167,7 @@ func (entry *MatchDataEntry) Save() (map[string]bigquery.Value, string, error) {
 	if entry.NumMatchValues > 0 {
 		matchValues := make([]bigquery.Value, entry.NumMatchValues)
 		for i := 0; i < int(entry.NumMatchValues); i++ {
-			matchValues[i] = int(entry.MatchValues[i])
+			matchValues[i] = float64(entry.MatchValues[i])
 		}
 		e["matchValues"] = matchValues
 	}

--- a/modules/match_data/match_data_entry_test.go
+++ b/modules/match_data/match_data_entry_test.go
@@ -162,14 +162,6 @@ func TestValidateMatchDataEntry(t *testing.T) {
 		assert.False(t, valid)
 	})
 
-	t.Run("match id", func(t *testing.T) {
-		entry := getTestMatchDataEntry()
-		entry.MatchID = 0
-
-		valid := entry.Validate()
-		assert.False(t, valid)
-	})
-
 	t.Run("num match values", func(t *testing.T) {
 		entry := getTestMatchDataEntry()
 		entry.NumMatchValues = -1


### PR DESCRIPTION
Forgot to update the backend PR when we decided to allow `MatchID` as 0 in the SDK.