### PR TITLE
Close Portal Cruncher Receiving Channels

### DIFF
--- a/cmd/portal_cruncher/portal_cruncher.go
+++ b/cmd/portal_cruncher/portal_cruncher.go
@@ -353,12 +353,13 @@ func mainReturnWithCode() int {
 	case <-errChan: // Exit with an error code of 1 if we receive any errors from goroutines
 		// Still let essential goroutines finish even though we got an error
 		cancel()
-		// wg.Wait()
+		// Wait for essential goroutines to finish up
+		wg.Wait()
 
 		// Close the redis pool connection
-		// portalCruncher.CloseRedisPool()
+		portalCruncher.CloseRedisPool()
 		// Close Bigtable client
-		// portalCruncher.CloseBigTable()
+		portalCruncher.CloseBigTable()
 
 		return 1
 	}

--- a/modules/portal_cruncher/portal_cruncher.go
+++ b/modules/portal_cruncher/portal_cruncher.go
@@ -119,6 +119,10 @@ func (cruncher *PortalCruncher) Start(ctx context.Context, numRedisInsertGorouti
 		for {
 			select {
 			case <-ctx.Done():
+				// Close receiving channels
+				close(cruncher.redisCountMessageChan)
+				close(cruncher.redisDataMessageChan)
+				close(cruncher.btDataMessageChan)
 				return
 			case err := <-cruncher.ReceiveMessage(ctx):
 				if err != nil {


### PR DESCRIPTION
Close the portal cruncher receiving channels when context is canceled and we stop receiving messages. This will prevent channels from blocking and will let all goroutines exit cleanly.