### PR TITLE
hot fix for no first or last name in TOS

### DIFF
--- a/cmd/next/customers.go
+++ b/cmd/next/customers.go
@@ -55,7 +55,9 @@ func getCustomerInfo(env Environment, id string) {
 
 	customerInfo := "Customer " + reply.Customer.Name + " info:\n"
 	customerInfo += "  Code         : " + reply.Customer.Code + "\n"
-	customerInfo += "  Name         : " + reply.Customer.Name + "\n\n"
+	customerInfo += "  Name         : " + reply.Customer.Name + "\n"
+	customerInfo += "  TOS Signer   : " + reply.Customer.BuyerTOSSignerEmail + "\n"
+	customerInfo += "  TOS Time     : " + reply.Customer.BuyerTOSSignedTimestamp + "\n\n"
 	customerInfo += "  Automatic Sign-In Domains:\n"
 	if reply.Customer.AutomaticSignInDomains == "" {
 		customerInfo += "\tnone"


### PR DESCRIPTION
Some legacy users don't have first or last names assigned to their Auth0 account and still need to be able to sign the TOS.