### PR TITLE
Hotfix - Restart portal crunchers

### DIFF
--- a/modules/portal_cruncher/portal_cruncher.go
+++ b/modules/portal_cruncher/portal_cruncher.go
@@ -238,7 +238,7 @@ func (cruncher *PortalCruncher) ReceiveMessage(ctx context.Context) <-chan error
 		select {
 		case <-ctx.Done():
 			errChan <- ctx.Err()
-
+			return
 		case messageInfo := <-cruncher.subscriber.ReceiveMessage():
 			cruncher.metrics.ReceivedMessageCount.Add(1)
 


### PR DESCRIPTION
When the context is canceled, we need to exit from `ReceiveMessage()`.