### PR TITLE
Hotfix - portal cruncher exit immediately on error

### DIFF
--- a/cmd/portal_cruncher/portal_cruncher.go
+++ b/cmd/portal_cruncher/portal_cruncher.go
@@ -353,12 +353,12 @@ func mainReturnWithCode() int {
 	case <-errChan: // Exit with an error code of 1 if we receive any errors from goroutines
 		// Still let essential goroutines finish even though we got an error
 		cancel()
-		wg.Wait()
+		// wg.Wait()
 
 		// Close the redis pool connection
-		portalCruncher.CloseRedisPool()
+		// portalCruncher.CloseRedisPool()
 		// Close Bigtable client
-		portalCruncher.CloseBigTable()
+		// portalCruncher.CloseBigTable()
 
 		return 1
 	}


### PR DESCRIPTION
This is temporary until we figure out which goroutines aren't returning when context is canceled.