### PR TITLE
Restart Relay Pusher

### DIFF
--- a/cmd/relay_pusher/dev.env
+++ b/cmd/relay_pusher/dev.env
@@ -30,3 +30,4 @@ FEATURE_ENABLE_PPROF=false
 NEXT_DEBUG_LOGS=1
 OVERLAY_FILE_NAME=gs://dev_database_bin/overlay.bin
 OVERLAY_OUTPUT_LOCATION=/app/overlay.bin
+BIN_FILE_GCP_TIMEOUT=5s

--- a/cmd/relay_pusher/prod.env
+++ b/cmd/relay_pusher/prod.env
@@ -29,4 +29,4 @@ DEBUG_SERVER_BACKEND_NAME=debug-server-backend-prod-1
 FEATURE_ENABLE_PPROF=false
 OVERLAY_FILE_NAME=gs://prod_database_bin/overlay.bin
 OVERLAY_OUTPUT_LOCATION=/app/overlay.bin
-
+BIN_FILE_GCP_TIMEOUT=5s

--- a/cmd/relay_pusher/staging.env
+++ b/cmd/relay_pusher/staging.env
@@ -29,3 +29,4 @@ DEBUG_SERVER_BACKEND_NAME=debug-server-backend-staging-1
 FEATURE_ENABLE_PPROF=false
 OVERLAY_FILE_NAME=gs://staging_database_bin/overlay.bin
 OVERLAY_OUTPUT_LOCATION=/app/overlay.bin
+BIN_FILE_GCP_TIMEOUT=5s

--- a/modules/storage/gcp_storage.go
+++ b/modules/storage/gcp_storage.go
@@ -157,7 +157,7 @@ func (g *GCPStorage) CopyFromBucketToLocal(ctx context.Context, artifactName str
 		}
 	}
 
-	runnable := exec.Command("gsutil", "cp", artifactName, outputLocation)
+	runnable := exec.CommandContext(ctx, "gsutil", "cp", artifactName, outputLocation)
 	buffer, err := runnable.CombinedOutput()
 
 	if err != nil {


### PR DESCRIPTION
This PR uses context with timeout to restart the relay pusher when it takes too long to pull overlay.bin or database.bin from GCP Cloud Storage. The timeout is currently set to 5 seconds.