### PR TITLE
Add a func test for concurrency issues in the relay manager, and fixed one that showed up

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -242,6 +242,10 @@ blocks:
           commands:
             - cd ./dist && ./func_tests_backend test_session_data_serialize
 
+        - name: "test_relay_manager"
+          commands:
+            - cd ./dist && ./func_tests_backend test_relay_manager
+
 
   - name: "Build Functional Tests (sdk4)"
     dependencies: []

--- a/scripts/run/run.go
+++ b/scripts/run/run.go
@@ -289,7 +289,7 @@ func func_backend5() {
 }
 
 func func_test_backend(tests []string) {
-	command := "make ./dist/func_tests_backend && ./dist/func_tests_backend"
+	command := "make ./dist/func_tests_backend && cd dist && ./func_tests_backend"
 	if len(tests) > 0 {
 		for _, test := range tests {
 			bash(fmt.Sprintf("%s %s", command, test))


### PR DESCRIPTION
The relay manager historically has worked fine, then above a certain number of relays starts to have issues.

To catch this, I added a func test that has n relays, and they each do an update once per-second to the relay manager.

The relay manager tries to build a cost matrix every 1 second in another groutine.

Above 1200 relays, it would deadlock. I fixed that by simplifying the locking scheme.

In the future, it's probably a good idea to move to relay updates once every 10 seconds...